### PR TITLE
Changed wrong ngdoc example

### DIFF
--- a/js/ext/angular/src/directive/ionicViewState.js
+++ b/js/ext/angular/src/directive/ionicViewState.js
@@ -19,7 +19,7 @@ angular.module('ionic.ui.viewState', ['ionic.service.view', 'ionic.service.gestu
  *
  * ```html
  * <ion-nav-bar></ion-nav-bar>
- * <ion-nav-view class="slide-left-right">
+ * <ion-nav-view animation="slide-left-right">
  *   <ion-view title="My Page">
  *     <ion-content>
  *       Hello!


### PR DESCRIPTION
ion-nav-view needs an animation attribute="slide-left-right", not a class="slide-left-right"
