### PR TITLE
Fixes #746 ability to now style checkboxes with the utility colors

### DIFF
--- a/scss/_checkbox.scss
+++ b/scss/_checkbox.scss
@@ -5,10 +5,41 @@
  */
 
 .checkbox {
+  // set the color defaults
+  @include checkbox-style($checkbox-off-border-default, $checkbox-on-bg-default);
+
   position: relative;
   display: inline-block;
   padding: ($checkbox-height / 4) ($checkbox-width / 4);
   cursor: pointer;
+
+  &.checkbox-light  {
+    @include checkbox-style($checkbox-off-border-light, $checkbox-on-bg-light);
+  }
+  &.checkbox-stable  {
+    @include checkbox-style($checkbox-off-border-stable, $checkbox-on-bg-stable);
+  }
+  &.checkbox-positive  {
+    @include checkbox-style($checkbox-off-border-positive, $checkbox-on-bg-positive);
+  }
+  &.checkbox-calm  {
+    @include checkbox-style($checkbox-off-border-calm, $checkbox-on-bg-calm);
+  }
+  &.checkbox-assertive  {
+    @include checkbox-style($checkbox-off-border-assertive, $checkbox-on-bg-assertive);
+  }
+  &.checkbox-balanced  {
+    @include checkbox-style($checkbox-off-border-balanced, $checkbox-on-bg-balanced);
+  }
+  &.checkbox-energized  {
+    @include checkbox-style($checkbox-off-border-energized, $checkbox-on-bg-energized);
+  }
+  &.checkbox-royal  {
+    @include checkbox-style($checkbox-off-border-royal, $checkbox-on-bg-royal);
+  }
+  &.checkbox-dark  {
+    @include checkbox-style($checkbox-off-border-dark, $checkbox-on-bg-dark);
+  }
 }
 
 .checkbox input {
@@ -25,7 +56,6 @@
     display: table;
     width: 100%;
     height: 100%;
-    border: $checkbox-border-width solid $checkbox-off-border-color;
     border-radius: $checkbox-border-radius;
     background: $checkbox-off-bg-color;
     content: ' ';
@@ -59,11 +89,6 @@
   font-weight: bold;
   font-size: 20px;
   content: '\2713';
-}
-
-/* what the background looks like when its checked */
-.checkbox input:checked:before {
-  background: $checkbox-on-bg-color;
 }
 
 /* what the checkmark looks like when its checked */

--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -121,6 +121,21 @@
 }
 
 
+// Checkbox Mixins
+// --------------------------------------------------
+
+@mixin checkbox-style($off-border-color, $on-bg-color) {
+  & input:before {
+    border: $checkbox-border-width solid $off-border-color;
+  }
+
+  /* what the background looks like when its checked */
+  & input:checked:before {
+    background: $on-bg-color;
+  }
+}
+
+
 // Clearfix
 // --------------------------------------------------
 

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -426,6 +426,8 @@ $toggle-off-border-color:         #E5E5E5 !default;
 $toggle-on-bg-color:              $positive !default;
 $toggle-on-border-color:          $toggle-on-bg-color !default;
 
+$toggle-on-royal-bg:              $royal !default;
+$toggle-on-royal-border:          $toggle-on-royal-bg !default;
 
 $toggle-handle-off-bg-color:      $light !default;
 $toggle-handle-on-bg-color:       $toggle-handle-off-bg-color !default;
@@ -444,10 +446,27 @@ $checkbox-border-radius:          $checkbox-width !default;
 $checkbox-border-width:           1px !default;
 
 $checkbox-off-bg-color:           #fff !default;
-$checkbox-off-border-color:       $positive !default;
+$checkbox-off-border-light:       $button-light-border !default;
+$checkbox-on-bg-light:            $button-light-border !default;
+$checkbox-off-border-stable:      $button-stable-border !default;
+$checkbox-on-bg-stable:           $button-stable-border !default;
+$checkbox-off-border-positive:    $positive !default;
+$checkbox-on-bg-positive:         $positive !default;
+$checkbox-off-border-calm:        $calm !default;
+$checkbox-on-bg-calm:             $calm !default;
+$checkbox-off-border-assertive:   $assertive !default;
+$checkbox-on-bg-assertive:        $assertive !default;
+$checkbox-off-border-balanced:    $balanced !default;
+$checkbox-on-bg-balanced:         $balanced !default;
+$checkbox-off-border-energized:   $energized !default;
+$checkbox-on-bg-energized:        $energized !default;
+$checkbox-off-border-royal:       $royal !default;
+$checkbox-on-bg-royal:            $royal !default;
+$checkbox-off-border-dark:        $dark !default;
+$checkbox-on-bg-dark:             $dark !default;
+$checkbox-off-border-default:     $button-stable-border !default;
+$checkbox-on-bg-default:          $button-stable-border !default;
 
-$checkbox-on-bg-color:            $positive !default;
-$checkbox-on-border-color:        $positive !default;
 
 $checkbox-check-width:            3px !default;
 $checkbox-check-color:            #fff !default;


### PR DESCRIPTION
Fixes #746 with the ability to now style checkboxes with the utility colours. No specified color class defaults to stable style.
Checkboxes can now be styled like the following: 

```
           <li class="item item-checkbox">
                <label class="checkbox checkbox-positive">
                    <input type="checkbox">
                </label>
                Flux Capacitor
            </li>
```
