### PR TITLE
refactor directives' controller instance creation to use js constructor

### DIFF
--- a/js/ext/angular/src/directive/ionicNav.js
+++ b/js/ext/angular/src/directive/ionicNav.js
@@ -23,9 +23,6 @@
 angular.module('ionic.ui.nav', ['ionic.service.templateLoad', 'ionic.service.gesture', 'ionic.service.platform', 'ngAnimate'])
 
 .controller('NavCtrl', ['$scope', '$element', '$animate', '$compile', '$timeout', 'TemplateLoader', 'Platform', function($scope, $element, $animate, $compile, $timeout, TemplateLoader, Platform) {
-  var _this = this;
-
-  angular.extend(this, ionic.controllers.NavController.prototype);
 
   var pushInAnimation = $scope.pushInAnimation || 'slide-in-left';
   var pushOutAnimation = $scope.pushOutAnimation || 'slide-out-left';
@@ -38,15 +35,35 @@ angular.module('ionic.ui.nav', ['ionic.service.templateLoad', 'ionic.service.ges
     el.removeClass(pushOutAnimation);
     el.removeClass(popInAnimation);
     el.removeClass(popOutAnimation);
-  }
+  };
+
+  var navController = new ionic.controllers.NavController({
+    content: {
+    },
+    navBar: {
+      shouldGoBack: function() {
+      },
+      show: function() {
+        this.isVisible = true;
+      },
+      hide: function() {
+        this.isVisible = false;
+      },
+      setTitle: function(title) {
+        $scope.navController.title = title;
+      },
+      showBackButton: function(show) {
+      },
+    }
+  });
 
   /**
    * Push a template onto the navigation stack.
    * @param {string} templateUrl the URL of the template to load.
    */
-  this.pushFromTemplate = function(templateUrl) {
+  navController.pushFromTemplate = function(templateUrl) {
     var childScope = $scope.$new();
-    var last = _this.getTopController();
+    var last = navController.getTopController();
 
     // Load the given template
     TemplateLoader.load(templateUrl).then(function(templateString) {
@@ -82,10 +99,10 @@ angular.module('ionic.ui.nav', ['ionic.service.templateLoad', 'ionic.service.ges
   };
 
   // Pop function
-  this.popController = function() {
-    var last = _this.pop();
+  navController.popController = function() {
+    var last = navController.pop();
 
-    var next = _this.getTopController();
+    var next = navController.getTopController();
 
     if(last) {
 
@@ -106,43 +123,20 @@ angular.module('ionic.ui.nav', ['ionic.service.templateLoad', 'ionic.service.ges
     $scope.$parent.$broadcast('navigation.pop');
   };
 
-
-  // Extend the low-level navigation controller
-  // for this angular controller
-  ionic.controllers.NavController.call(this, {
-    content: {
-    },
-    navBar: {
-      shouldGoBack: function() {
-      },
-      show: function() {
-        this.isVisible = true;
-      },
-      hide: function() {
-        this.isVisible = false;
-      },
-      setTitle: function(title) {
-        $scope.navController.title = title;
-      },
-      showBackButton: function(show) {
-      },
-    }
-  });
-
   // Support Android hardware back button (native only, not mobile web)
   var onHardwareBackButton = function(e) {
     $scope.$apply(function() {
-      _this.popController();
+      navController.popController();
     });
-  }
+  };
   Platform.onHardwareBackButton(onHardwareBackButton);
 
 
-  this.handleDrag = function(e) {
+  navController.handleDrag = function(e) {
     // TODO: Support dragging between pages
   };
 
-  this.endDrag = function(e) {
+  navController.endDrag = function(e) {
   };
 
   /**
@@ -150,27 +144,19 @@ angular.module('ionic.ui.nav', ['ionic.service.templateLoad', 'ionic.service.ges
    * nav-content directive when it is linked to a scope on the page.
    */
   $scope.pushController = function(scope, element) {
-    _this.push({
+    navController.push({
       scope: scope,
       element: element
     });
     $scope.$parent.$broadcast('navigation.push', scope);
   };
-
-  this.pushController = function(scope, element) {
-    _this.push({
-      scope: scope,
-      element: element
-    });
-    $scope.$parent.$broadcast('navigation.push', scope);
-  };
-
-  $scope.navController = this;
 
   $scope.$on('$destroy', function() {
     // Remove back button listener
     Platform.offHardwareBackButton(onHardwareBackButton);
   });
+
+  return $scope.navController = navController;
 }])
 
 /**

--- a/js/ext/angular/src/directive/ionicSideMenu.js
+++ b/js/ext/angular/src/directive/ionicSideMenu.js
@@ -15,11 +15,7 @@ angular.module('ionic.ui.sideMenu', ['ionic.service.gesture'])
  * some side menu stuff on the current scope.
  */
 .controller('SideMenuCtrl', function($scope) {
-  var _this = this;
-
-  angular.extend(this, ionic.controllers.SideMenuController.prototype);
-
-  ionic.controllers.SideMenuController.call(this, {
+  var sideMenuCtrl = new ionic.controllers.SideMenuController(this, {
     // Our quick implementation of the left side menu
     left: {
       width: 270,
@@ -32,8 +28,7 @@ angular.module('ionic.ui.sideMenu', ['ionic.service.gesture'])
   });
 
   $scope.sideMenuContentTranslateX = 0;
-
-  $scope.sideMenuController = this;
+  return $scope.sideMenuController = sideMenuCtrl;
 })
 
 .directive('sideMenus', function() {

--- a/js/ext/angular/src/directive/ionicTabBar.js
+++ b/js/ext/angular/src/directive/ionicTabBar.js
@@ -8,11 +8,7 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
  */
 
 .controller('TabsCtrl', ['$scope', '$element', '$animate', function($scope, $element, $animate) {
-  var _this = this;
-
-  angular.extend(this, ionic.controllers.TabBarController.prototype);
-
-  ionic.controllers.TabBarController.call(this, {
+  var tabsCtrl = new ionic.controllers.TabBarController({
     controllerChanged: function(oldC, oldI, newC, newI) {
       $scope.controllerChanged && $scope.controllerChanged({
         oldController: oldC,
@@ -28,19 +24,18 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
     }
   });
 
-  this.add = function(controller) {
-    this.addController(controller);
-    this.select(0);
+  tabsCtrl.add = function(controller) {
+    tabsCtrl.addController(controller);
+    tabsCtrl.select(0);
   };
 
-  this.select = function(controllerIndex) {
+  tabsCtrl.select = function(controllerIndex) {
     $scope.activeAnimation = $scope.animation;
-    _this.selectController(controllerIndex);
+    tabsCtrl.selectController(controllerIndex);
   };
 
-  $scope.controllers = this.controllers;
-
-  $scope.tabsController = this;
+  $scope.controllers = tabsCtrl.controllers;
+  return $scope.tabsController = tabsCtrl;
 }])
 
 .directive('tabs', function() {
@@ -137,7 +132,7 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
         });
 
         tabsCtrl.add($scope);
-        
+
         $scope.$watch('isVisible', function(value) {
           if(childElement) {
             $animate.leave(childElement);
@@ -184,9 +179,9 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
     transclude: true,
     replace: true,
     scope: true,
-    template: '<div class="tabs">' + 
-      '<tab-controller-item title="{{controller.title}}" icon="{{controller.icon}}" icon-on="{{controller.iconOn}}" icon-off="{{controller.iconOff}}" active="controller.isVisible" index="$index" ng-repeat="controller in controllers"></tab-controller-item>' + 
-    '</div>',
+    template: '<div class="tabs">' +
+      '<tab-controller-item title="{{controller.title}}" icon="{{controller.icon}}" icon-on="{{controller.iconOn}}" icon-off="{{controller.iconOff}}" active="controller.isVisible" index="$index" ng-repeat="controller in controllers"></tab-controller-item>' +
+      '</div>',
     link: function($scope, $element, $attr, tabsCtrl) {
       $element.addClass($scope.tabsType);
       $element.addClass($scope.tabsStyle);
@@ -216,12 +211,12 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
         tabsCtrl.select(scope.index);
       };
     },
-    template: 
+    template:
       '<a ng-class="{active:active}" ng-click="selectTab()" class="tab-item">' +
         '<i class="{{icon}}" ng-if="icon"></i>' +
         '<i class="{{iconOn}}" ng-if="active"></i>' +
         '<i class="{{iconOff}}" ng-if="!active"></i> {{title}}' +
-      '</a>'
+        '</a>'
   };
 })
 
@@ -230,8 +225,8 @@ angular.module('ionic.ui.tabs', ['ngAnimate'])
     restrict: 'E',
     replace: true,
     transclude: true,
-    template: '<div class="tabs tabs-primary" ng-transclude>' + 
-    '</div>'
+    template: '<div class="tabs tabs-primary" ng-transclude>' +
+      '</div>'
   }
 });
 


### PR DESCRIPTION
In your directives' controller, you were trying to import `ionic.controllers.?`'s behaviour by extending your `this` with their prototype, and `.call`ing their constructor with your `this`. 

Your end result can be accomplished much easier: you can create a normal instance of a `ionic.controllers.?` with the `new` operator, and at the end return it.

I refactored the directives' controller to be using the simpler `new` way :)
