### PR TITLE
remove ability to resize textareas

### DIFF
--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -187,6 +187,7 @@ input[type="color"] {
 input,
 textarea {
   width: 100%;
+  resize: none;
 }
 
 // Reset height since textareas have rows


### PR DESCRIPTION
On android, without this line you see 3 diagonal lines in the lower right hand side of textareas. This suggests to the app user that the textarea is resizeable. On mobile apps you probably don't want the user to be able to resize textareas so I suggest this edit.
