### PR TITLE
Add padding to .placeholder-icon

### DIFF
--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -1,4 +1,3 @@
-
 /**
  * Forms
  * --------------------------------------------------
@@ -121,6 +120,12 @@ textarea {
 
 .placeholder-icon {
   color: #aaa;
+  &:first-child {
+    padding-right: 6px;
+  }
+  &:last-child {
+    padding-left: 6px;
+  }
 }
 
 .item-stacked-label {


### PR DESCRIPTION
Currently there is no gap between the `.placeholder-icon` and the placeholder text (see this in action here http://ionicframework.com/docs/components/#input-icons), sometimes its fixed by someone using `&nbsp;` which is just a bad workaround, I think adding padding is a better solution.

I hope I did the sass selector correctly, you may check it twice.
