### PR TITLE
Added support for align-items: stretch in grid

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -1,4 +1,3 @@
-
 /**
  * Grid
  * --------------------------------------------------
@@ -38,6 +37,9 @@
 }
 .row-center {
   @include align-items(center);
+}
+.row-stretch {
+  @include align-items(stretch);
 }
 
 /* .col-* vertically aligns an individual .col */


### PR DESCRIPTION
Now you can do:

```
<div class="row row-stretch">
    <div class="col">Very<br />Much<br />Text<br /></div>
    <div class="col">Short</div>
    <div class="col">Shrt</div>
</div>
```

All columns will have equal heights. Especially useful when 'simulating' tables with the grid system.
