### PR TITLE
Allowed a tab-title to be watched

### DIFF
--- a/js/ext/angular/src/directive/ionicTabBar.js
+++ b/js/ext/angular/src/directive/ionicTabBar.js
@@ -409,7 +409,7 @@ function($rootScope, $animate, $ionicBind, $compile, $ionicViewService, $state, 
       '<span class="tab-title" ng-bind-html="title"></span>' +
     '</a>',
     scope: {
-      title: '@',
+      title: '=',
       icon: '@',
       iconOn: '@',
       iconOff: '@',


### PR DESCRIPTION
Not sure if there is a better way (tried using observes and watches and I can't get it to work), but we have a requirement to allow the title of a tab to change - internal language service - and the current ion-tab-nav doesn't do this.

I've changed the binding to two-way and it works...
