### PR TITLE
Uses grunt-contrib connect as a static server

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -80,9 +80,17 @@ module.exports = function(grunt) {
       },
       sass: {
         files: ['scss/**/*.scss'],
-        tasks: ['sass', 'concat'],
+        tasks: ['sass'],
         options: {
           spawn: false
+        }
+      }
+    },
+    connect: {
+      server: {
+        options: {
+          port: process.env.PORT || 9001,
+          base: 'dist'
         }
       }
     }
@@ -94,6 +102,9 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-watch');
   grunt.loadNpmTasks('grunt-contrib-concat');
   grunt.loadNpmTasks('grunt-contrib-sass');
+  grunt.loadNpmTasks('grunt-contrib-connect');
 
-  grunt.registerTask('default', ['jshint', 'sass', 'concat']);
+  grunt.registerTask('dist', ['jshint', 'sass', 'concat']);
+  grunt.registerTask('server', ['connect', 'watch']);
+  grunt.registerTask('default', ['server']);
 };

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.9.04",
   "devDependencies": {
     "karma": "~0.10",
-    "grunt": "~0.4.1",
+    "grunt": "~0.4.2",
     "grunt-cli": "~0.1.9",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-copy": "~0.4.1",
@@ -13,7 +13,8 @@
     "grunt-contrib-jshint": "~0.6.4",
     "grunt-contrib-sass": "~0.5.0",
     "karma-jasmine": "~0.1.3",
-    "karma-chrome-launcher": "~0.1.0"
+    "karma-chrome-launcher": "~0.1.0",
+    "grunt-contrib-connect": "~0.5.0"
   },
   "scripts": {
     "test": "./node_modules/.bin/karma start ionic.conf.js --single-run --browsers Firefox"
@@ -22,5 +23,9 @@
     {
       "type": "MIT"
     }
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:driftyco/ionic.git"
+  }
 }


### PR DESCRIPTION
This PR contains a number of small changes related to the development environment:

One question about how the Ionic repo should be used: Is it only supposed to be used to build Ionic, or is it thought as a base for applications?

There are (IMO) indications for both in the structure of the repo:
- The `dist` folder indicates that it is meant to be used to build applications
- But there is no `index.html` inside it
- The `Gruntfile.js` doesn't show any task apart from builing the Ionic framework
- As a developer, and as per the documentation, I would love to use the SASS files to customize Ionic.
## 
- Uses grunt-contrib connect as a static server
- Sets server as the default grunt task
- Removes useless `concat` task in `watch:sass`
- Add `repository` field in `package.json`
