### PR TITLE
Clean up the tabs directive

### DIFF
--- a/js/ext/angular/src/directive/ionicTabBar.js
+++ b/js/ext/angular/src/directive/ionicTabBar.js
@@ -33,7 +33,7 @@ angular.module('ionic.ui.tabs', ['ionic.service.view'])
       return;
     }
     //Use a field like '$tabSelected' so developers won't accidentally set it in controllers etc
-    if (tab.$tabSelected) { 
+    if (tab.$tabSelected) {
       self.deselect(tab);
       //Try to select a new tab if we're removing a tab
       if (self.tabs.length === 1) {
@@ -59,10 +59,10 @@ angular.module('ionic.ui.tabs', ['ionic.service.view'])
     }
   };
 
-  $scope.select = self.select = function(tab, shouldEmitEvent) {
+  self.select = function(tab, shouldEmitEvent) {
     var tabIndex;
     if (angular.isNumber(tab)) {
-      tabIndex = tab; 
+      tabIndex = tab;
       tab = self.tabs[tabIndex];
     } else {
       tabIndex = self.tabs.indexOf(tab);

--- a/js/ext/angular/test/directive/ionicTabBar.unit.js
+++ b/js/ext/angular/test/directive/ionicTabBar.unit.js
@@ -296,8 +296,6 @@ describe('tabs', function() {
 
     it('should set navViewName and select when necessary if a child nav-view', inject(function($ionicViewService, $rootScope) {
       var isCurrent = false;
-      var deregister = function(){};
-      var listener;
       spyOn($ionicViewService, 'isCurrentStateNavView').andCallFake(function(name) {
         return isCurrent;
       });


### PR DESCRIPTION
It's gone through many changes since Ionic started, so a fresh look at how it works and why look would be a good idea.

Below related issues in one list:
- [x] #634: tabsController is on `<ion-tabs>` scope, user can watch `selectedTab` or `getTabIndex(selectedTab)`
- [x] #620, #395, #419 has-{tabs,header,footer,etc} css/js refactor
- [x] #334 fixed
- [x] #175 Use `tabsController.select` - it takes an index or a tab scope
- [x] #646 fixed

**wontfix**:
- [x] #647 cannot see a better way to do this one than what the user is doing, unless we move to element nav-items (which could be done later). Example: `<ion-tab><ion-tab-nav on-swipe-left="previousTab()"></ion-tab-nav></ion-tab>`
