### PR TITLE
fixed the header bar link to the docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,7 +75,7 @@ New Code:
 
 * **ionHeaderBar, ionFooterBar**: remove `type`, `title`, `left-buttons`, `right-buttons`.
 
-Relevant Documentation: [ionHeaderBar](http://ionicframework.com/docs/api/directive/ionHeaerBar),
+Relevant Documentation: [ionHeaderBar](http://ionicframework.com/docs/api/directive/ionHeaderBar),
 [ionFooterBar](http://ionicframework.com/docs/api/directive/ionFooterBar).
 
 Old Code:


### PR DESCRIPTION
The link to the relevant documentation on the header bar [1.0.0-beta.1 (2014-03-25)] was missing a "d". This caused it to return a 404 "Page not found" whenever it was clicked.
