### PR TITLE
fix(scrollView): browserify issue: undefined core

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -35,7 +35,7 @@ var IS_EMBEDDED_OBJECT_REGEX = /object|embed/i;
 
 	// Create namespaces
 	if (!global.core) {
-		global.core = { effect : {} };
+		var core = global.core = { effect : {} };
 
 	} else if (!core.effect) {
 		core.effect = {};


### PR DESCRIPTION
Initialize core object.

Running browserify script with required ionic raises an error: Uncaught ReferenceError: core is not defined.
