### PR TITLE
add angular-sanitize.js to the list of concatenated resources 

### DIFF
--- a/config/build.config.js
+++ b/config/build.config.js
@@ -21,7 +21,8 @@ module.exports = {
     '/*!\n' +
     ' * ionic.bundle.js is a concatenation of:\n' +
     ' * ionic.js, angular.js, angular-animate.js,\n'+
-    ' * angular-ui-router.js, and ionic-angular.js\n'+
+    ' * angular-sanitize.js, angular-ui-router.js,\n'+
+    ' * and ionic-angular.js\n'+
     ' */\n\n',
   closureStart: '(function() {\n',
   closureEnd: '\n})();',


### PR DESCRIPTION
The list of concatenated resources in the release js file doesn't include angular-sanitize.js. It posed problems for my so I fixed it. Please accept this pull request to help others :)
