### PR TITLE
Responsive grid

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -132,7 +132,7 @@
 /* Adjust the max-width value to fit your own needs */
 /* Defaults to 767px (iPad portrait width)*/
 
- @media (max-width: 767px) {
+ @media (max-width: $grid-responsive-break) {
 .responsive .col {
   width: 100%;
   margin-bottom:15px;

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -490,6 +490,7 @@ $modal-bg-color:              #fff !default;
 // -------------------------------
 
 $grid-padding-width:           10px !default;
+$grid-responsive-break:        767px !default;
 
 
 // Action Sheets


### PR DESCRIPTION
Adding a class of responsive to row will trigger a change of the flex-direction to column and add a little margin between and columns to space out content a bit. Resolves issue [Responsive Grid layout #534](https://github.com/driftyco/ionic/issues/534)
