### PR TITLE
Avoid white as button-clear text color for .bar-light and .bar-stable

### DIFF
--- a/dist/css/ionic.css
+++ b/dist/css/ionic.css
@@ -2799,7 +2799,7 @@ a.subdued {
     box-shadow: inset 0px 1px 3px rgba(0, 0, 0, 0.15);
     border-color: #cccccc; }
   .bar-light .button.button-clear {
-    color: white;
+    color: #444444;
     background: none;
     border-color: transparent;
     box-shadow: none;
@@ -2820,7 +2820,7 @@ a.subdued {
     box-shadow: inset 0px 1px 3px rgba(0, 0, 0, 0.15);
     border-color: #a2a2a2; }
   .bar-stable .button.button-clear {
-    color: white;
+    color: #444444;
     background: none;
     border-color: transparent;
     box-shadow: none;

--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -155,13 +155,13 @@
 .bar-light {
   .button {
     @include button-style($bar-light-bg, $bar-light-border, $bar-light-active-bg, $bar-light-active-border, $bar-light-text);
-    @include button-clear(#fff, $bar-title-font-size);
+    @include button-clear($bar-light-text, $bar-title-font-size);
   }
 }
 .bar-stable {
   .button {
     @include button-style($bar-stable-bg, $bar-stable-border, $bar-stable-active-bg, $bar-stable-active-border, $bar-stable-text);
-    @include button-clear(#fff, $bar-title-font-size);
+    @include button-clear($bar-stable-text, $bar-title-font-size);
   }
 }
 .bar-positive {


### PR DESCRIPTION
Currently, if you have a header bar with class="bar-stable" (or "bar-light") followed by a "button-clear" button, the text will be #fff. This means that button-clear text will be white on a bar-light or bar-stable bar, and thus unreadable.

This changes _bar.scss .bar-light and .bar-stable .button to @include button-clear a darker text color, currently $bar-light-text and $bar-stable-text respectively.

For consistency, perhaps either all @include button-clear should reference $bar-...-text, or the $fff should be changed to #444444 (or something similar) in _bar.scss
