### PR TITLE
ios emulator doesnt have window.device

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -57,7 +57,7 @@
     },
     isIOS7: function() {
       if(!window.device) {
-        return false;
+        return navigator.userAgent.match(/(iPad|iPhone|iPod touch);.*CPU.*OS 7_\d/i);
       }
       return window.device.platform == 'iOS' && parseFloat(window.device.version) >= 7.0;
     },


### PR DESCRIPTION
use a good old regex to detect ios7 on emulator.
