### PR TITLE
Remove scroll-content class and scroll element if scroll="false"

### DIFF
--- a/js/ext/angular/src/directive/ionicContent.js
+++ b/js/ext/angular/src/directive/ionicContent.js
@@ -132,10 +132,17 @@ function($parse, $timeout, $controller, $ionicBind) {
         }
 
         transclude($scope, function(clone) {
-          if (scrollCtrl) {
-            clone.data('$$ionicScrollController', scrollCtrl);
+          if($scope.scroll === "false") {
+            $element.append(clone);
+            $element.removeClass("scroll-content");
+            scrollContent.remove();
           }
-          scrollContent.append(clone);
+          else{
+            if (scrollCtrl) {
+              clone.data('$$ionicScrollController', scrollCtrl);
+            }
+            scrollContent.append(clone);
+          }
         });
 
       }


### PR DESCRIPTION
Potential fix for #841

This pull request is not complete, just meant to generate discussion around a fix for #841.  If scroll="false", we don't want any scrolling behaviour, and to remove the scroll element so that we have access to the parent container height.
