### PR TITLE
Update _popup.scss – max-width:100%

### DIFF
--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -14,6 +14,7 @@
   visibility: hidden;
 
   width: $popup-width;
+  max-width: 100%;
 
   border-radius: $popup-border-radius;
   background-color: $popup-background-color;


### PR DESCRIPTION
popups should not be wider than the display. Needed for small screens.
