### PR TITLE
fix(navBar): remove flickering/bumping for back button

### DIFF
--- a/js/ext/angular/test/directive/ionicView.unit.js
+++ b/js/ext/angular/test/directive/ionicView.unit.js
@@ -51,23 +51,25 @@ describe('Ionic View', function() {
     function backButton() {
       return angular.element(element[0].querySelector('.back-button'));
     };
-    expect(backButton().length).toEqual(1);
+    //hidden by default
+    expect(backButton().hasClass('ng-hide')).toBe(true);
 
     scope.$broadcast('viewState.showBackButton', false);
     scope.$apply();
-    expect(backButton().length).toEqual(0);
+    expect(backButton().hasClass('ng-hide')).toBe(true);
 
     scope.$broadcast('viewState.showBackButton', true);
     scope.$apply();
     expect(backButton().length).toEqual(1);
+    expect(backButton().hasClass('ng-hide')).toBe(false);
 
     scope.$broadcast('$viewHistory.historyChange', { showBack: false });
     scope.$apply();
-    expect(backButton().length).toEqual(0);
+    expect(backButton().hasClass('ng-hide')).toBe(true);
 
     scope.$broadcast('$viewHistory.historyChange', { showBack: true });
     scope.$apply();
-    expect(backButton().length).toEqual(1);
+    expect(backButton().hasClass('ng-hide')).toBe(false);
   });
 
   it('should show/hide navBar', function() {
@@ -193,7 +195,7 @@ describe('Ionic View', function() {
     var element = compile('<ion-nav-bar></ion-nav-bar>')(scope);
     scope.$digest();
     var backButton = angular.element(element[0].querySelector('.back-button'));
-    expect(backButton.length).toEqual(0);
+    expect(backButton.hasClass('ng-hide')).toBe(true);
   });
 
   it('should have the back button if back-button-type attributes set', function() {

--- a/scss/_animations.scss
+++ b/scss/_animations.scss
@@ -140,14 +140,14 @@ $slide-in-up-function: cubic-bezier(.1, .7, .1, 1);
 // Spin
 // -------------------------------
 
-@-webkit-keyframes spin { 
-  100% { -webkit-transform: rotate(360deg); } 
+@-webkit-keyframes spin {
+  100% { -webkit-transform: rotate(360deg); }
 }
-@-moz-keyframes spin { 
-  100% { -moz-transform: rotate(360deg); } 
+@-moz-keyframes spin {
+  100% { -moz-transform: rotate(360deg); }
 }
-@keyframes spin { 
-  100% { transform: rotate(360deg); } 
+@keyframes spin {
+  100% { transform: rotate(360deg); }
 }
 
 .no-animation {
@@ -181,7 +181,7 @@ $slide-in-up-function: cubic-bezier(.1, .7, .1, 1);
  */
 
 .slide-left-right {
-  > .ng-enter, &.ng-enter, 
+  > .ng-enter, &.ng-enter,
   > .ng-leave, &.ng-leave {
     @include transition(all ease-in-out $transition-duration);
     position: absolute;
@@ -229,14 +229,14 @@ $slide-in-up-function: cubic-bezier(.1, .7, .1, 1);
 
 
 /**
- * iOS7 style slide left to right 
+ * iOS7 style slide left to right
  * --------------------------------------------------
  */
 $ios7-timing-function: ease-in-out;
 $ios7-transition-duration: 250ms;
 
 .slide-left-right-ios7 {
-  > .ng-enter, &.ng-enter, 
+  > .ng-enter, &.ng-enter,
   > .ng-leave, &.ng-leave {
     @include transition(all $ios7-timing-function $ios7-transition-duration);
     position: absolute;
@@ -260,7 +260,7 @@ $ios7-transition-duration: 250ms;
     /* OLD content ACTIVELY sliding OUT to the LEFT */
     @include translate3d(-15%, 0, 0);
   }
-  
+
   &.reverse {
     > .ng-enter, &.ng-enter, > .ng-leave, &.ng-leave {
       @include transition(all $ios7-timing-function $ios7-transition-duration);
@@ -472,42 +472,102 @@ $ios7-transition-duration: 250ms;
  */
 $nav-title-slide-ios7-delay: 250ms;
 .nav-title-slide-ios7 {
-  > .ng-enter, &.ng-enter, 
-  > .ng-leave, &.ng-leave {
-    @include transition(all $nav-title-slide-ios7-delay);
-    @include transition-timing-function($ios7-timing-function);
+  // Initial class used on animated titles to keep them invisible initially so they don't 
+  // flicker on top of existing titles on iOS
+  // When title is not animated, the class does nothing
+  > .title.title-animate-no-flicker {
+    visibility: hidden;
+  }
+
+  > .ng-enter, &.ng-enter,
+  > .ng-leave, &.ng-leave,
+  > .ng-hide-add,
+  > .ng-hide-remove {
+    @include transition-duration($nav-title-slide-ios7-delay);
+    @include transition-property(opacity);
+    // Only title transitions translate3d
+    &.title {
+      @include transition-property(all);
+    }
+    // ng-hide has display: none !important; on it by default
+    display: block !important;
+  }
+
+  > .ng-leave, &.ng-leave,
+  > .ng-hide-add {
     opacity: 1;
+    // An active button shouldn't start at 1 opacity; it's already at 0.3
+    // in navBackButton directive, when back button is clicked it gets active class
+    // added to it and keeps it for the duration of the animation
+    &.button-icon.active {
+      opacity: $button-icon-active-opacity;
+    }
+    &.title {
+      @include translate3d(0, 0, 0);
+    }
   }
-  > .ng-enter, &.ng-enter {
-    @include translate3d(30%, 0, 0);
+
+  > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active,
+  > .ng-hide-add.ng-hide-add-active {
     opacity: 0;
+    &.title {
+      @include translate3d(-30%, 0, 0);
+    }
   }
-  > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active {
-    @include translate3d(0, 0, 0);
+
+  > .ng-enter, &.ng-enter,
+  > .ng-hide-remove {
+    opacity: 0;
+    &.title {
+      @include translate3d(30%, 0, 0);
+    }
+  }
+  > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active,
+  > .ng-hide-remove.ng-hide-remove-active {
     opacity: 1;
-  }
-  > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active {
-    @include translate3d(-30%, 0, 0);
-    opacity: 0;
+    &.title {
+      @include translate3d(0, 0, 0);
+    }
   }
 
   &.reverse {
-    > .ng-enter, &.ng-enter, 
-    > .ng-leave, &.ng-leave {
-      @include transition(all ease-in-out $transition-duration);
-      opacity: 1;
+    > .ng-enter, &.ng-enter,
+    > .ng-leave, &.ng-leave,
+    > .ng-hide-add,
+    > .ng-hide-remove {
+      &.title {
+        @include transition(all ease-in-out $transition-duration);
+      }
     }
-    > .ng-enter, &.ng-enter {
-      @include translate3d(-30%, 0, 0);
+
+    > .ng-enter, &.ng-enter,
+    > .ng-hide-remove {
       opacity: 0;
+      &.title {
+        @include translate3d(-30%, 0, 0);
+      }
     }
-    > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active {
-      @include translate3d(0, 0, 0);
+    > .ng-leave, &.ng-leave,
+    > .ng-hide-add {
       opacity: 1;
+      &.title {
+        @include translate3d(0, 0, 0);
+      }
     }
-    > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active {
-      @include translate3d(30%, 0, 0);
+
+    > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active,
+    > .ng-hide-remove.ng-hide-remove-active {
+      opacity: 1;
+      &.title {
+        @include translate3d(0, 0, 0);
+      }
+    }
+    > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active,
+    > .ng-hide-add.ng-hide-add-active {
       opacity: 0;
+      &.title {
+        @include translate3d(30%, 0, 0);
+      }
     }
   }
 }

--- a/scss/_button.scss
+++ b/scss/_button.scss
@@ -159,17 +159,20 @@
 
 .button-icon {
   @include transition(opacity .1s);
+  // Opacity transition 'bounce/bump' fix in Chrome
+  // http://stackoverflow.com/questions/12980153/
+  @include backface-visibility(hidden);
   padding: 0 6px;
   min-width: initial;
   border-color: transparent;
   background: none;
 
-  &.button:active, 
+  &.button:active,
   &.button.active {
     border-color: transparent;
     background: none;
     box-shadow: none;
-    opacity: 0.3;
+    opacity: $button-icon-active-opacity;
   }
 
   .icon:before,
@@ -181,6 +184,9 @@
 .button-clear {
   @include button-clear($button-default-border);
   @include transition(opacity .1s);
+  // Opacity transition 'bounce/bump' fix in Chrome
+  // http://stackoverflow.com/questions/12980153/
+  @include backface-visibility(hidden);
   padding: 0 $button-clear-padding;
   max-height: $button-height;
   border-color: transparent;
@@ -188,7 +194,7 @@
   box-shadow: none;
 
   &:active, &.active {
-    opacity: 0.3;
+    opacity: $button-icon-active-opacity;
   }
 }
 
@@ -206,8 +212,8 @@
 .button-block {
   display: block;
   clear: both;
-  
-  &:after { 
+
+  &:after {
     clear: both;
   }
 }

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -77,6 +77,7 @@ $button-font-size:                    16px !default;
 $button-height:                       42px !default;
 $button-padding:                      12px !default;
 $button-icon-size:                    24px !default;
+$button-icon-active-opacity:          0.3 !default;
 
 $button-large-font-size:              20px !default;
 $button-large-height:                 54px !default;


### PR DESCRIPTION
Tested on Android 4.0, 4.1, 4.2, 4.4, iOS7, iOS7 Simulator

A few changes:
1. Use ng-show for back button, so there's no possibility of it flickering when it is created each time
2. Hide back button by default
3. Add styles for ng-hide/ng-show in nav-title-slide
4. Make it so only the title translates on transition
5. Make titles only be invisible on start if there's an animation on the navbar (using css & new `title-animate-no-flicker` class).  This stops the titles being blank then appearing only after a frame on old android when there's no animation.
6. When you press an icon-button (the back-button), it goes to 0.3 opacity.  Before, you would press it, see 0.3 opacity, let go, then see it go from 1->0 opacity. It looked weird (0.3->1->0). Now when you press the back button it adds the active class to it for the duration of its animation and the back button just goes from 0.3->0.
7. Fixed #624. In chrome, there's a bug where items transitioning on opacity 'bounce/bump' a bit while changing. http://stackoverflow.com/questions/12980153/  It was fixed by putting backface-visibility: none on button-icon & button-clear buttons.  I tested this and it _does_ fix the problem, and presents no other problems I could find (unless people _do_ want backface visibility!). Lemme know if this is bad, you can see it in the scss, and we can remove it and just ignore the bug if you wish (it's in desktop Chrome only, that I could find)
