### PR TITLE
add missing karma plugins to devDependencies in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-uglify": "~0.2.4",
     "grunt-contrib-jshint": "~0.6.4",
-    "grunt-contrib-sass": "~0.5.0"
+    "grunt-contrib-sass": "~0.5.0",
+    "karma-jasmine": "~0.1.3",
+    "karma-chrome-launcher": "~0.1.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/karma start ionic.conf.js --single-run --browsers Firefox"


### PR DESCRIPTION
You were missing `karma-jasmine` and `karma-chrome-laucher` from your `package.json`, making `karma start ionic.conf.js` throw errors.

It's probably installed globally on your machine, but it should still be listed in the `devDependencies`.

This PR adds them as `devDependencies` to the project :)
