### PR TITLE
Wrong attribute to animate view transition in the docs

### DIFF
--- a/js/ext/angular/src/directive/ionicViewState.js
+++ b/js/ext/angular/src/directive/ionicViewState.js
@@ -117,7 +117,7 @@ angular.module('ionic.ui.viewState', ['ionic.service.view', 'ionic.service.gestu
  * Recommended for page transitions: 'slide-left-right', 'slide-left-right-ios7', 'slide-in-up'.
  *
  * ```html
- * <ion-nav-view class="slide-left-right">
+ * <ion-nav-view animation="slide-left-right">
  *   <!-- Center content -->
  *   <ion-nav-bar>
  *   </ion-nav-bar>


### PR DESCRIPTION
Hello

Seems to have a typo in the code. The correct attribute to set animation for view transistion is `animation`instead of `class`.

It took me some time to figure it out.

Best regards !
