### PR TITLE
TabBar badges support

### DIFF
--- a/js/ext/angular/src/directive/ionicViewState.js
+++ b/js/ext/angular/src/directive/ionicViewState.js
@@ -137,10 +137,6 @@ angular.module('ionic.ui.viewState', ['ionic.service.view', 'ionic.service.gestu
         updateHeaderData(data);
       });
 
-      $rootScope.$on('viewState.titleUpdated', function(e, data) {
-        $scope.currentTitle = (data && data.title ? data.title : '');
-      });
-
       // If a nav page changes the left or right buttons, update our scope vars
       $scope.$parent.$on('viewState.leftButtonsChanged', function(e, data) {
         $scope.leftButtons = data;
@@ -202,16 +198,10 @@ angular.module('ionic.ui.viewState', ['ionic.service.view', 'ionic.service.gestu
           $scope.$emit('viewState.rightButtonsChanged', $scope.rightButtons);
         });
 
-        // watch for changes in the title
-        var deregTitle = $scope.$watch('title', function(val) {
-          $scope.$emit('viewState.titleUpdated', $scope);
-        });
-
         $scope.$on('$destroy', function(){
           // deregister on destroy
           deregLeftButtons();
           deregRightButtons();
-          deregTitle();
         });
 
       };


### PR DESCRIPTION
Added support for TabBar icon badges using the attribute badge in the tab directive.

``` html
<tab icon-on="icon ion-ios7-person" icon-off="icon
ion-ios7-person-outline" href="#/tab/myprofile" badge="3">
```

I’ve used the colors of the TabBar itself but inverted for the badge. I don’t know if you’ll want to merge this straight on but I think it can help as a start point for this feature. I’ve tried to do it as integrated as possible.
