### PR TITLE
chore(build.config): remove 'fs' module

### DIFF
--- a/config/build.config.js
+++ b/config/build.config.js
@@ -1,4 +1,3 @@
-var fs = require('fs');
 module.exports = {
   dist: 'dist',
   distJs: 'dist/js',


### PR DESCRIPTION
I'm not sure why <code>var fs = require('fs');</code> is here anymore
