### PR TITLE
fix(ionCheckbox) add missing ng-disabled attribute

### DIFF
--- a/js/ext/angular/src/directive/ionicCheckbox.js
+++ b/js/ext/angular/src/directive/ionicCheckbox.js
@@ -27,6 +27,7 @@ angular.module('ionic.ui.checkbox', [])
       ngModel: '=?',
       ngValue: '=?',
       ngChecked: '=?',
+      ngDisabled: '=?',
       ngChange: '&'
     },
     transclude: true,
@@ -42,6 +43,7 @@ angular.module('ionic.ui.checkbox', [])
       var input = element.find('input');
       if(attr.name) input.attr('name', attr.name);
       if(attr.ngChecked) input.attr('ng-checked', 'ngChecked');
+      if(attr.ngDisabled) input.attr('ng-disabled', 'ngDisabled');
       if(attr.ngTrueValue) input.attr('ng-true-value', attr.ngTrueValue);
       if(attr.ngFalseValue) input.attr('ng-false-value', attr.ngFalseValue);
     }


### PR DESCRIPTION
Setting the ng-disabled attribute to true on the ion-checkbox had no effect.  Now it will make the checkbox disabled as it should.
