### PR TITLE
fixes #516 ?

### DIFF
--- a/dist/js/ionic-angular.js
+++ b/dist/js/ionic-angular.js
@@ -2616,7 +2616,7 @@ angular.module('ionic.ui.touch', [])
     
     function onTap(e) {
       // wire this up to Ionic's tap/click simulation
-      ionic.clickElement(e.target, e);
+      ionic.tapElement(e.target, e);
     }
 
     // Actual linking function.


### PR DESCRIPTION
I think this solves issue #516.
There is no clickElement function in ionic, but there is a tapElement, so I assume that this is the fix, based on the comment `// wire this up to Ionic's tap/click simulation`
