### PR TITLE
fix(navBar): animations work properly

### DIFF
--- a/config/karma.conf.js
+++ b/config/karma.conf.js
@@ -29,6 +29,7 @@ module.exports = function(config) {
 
     // list of files to exclude
     exclude: [
+      'js/ext/angular/test/dom-trace.js'
     ],
 
     // test results reporter to use

--- a/js/ext/angular/test/directive/ionicView.unit.js
+++ b/js/ext/angular/test/directive/ionicView.unit.js
@@ -45,13 +45,29 @@ describe('Ionic View', function() {
     expect(scope.$broadcast).toHaveBeenCalledWith('viewState.showBackButton', false);
   });
 
-  it('should show/hide viewBack', function() {
-    var element = compile('<button view-back>BUTTON</button>')(scope);
-    expect(element.hasClass('hide')).toEqual(true);
+  it('should add/remove back button based on events', function() {
+    var element = compile('<nav-bar back-button-label="Back"></nav-bar>')(scope);
+    scope.$apply();
+    function backButton() {
+      return angular.element(element[0].querySelector('.back-button'));
+    };
+    expect(backButton().length).toEqual(1);
+
+    scope.$broadcast('viewState.showBackButton', false);
+    scope.$apply();
+    expect(backButton().length).toEqual(0);
+
     scope.$broadcast('viewState.showBackButton', true);
-    expect(element.hasClass('hide')).toEqual(false);
+    scope.$apply();
+    expect(backButton().length).toEqual(1);
+
     scope.$broadcast('$viewHistory.historyChange', { showBack: false });
-    expect(element.hasClass('hide')).toEqual(true);
+    scope.$apply();
+    expect(backButton().length).toEqual(0);
+
+    scope.$broadcast('$viewHistory.historyChange', { showBack: true });
+    scope.$apply();
+    expect(backButton().length).toEqual(1);
   });
 
   it('should show/hide navBar', function() {
@@ -89,68 +105,71 @@ describe('Ionic View', function() {
   it('should not have the back button if no back button attributes set', function() {
     var element = compile('<nav-bar></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.length).toEqual(0);
   });
 
   it('should have the back button if back-button-type attributes set', function() {
     var element = compile('<nav-bar back-button-type="button-icon"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.length).toEqual(1);
   });
 
   it('should have the back button if back-button-icon attributes set', function() {
     var element = compile('<nav-bar back-button-icon="ion-back"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.length).toEqual(1);
   });
 
   it('should have the back button if back-button-label attributes set', function() {
     var element = compile('<nav-bar back-button-label="Button"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.length).toEqual(1);
   });
 
   it('should have the back button if all back button attributes set', function() {
     var element = compile('<nav-bar back-button-type="button-icon" back-button-icon="ion-back" back-button-label="Button"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.length).toEqual(1);
   });
 
   it('should set just a back button icon, no text', function() {
     var element = compile('<nav-bar back-button-icon="ion-back" back-button-type="button-icon"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.hasClass('button')).toEqual(true);
     expect(backButton.hasClass('button-icon')).toEqual(true);
     expect(backButton.hasClass('icon')).toEqual(true);
     expect(backButton.hasClass('ion-back')).toEqual(true);
-    expect(backButton.html()).toEqual('');
+    expect(backButton.children().length).toEqual(0);
+    expect(backButton.text().trim()).toEqual('');
   });
 
   it('should set just a back button with only text, button-clear', function() {
     var element = compile('<nav-bar back-button-label="Back" back-button-type="button-clear"></nav-bar>')(scope);
-    scope.$digest();
-    var backButton = element.find('div').find('button');
+    scope.$apply();
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.hasClass('button')).toEqual(true);
     expect(backButton.hasClass('button-clear')).toEqual(true);
     expect(backButton.hasClass('icon')).toEqual(false);
-    expect(backButton.html()).toEqual('Back');
+    expect(backButton.text().trim()).toEqual('Back');
   });
 
   it('should set a back button with an icon and text, button-icon', function() {
     var element = compile('<nav-bar back-button-icon="ion-back" back-button-label="Back" back-button-type="button-icon"></nav-bar>')(scope);
     scope.$digest();
-    var backButton = element.find('div').find('button');
+    var backButton = angular.element(element[0].querySelector('.back-button'));
     expect(backButton.hasClass('button')).toEqual(true);
     expect(backButton.hasClass('button-icon')).toEqual(true);
     var icon = backButton.find('i');
     expect(icon.hasClass('icon')).toEqual(true);
-    expect(backButton.html()).toEqual('<i class="icon ion-back"></i> Back');
+    expect(backButton.children()[0].tagName.toLowerCase()).toBe('i');
+    expect(backButton.children()[0].className).toBe('icon ion-back');
+    expect(backButton.text().trim()).toBe('Back');
   });
 
 });

--- a/js/ext/angular/test/dom-trace.js
+++ b/js/ext/angular/test/dom-trace.js
@@ -214,4 +214,9 @@
     }
   }, false);
 
+  //Shortcuts for tests
+  angular.element(document).ready(function() {
+    window.$s = angular.element(document).scope().$root;
+    window.$i = angular.element(document).injector();
+  });
 })(window);

--- a/js/views/headerBarView.js
+++ b/js/views/headerBarView.js
@@ -17,74 +17,71 @@
      * so that the header text size is maximized and aligned
      * correctly as long as possible.
      */
-    align: function() {
+    align: function(titleSelector) {
       var _this = this;
 
       window.rAF(ionic.proxy(function() {
-        var i, c, childSize;
-        var childNodes = this.el.childNodes;
 
-        // Find the title element
-        var title = this.el.querySelector('.title');
-        if(!title) {
+        // Find the titleEl element
+        var titleEl = this.el.querySelector(titleSelector || '.title');
+        if(!titleEl) {
           return;
         }
-      
+
+        var i, c, childSize;
+        var childNodes = this.el.childNodes;
         var leftWidth = 0;
         var rightWidth = 0;
-        var titlePos = Array.prototype.indexOf.call(childNodes, title);
+        var isCountingRightWidth = true;
 
         // Compute how wide the left children are
-        for(i = 0; i < titlePos; i++) {
-          childSize = null;
+        // Skip all titles (there may still be two titles, one leaving the dom)
+        // Once we encounter a titleEl, realize we are now counting the right-buttons, not left
+        for(i = 0; i < childNodes.length; i++) {
           c = childNodes[i];
-          if(c.nodeType == 3) {
-            childSize = ionic.DomUtil.getTextBounds(c);
-          } else if(c.nodeType == 1) {
-            childSize = c.getBoundingClientRect();
+          if (c.tagName && c.tagName.toLowerCase() == 'h1') {
+            isCountingRightWidth = false;
+            continue;
           }
-          if(childSize) {
-            leftWidth += childSize.width;
-          }
-        }
 
-        // Compute how wide the right children are
-        for(i = titlePos + 1; i < childNodes.length; i++) {
           childSize = null;
-          c = childNodes[i];
           if(c.nodeType == 3) {
             childSize = ionic.DomUtil.getTextBounds(c);
           } else if(c.nodeType == 1) {
             childSize = c.getBoundingClientRect();
           }
           if(childSize) {
-            rightWidth += childSize.width;
+            if (isCountingRightWidth) {
+              rightWidth += childSize.width;
+            } else {
+              leftWidth += childSize.width;
+            }
           }
         }
 
         var margin = Math.max(leftWidth, rightWidth) + 10;
 
-        // Size and align the header title based on the sizes of the left and
+        // Size and align the header titleEl based on the sizes of the left and
         // right children, and the desired alignment mode
         if(this.alignTitle == 'center') {
           if(margin > 10) {
-            title.style.left = margin + 'px';
-            title.style.right = margin + 'px';
+            titleEl.style.left = margin + 'px';
+            titleEl.style.right = margin + 'px';
           }
-          if(title.offsetWidth < title.scrollWidth) {
+          if(titleEl.offsetWidth < titleEl.scrollWidth) {
             if(rightWidth > 0) {
-              title.style.right = (rightWidth + 5) + 'px';
+              titleEl.style.right = (rightWidth + 5) + 'px';
             }
           }
         } else if(this.alignTitle == 'left') {
-          title.classList.add('title-left');
+          titleEl.classList.add('titleEl-left');
           if(leftWidth > 0) {
-            title.style.left = (leftWidth + 15) + 'px';
+            titleEl.style.left = (leftWidth + 15) + 'px';
           }
         } else if(this.alignTitle == 'right') {
-          title.classList.add('title-right');
+          titleEl.classList.add('titleEl-right');
           if(rightWidth > 0) {
-            title.style.right = (rightWidth + 15) + 'px';
+            titleEl.style.right = (rightWidth + 15) + 'px';
           }
         }
       }, this));


### PR DESCRIPTION
Starting a couple of versions ago, animations in navbar stopped working.
I took this as a chance to fix this, and do a refactor to make the code
more modular and testable.

Additionally, all of the navbar attributes are now interpolated and flexible (so for example people can change their back button icon at runtime if they do `back-button-icon="icon-{{myIcon}}`.

Also fixed some memory links with rootScope listeners that were never unregistered.
