### PR TITLE
Remove column offset with responsive grid breaks

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -629,6 +629,7 @@
         margin-bottom: ($grid-padding-width * 3) / 2;
         max-width: 100%;
         width: 100%;
+        margin-left: 0;
       }
     }
   }


### PR DESCRIPTION
I was using explicit column size and an offset to create a horizontally centered box on larger screens and found that the responsive break classes don't zero out column offsets. This change fixes that.

I don't think there is any use case that you need to keep the column offset with responsive break point?
