### PR TITLE
Fix item-text-wrap

### DIFF
--- a/scss/_items.scss
+++ b/scss/_items.scss
@@ -218,7 +218,7 @@ a.item-content {
 .item-body h5,
 .item-body h6,
 .item-body p {
-  overflow: hidden;
+  overflow: visible;
   white-space: normal;
 }
 .item-complex.item-text-wrap,
@@ -229,8 +229,8 @@ a.item-content {
 .item-complex.item-text-wrap h5,
 .item-complex.item-text-wrap h6,
 .item-complex.item-text-wrap p {
-  overflow: hidden;
-  white-space: nowrap;
+  overflow: visible;
+  white-space: normal;
 }
 
 


### PR DESCRIPTION
Looks like that item-text-wrap `overlow:` and `white-space` properties don't actually override the default behavior. This fix changes both properties, `visible` and `normal`, on item-text-wrap.

<ion-list>
  <ion-item ng-repeat="activity in activities"
            class="item-text-wrap"
            href="#/tab/activity/{{activity.id}}">
  </ion-item>
</ion-list>
