### PR TITLE
fix show() when content is different

### DIFF
--- a/js/ext/angular/src/service/ionicLoading.js
+++ b/js/ext/angular/src/service/ionicLoading.js
@@ -27,11 +27,7 @@ angular.module('ionic.service.loading', ['ionic.ui.loading'])
       // Make sure there is only one loading element on the page at one point in time
       var existing = angular.element($document[0].querySelector('.loading-backdrop'));
       if(existing.length) {
-        scope = existing.scope();
-        if(scope.loading) {
-          scope.loading.show();
-          return scope.loading;
-        }
+        existing.remove();
       }
 
       // Compile the template


### PR DESCRIPTION
Just call `$ionicLoading.show({content: 'Registration process' });` and after a while call `$ionicLoading.show({content: 'Authentication process' });` to understand why showing `existing` is not a good idea.
