### PR TITLE
Expose isOpen to $ionicSideMenuDelegate

### DIFF
--- a/js/ext/angular/src/directive/ionicSideMenu.js
+++ b/js/ext/angular/src/directive/ionicSideMenu.js
@@ -87,6 +87,12 @@ angular.module('ionic.ui.sideMenu', ['ionic.service.gesture', 'ionic.service.vie
   'getOpenRatio',
   /**
    * @ngdoc method
+   * @name $ionicSideMenuDelegate#isOpen
+   * @returns {boolean} Whether the menu (left or right) is currently opened.
+   */
+  'isOpen',
+  /**
+   * @ngdoc method
    * @name $ionicSideMenuDelegate#isOpenLeft
    * @returns {boolean} Whether the left menu is currently opened.
    */


### PR DESCRIPTION
One universal way to check if any menu is opened; left or right through the $ionicSideMenuDelegate
