### PR TITLE
Feature(#348): dynamic item type

### DIFF
--- a/js/ext/angular/src/directive/ionicList.js
+++ b/js/ext/angular/src/directive/ionicList.js
@@ -48,9 +48,7 @@ angular.module('ionic.ui.list', ['ngAnimate'])
       // Set this item's class, first from the item directive attr, and then the list attr if item not set
       $scope.itemClass = $scope.itemType || $parentScope.itemType;
       var getter = $parse( $scope.itemClass );
-      $scope.parsedClass = function(a) {
-        return getter($scope.$parent);
-      };
+      $scope.parsedClass = angular.bind( $scope, getter, $scope.$parent );
       // Decide if this item can do stuff, and follow a certain priority 
       // depending on where the value comes from
       if(($attr.canDelete ? $scope.canDelete : $parentScope.canDelete) !== "false") {


### PR DESCRIPTION
#348 requests to be able to create dividers dynamically. Using this pull, item-type can be defined in a similar way as ng-class using an angular expression, thus making it possible to change the type dynamically. For example, using the existing Ionic list example, with line 58 as

item ng-repeat="movie in movies" href="#/movie/{{movie.id}}" item-type="{'item-divider': (movie.rating > 7)}"

will result in the list seen in screenshot (all movies that have rating higher than 7 are bold)
![screenshot](https://f.cloud.github.com/assets/487758/1837886/2f5f7690-7448-11e3-929f-c47ae80251ec.png)

Note however that this is a breaking change as item-type="item-divider" for example won't work (must be item-type="'item-divider'" again following the same pattern as ng-class).
