### PR TITLE
feat(navBar): add sensible defaults

### DIFF
--- a/js/ext/angular/src/directive/ionicSideMenu.js
+++ b/js/ext/angular/src/directive/ionicSideMenu.js
@@ -155,7 +155,7 @@ angular.module('ionic.ui.sideMenu', ['ionic.service.gesture', 'ionic.service.vie
       angular.isUndefined(attr.width) && attr.$set('width', '275');
 
       return function($scope, $element, $attr, sideMenuCtrl) {
-        $scope.side = $attr.side;
+        $scope.side = $attr.side || 'left';
 
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
           width: 275,

--- a/js/ext/angular/src/directive/ionicTabBar.js
+++ b/js/ext/angular/src/directive/ionicTabBar.js
@@ -108,7 +108,7 @@ angular.module('ionic.ui.tabs', ['ionic.service.view', 'ionic.ui.bindHtml'])
         var tabs = $element[0].querySelector('.tabs');
 
         $scope.tabsType = $attr.tabsType || 'tabs-positive';
-        $scope.tabsStyle = $attr.tabsStyle;
+        $scope.tabsStyle = $attr.tabsStyle || 'tabs-icon-only';
         $scope.animation = $attr.animation;
 
         $scope.animateNav = $scope.$eval($attr.animateNav);

--- a/js/ext/angular/test/directive/ionicView.unit.js
+++ b/js/ext/angular/test/directive/ionicView.unit.js
@@ -120,7 +120,7 @@ describe('Ionic View', function() {
     title = navBar.find('h1');
     expect(title.text().trim()).toEqual('New Title');
 
-    scope.$broadcast('viewState.titleUpdated', { title: 'Event Title' });
+    scope.$broadcast('viewState.titleUpdated', 'Event Title');
     scope.$digest();
     title = navBar.find('h1');
     expect(title.text().trim()).toEqual('Event Title');

--- a/js/ext/angular/test/viewState.html
+++ b/js/ext/angular/test/viewState.html
@@ -12,12 +12,8 @@
   <body>
 
     <div ng-controller="AppCtrl">
-      <ion-nav-bar animation="nav-title-slide-ios7"
-               type="bar-positive"
-               back-button-type="button-icon"
-               back-button-label=" Back"
-               back-button-icon="ion-arrow-left-c"></ion-nav-bar>
-      <ion-nav-view animation="slide-left-right"></ion-nav-view>
+      <ion-nav-bar type="bar-positive"></ion-nav-bar>
+      <ion-nav-view></ion-nav-view>
     </div>
 
     <script id="sign-in.html" type="text/ng-template">


### PR DESCRIPTION
BREAKING CHANGE: Before, if ionNavBar back-button-type attribute was not defined,
no back button will appear. Now the back button defaults to an os-specific
icon, with the previous view's title.

Additionally, before, if ionNavBar animation attribute was not defined,
no title animation would happen.  Now the ionNavBar animation defaults
to nav-title-slide-ios7.

To migrate, change your code from this (used to be no back button, no
title animation):

``` html
<nav-bar></nav-bar>
```

To this (no back button, no title animation):

``` html
<nav-bar back-button-type="" animation=""></nav-bar>
```
