### PR TITLE
feat(ionEvents): add .emit() mapped to .trigger()

### DIFF
--- a/js/utils/events.js
+++ b/js/utils/events.js
@@ -149,10 +149,11 @@
 
 
   // Map some convenient top-level functions for event handling
-  ionic.on = function() { ionic.EventController.on.apply(ionic.EventController, arguments); };
-  ionic.off = function() { ionic.EventController.off.apply(ionic.EventController, arguments); };
-  ionic.trigger = ionic.EventController.trigger;//function() { ionic.EventController.trigger.apply(ionic.EventController.trigger, arguments); };
-  ionic.onGesture = function() { return ionic.EventController.onGesture.apply(ionic.EventController.onGesture, arguments); };
+  ionic.on         = function() { ionic.EventController.on.apply(ionic.EventController, arguments); };
+  ionic.off        = function() { ionic.EventController.off.apply(ionic.EventController, arguments); };
+  ionic.trigger    = ionic.EventController.trigger;//function() { ionic.EventController.trigger.apply(ionic.EventController.trigger, arguments); };
+  ionic.emit       = ionic.EventController.trigger;
+  ionic.onGesture  = function() { return ionic.EventController.onGesture.apply(ionic.EventController.onGesture, arguments); };
   ionic.offGesture = function() { return ionic.EventController.offGesture.apply(ionic.EventController.offGesture, arguments); };
 
 })(window.ionic);


### PR DESCRIPTION
Normally the event emitter pattern uses .emit() rather than .trigger() for example Angular uses .$emit() and Node's EventEmitter .emit()
