### PR TITLE
[Feature #916] custom pager-icon classes for slide-box

### DIFF
--- a/js/ext/angular/src/directive/ionicSlideBox.js
+++ b/js/ext/angular/src/directive/ionicSlideBox.js
@@ -1,290 +1,284 @@
 (function() {
-  'use strict';
+'use strict';
 
-  angular.module('ionic.ui.slideBox', [])
+angular.module('ionic.ui.slideBox', [])
 
+/**
+ * @ngdoc service
+ * @name $ionicSlideBoxDelegate
+ * @module ionic
+ * @description
+ * Delegate that controls the {@link ionic.directive:ionSlideBox} directive.
+ *
+ * Methods called directly on the $ionicSlideBoxDelegate service will control all side
+ * menus.  Use the {@link ionic.service:$ionicSlideBoxDelegate#$getByHandle $getByHandle}
+ * method to control specific slide box instances.
+ *
+ * @usage
+ *
+ * ```html
+ * <body ng-controller="MyCtrl">
+ *   <ion-slide-box>
+ *     <ion-slide>
+ *       <div class="box blue">
+ *         <button ng-click="nextSlide()">Next slide!</button>
+ *       </div>
+ *     </ion-slide>
+ *     <ion-slide>
+ *       <div class="box red">
+ *         Slide 2!
+ *       </div>
+ *     </ion-slide>
+ *   </ion-slide-box>
+ * </body>
+ * ```
+ * ```js
+ * function MyCtrl($scope, $ionicSlideBoxDelegate) {
+ *   $scope.nextSlide = function() {
+ *     $ionicSlideBoxDelegate.next();
+ *   }
+ * }
+ * ```
+ */
+.service('$ionicSlideBoxDelegate', delegateService([
   /**
-   * @ngdoc service
-   * @name $ionicSlideBoxDelegate
-   * @module ionic
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#update
    * @description
-   * Delegate that controls the {@link ionic.directive:ionSlideBox} directive.
-   *
-   * Methods called directly on the $ionicSlideBoxDelegate service will control all side
-   * menus.  Use the {@link ionic.service:$ionicSlideBoxDelegate#$getByHandle $getByHandle}
-   * method to control specific slide box instances.
-   *
-   * @usage
-   *
-   * ```html
-   * <body ng-controller="MyCtrl">
-   *   <ion-slide-box>
-   *     <ion-slide>
-   *       <div class="box blue">
-   *         <button ng-click="nextSlide()">Next slide!</button>
-   *       </div>
-   *     </ion-slide>
-   *     <ion-slide>
-   *       <div class="box red">
-   *         Slide 2!
-   *       </div>
-   *     </ion-slide>
-   *   </ion-slide-box>
-   * </body>
-   * ```
-   * ```js
-   * function MyCtrl($scope, $ionicSlideBoxDelegate) {
-   *   $scope.nextSlide = function() {
-   *     $ionicSlideBoxDelegate.next();
-   *   }
-   * }
-   * ```
+   * Update the slidebox (for example if using Angular with ng-repeat,
+   * resize it for the elements inside).
    */
-  .service('$ionicSlideBoxDelegate', delegateService([
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#update
-     * @description
-     * Update the slidebox (for example if using Angular with ng-repeat,
-     * resize it for the elements inside).
-     */
-    'update',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#slide
-     * @param {number} to The index to slide to.
-     * @param {number=} speed The number of milliseconds for the change to take.
-     */
-    'slide',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#previous
-     * @description Go to the previous slide. Wraps around if at the beginning.
-     */
-    'previous',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#next
-     * @description Go to the next slide. Wraps around if at the end.
-     */
-    'next',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#stop
-     * @description Stop sliding. The slideBox will not move again until
-     * explicitly told to do so.
-     */
-    'stop',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#currentIndex
-     * @returns number The index of the current slide.
-     */
-    'currentIndex',
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#slidesCount
-     * @returns number The number of slides there are currently.
-     */
-    'slidesCount'
-    /**
-     * @ngdoc method
-     * @name $ionicSlideBoxDelegate#$getByHandle
-     * @param {string} handle
-     * @returns `delegateInstance` A delegate instance that controls only the
-     * {@link ionic.directive:ionSlideBox} directives with `delegate-handle` matching
-     * the given handle.
-     *
-     * Example: `$ionicSlideBoxDelegate.$getByHandle('my-handle').stop();`
-     */
-  ]))
-
+  'update',
   /**
-   * The internal controller for the slide box controller.
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#slide
+   * @param {number} to The index to slide to.
+   * @param {number=} speed The number of milliseconds for the change to take.
    */
-
+  'slide',
   /**
-   * @ngdoc directive
-   * @name ionSlideBox
-   * @module ionic
-   * @delegate ionic.service:$ionicSlideBoxDelegate
-   * @restrict E
-   * @description
-   * The Slide Box is a multi-page container where each page can be swiped or dragged between:
-   *
-   * ![SlideBox](http://ionicframework.com.s3.amazonaws.com/docs/controllers/slideBox.gif)
-   *
-   * @usage
-   * ```html
-   * <ion-slide-box>
-   *   <ion-slide>
-   *     <div class="box blue"><h1>BLUE</h1></div>
-   *   </ion-slide>
-   *   <ion-slide>
-   *     <div class="box yellow"><h1>YELLOW</h1></div>
-   *   </ion-slide>
-   *   <ion-slide>
-   *     <div class="box pink"><h1>PINK</h1></div>
-   *   </ion-slide>
-   * </ion-slide-box>
-   * ```
-   *
-   * @param {string=} delegate-handle The handle used to identify this slideBox
-   * with {@link ionic.service:$ionicSlideBoxDelegate}.
-   * @param {boolean=} does-continue Whether the slide box should automatically slide.
-   * @param {number=} slide-interval How many milliseconds to wait to change slides (if does-continue is true). Defaults to 4000.
-   * @param {boolean=} show-pager Whether a pager should be shown for this slide box.
-   * @param {string=} pager-icon Type of icon to use for the pager when slide is not active.
-   * @param {string=} pager-icon-active Type of icon to use for the pager when slide is active.
-   * @param {boolean=} disable-scroll Whether to disallow scrolling/dragging of the slide-box content.
-   * @param {expression=} on-slide-changed Expression called whenever the slide is changed.
-   * @param {expression=} active-slide Model to bind the current slide to.
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#previous
+   * @description Go to the previous slide. Wraps around if at the beginning.
    */
-  .directive('ionSlideBox', [
-    '$timeout',
-    '$compile',
-    '$ionicSlideBoxDelegate',
-    function($timeout, $compile, $ionicSlideBoxDelegate) {
-      return {
-        restrict: 'E',
-        replace: true,
-        transclude: true,
-        scope: {
-          doesContinue: '@',
-          slideInterval: '@',
-          showPager: '@',
-          pagerIcon: '@',
-          pagerIconActive: '@',
-          disableScroll: '@',
-          onSlideChanged: '&',
-          activeSlide: '=?'
+  'previous',
+  /**
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#next
+   * @description Go to the next slide. Wraps around if at the end.
+   */
+  'next',
+  /**
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#stop
+   * @description Stop sliding. The slideBox will not move again until
+   * explicitly told to do so.
+   */
+  'stop',
+  /**
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#currentIndex
+   * @returns number The index of the current slide.
+   */
+  'currentIndex',
+  /**
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#slidesCount
+   * @returns number The number of slides there are currently.
+   */
+  'slidesCount'
+  /**
+   * @ngdoc method
+   * @name $ionicSlideBoxDelegate#$getByHandle
+   * @param {string} handle
+   * @returns `delegateInstance` A delegate instance that controls only the
+   * {@link ionic.directive:ionSlideBox} directives with `delegate-handle` matching
+   * the given handle.
+   *
+   * Example: `$ionicSlideBoxDelegate.$getByHandle('my-handle').stop();`
+   */
+]))
+
+/**
+ * The internal controller for the slide box controller.
+ */
+
+/**
+ * @ngdoc directive
+ * @name ionSlideBox
+ * @module ionic
+ * @delegate ionic.service:$ionicSlideBoxDelegate
+ * @restrict E
+ * @description
+ * The Slide Box is a multi-page container where each page can be swiped or dragged between:
+ *
+ * ![SlideBox](http://ionicframework.com.s3.amazonaws.com/docs/controllers/slideBox.gif)
+ *
+ * @usage
+ * ```html
+ * <ion-slide-box>
+ *   <ion-slide>
+ *     <div class="box blue"><h1>BLUE</h1></div>
+ *   </ion-slide>
+ *   <ion-slide>
+ *     <div class="box yellow"><h1>YELLOW</h1></div>
+ *   </ion-slide>
+ *   <ion-slide>
+ *     <div class="box pink"><h1>PINK</h1></div>
+ *   </ion-slide>
+ * </ion-slide-box>
+ * ```
+ *
+ * @param {string=} delegate-handle The handle used to identify this slideBox
+ * with {@link ionic.service:$ionicSlideBoxDelegate}.
+ * @param {boolean=} does-continue Whether the slide box should automatically slide.
+ * @param {number=} slide-interval How many milliseconds to wait to change slides (if does-continue is true). Defaults to 4000.
+ * @param {boolean=} show-pager Whether a pager should be shown for this slide box.
+ * @param {string=} pager-icon Type of icon to use for the pager when slide is not active.
+ *  @param {string=} pager-icon-active Type of icon to use for the pager when slide is active.
+ * @param {boolean=} disable-scroll Whether to disallow scrolling/dragging of the slide-box content.
+ * @param {expression=} on-slide-changed Expression called whenever the slide is changed.
+ * @param {expression=} active-slide Model to bind the current slide to.
+ */
+.directive('ionSlideBox', [
+  '$timeout',
+  '$compile',
+  '$ionicSlideBoxDelegate',
+function($timeout, $compile, $ionicSlideBoxDelegate) {
+  return {
+    restrict: 'E',
+    replace: true,
+    transclude: true,
+    scope: {
+      doesContinue: '@',
+      slideInterval: '@',
+      showPager: '@',
+      pagerIcon: '@',
+      pagerIconActive: '@',
+      disableScroll: '@',
+      onSlideChanged: '&',
+      activeSlide: '=?'
+    },
+    controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
+      var _this = this;
+
+      var continuous = $scope.$eval($scope.doesContinue) === true;
+      var slideInterval = continuous ? $scope.$eval($scope.slideInterval) || 4000 : 0;
+
+      var slider = new ionic.views.Slider({
+        el: $element[0],
+        auto: slideInterval,
+        disableScroll: ($scope.$eval($scope.disableScroll) === true) || false,
+        continuous: continuous,
+        startSlide: $scope.activeSlide,
+        slidesChanged: function() {
+          $scope.currentSlide = slider.currentIndex();
+
+          // Try to trigger a digest
+          $timeout(function() {});
         },
-        controller: ['$scope', '$element', '$attrs',
-          function($scope, $element, $attrs) {
-            var _this = this;
+        callback: function(slideIndex) {
+          $scope.currentSlide = slideIndex;
+          $scope.onSlideChanged({index:$scope.currentSlide});
+          $scope.$parent.$broadcast('slideBox.slideChanged', slideIndex);
+          $scope.activeSlide = slideIndex;
+          // Try to trigger a digest
+          $timeout(function() {});
+        }
+      });
 
-            var continuous = $scope.$eval($scope.doesContinue) === true;
-            var slideInterval = continuous ? $scope.$eval($scope.slideInterval) || 4000 : 0;
+      $scope.$watch('activeSlide', function(nv) {
+        if(angular.isDefined(nv)){
+          slider.slide(nv);
+        }
+      });
 
-            $scope.pagerIcon = $scope.pagerIcon || 'ion-record';
-            $scope.pagerIconActive = $scope.pagerIconActive || 'ion-record';
+      $scope.$on('slideBox.nextSlide', function() {
+        slider.next();
+      });
 
-            var slider = new ionic.views.Slider({
-              el: $element[0],
-              auto: slideInterval,
-              disableScroll: ($scope.$eval($scope.disableScroll) === true) || false,
-              continuous: continuous,
-              startSlide: $scope.activeSlide,
-              slidesChanged: function() {
-                $scope.currentSlide = slider.currentIndex();
+      $scope.$on('slideBox.prevSlide', function() {
+        slider.prev();
+      });
 
-                // Try to trigger a digest
-                $timeout(function() {});
-              },
-              callback: function(slideIndex) {
-                $scope.currentSlide = slideIndex;
-                $scope.onSlideChanged({
-                  index: $scope.currentSlide
-                });
-                $scope.$parent.$broadcast('slideBox.slideChanged', slideIndex);
-                $scope.activeSlide = slideIndex;
-                // Try to trigger a digest
-                $timeout(function() {});
-              }
-            });
+      $scope.$on('slideBox.setSlide', function(e, index) {
+        slider.slide(index);
+      });
 
-            $scope.$watch('activeSlide', function(nv) {
-              if (angular.isDefined(nv)) {
-                slider.slide(nv);
-              }
-            });
+      //Exposed for testing
+      this.__slider = slider;
 
-            $scope.$on('slideBox.nextSlide', function() {
-              slider.next();
-            });
+      var deregisterInstance = $ionicSlideBoxDelegate._registerInstance(slider, $attrs.delegateHandle);
 
-            $scope.$on('slideBox.prevSlide', function() {
-              slider.prev();
-            });
+      $scope.$on('$destroy', deregisterInstance);
 
-            $scope.$on('slideBox.setSlide', function(e, index) {
-              slider.slide(index);
-            });
+      this.slidesCount = function() {
+        return slider.slidesCount();
+      };
 
-            //Exposed for testing
-            this.__slider = slider;
-
-            var deregisterInstance = $ionicSlideBoxDelegate._registerInstance(slider, $attrs.delegateHandle);
-
-            $scope.$on('$destroy', deregisterInstance);
-
-            this.slidesCount = function() {
-              return slider.slidesCount();
-            };
-
-            $timeout(function() {
-              slider.load();
-            });
-          }
-        ],
-        template: '<div class="slider">\
+      $timeout(function() {
+        slider.load();
+      });
+    }],
+    template: '<div class="slider">\
             <div class="slider-slides" ng-transclude>\
             </div>\
           </div>',
 
-        link: function($scope, $element, $attr, slideBoxCtrl) {
-          // If the pager should show, append it to the slide box
-          if ($scope.$eval($scope.showPager) !== false) {
-            var childScope = $scope.$new();
-            var pager = angular.element('<ion-pager></ion-pager>');
-            $element.append(pager);
-            $compile(pager)(childScope);
+    link: function($scope, $element, $attr, slideBoxCtrl) {
+      // If the pager should show, append it to the slide box
+      if($scope.$eval($scope.showPager) !== false) {
+        var childScope = $scope.$new();
+        var pager = angular.element('<ion-pager></ion-pager>');
+        $element.append(pager);
+        $compile(pager)(childScope);
+      }
+    }
+  };
+}])
+
+.directive('ionSlide', function() {
+  return {
+    restrict: 'E',
+    require: '^ionSlideBox',
+    compile: function(element, attr) {
+      element.addClass('slider-slide');
+      return function($scope, $element, $attr) {};
+    },
+  };
+})
+
+.directive('ionPager', function() {
+  return {
+    restrict: 'E',
+    replace: true,
+    require: '^ionSlideBox',
+    template: '<div class="slider-pager"><span class="slider-pager-page" ng-repeat="slide in numSlides() track by $index" ng-class="{active: $index == currentSlide}"><i class="icon" ng-class="{true: pagerIconActive, false: pagerIcon}[$index == currentSlide]"></i></span></div>',
+    link: function($scope, $element, $attr, slideBox) {
+      $scope.pagerIcon = $scope.pagerIcon || 'ion-record';
+      $scope.pagerIconActive = $scope.pagerIconActive || 'ion-record';
+      var selectPage = function(index) {
+        var children = $element[0].children;
+        var length = children.length;
+        for(var i = 0; i < length; i++) {
+          if(i == index) {
+            children[i].classList.add('active');
+          } else {
+            children[i].classList.remove('active');
           }
         }
       };
+
+      $scope.numSlides = function() {
+        return new Array(slideBox.slidesCount());
+      };
+
+      $scope.$watch('currentSlide', function(v) {
+        selectPage(v);
+      });
     }
-  ])
+  };
 
-  .directive('ionSlide', function() {
-    return {
-      restrict: 'E',
-      require: '^ionSlideBox',
-      compile: function(element, attr) {
-        element.addClass('slider-slide');
-        return function($scope, $element, $attr) {};
-      },
-    };
-  })
-
-  .directive('ionPager', function() {
-    return {
-      restrict: 'E',
-      replace: true,
-      require: '^ionSlideBox',
-      template: '<div class="slider-pager"><span class="slider-pager-page" ng-repeat="slide in numSlides() track by $index" ng-class="{active: $index == currentSlide}"><i class="icon" ng-class="{true: pagerIconActive, false: pagerIcon}[$index == currentSlide]"></i></span></div>',
-      link: function($scope, $element, $attr, slideBox) {
-        var selectPage = function(index) {
-          var children = $element[0].children;
-          var length = children.length;
-          for (var i = 0; i < length; i++) {
-            if (i == index) {
-              children[i].classList.add('active');
-            } else {
-              children[i].classList.remove('active');
-            }
-          }
-        };
-
-        $scope.numSlides = function() {
-          return new Array(slideBox.slidesCount());
-        };
-
-        $scope.$watch('currentSlide', function(v) {
-          selectPage(v);
-        });
-      }
-    };
-
-  });
+});
 
 })();


### PR DESCRIPTION
Gives the option to specify pager-icons classes for the `ion-slide-box`. Both for when slide is active or when it's inactive. 

I added two attributes: `pager-icon` & `pager-icon-active`. If they aren't specified then it falls back to `ion-record`
