### PR TITLE
Matchdep

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,7 +1,6 @@
 module.exports = function(grunt) {
 
-  // Load Grunt tasks declared in package.json file
-  require('matchdep').filterDev('grunt-*').forEach(grunt.loadNpmTasks);
+  require('load-grunt-tasks')(grunt);
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "grunt-contrib-sass": "~0.5.0",
     "karma-jasmine": "~0.1.3",
     "karma-chrome-launcher": "~0.1.0",
-    "matchdep": "~0.3.0"
+    "load-grunt-tasks": "~0.2.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/karma start ionic.conf.js --single-run --browsers Firefox"


### PR DESCRIPTION
Removed grunt-cli as a dev dependency. Installing it globally is the supported way of use - https://github.com/gruntjs/grunt-cli

Also pulled in matchdep to clean up loading grunt NpmTasks. 
