### PR TITLE
Fix item-divider active state styling #789

### DIFF
--- a/scss/_items.scss
+++ b/scss/_items.scss
@@ -536,6 +536,11 @@ button.item-button-right:after,
   font-weight: bold;
 }
 
+.item-divider.active,
+.item-divider:active {
+  @include item-active-style($item-divider-bg, $item-default-border);
+}
+
 
 // Item Note
 // -------------------------------


### PR DESCRIPTION
Prevent item-divider from inheriting default item styling when in active state.

Issue #789
