### PR TITLE
renamed slideOutToleft to slideOutToLeft

### DIFF
--- a/scss/_animations.scss
+++ b/scss/_animations.scss
@@ -1,4 +1,3 @@
-
 /**
  * Animations
  * --------------------------------------------------
@@ -73,11 +72,11 @@ $slide-in-up-function: cubic-bezier(.1, .7, .1, 1);
 // Slide Out To Left
 // -------------------------------
 
-@-webkit-keyframes slideOutToleft {
+@-webkit-keyframes slideOutToLeft {
   from { -webkit-transform: translate3d(0, 0, 0); }
   to { -webkit-transform: translate3d(-100%, 0, 0); }
 }
-@-moz-keyframes slideOutToleft {
+@-moz-keyframes slideOutToLeft {
   from { -moz-transform: translateX(0); }
   to { -moz-transform: translateX(-100%); }
 }


### PR DESCRIPTION
I was listing all ionic animations and I found that at lines [76](https://github.com/driftyco/ionic/blob/master/scss/_animations.scss#L76) and [80](https://github.com/driftyco/ionic/blob/master/scss/_animations.scss#L80) in [scss/_animations.scss](https://github.com/driftyco/ionic/blob/master/scss/_animations.scss) it was written `slideOutToleft` instead of `slideOutToLeft`.
You can fix it directly without this pull request, I did it only to show the right lines,
thanks :) 
