### PR TITLE
Edge case where animation async event fires after loading was hidden

### DIFF
--- a/js/ext/angular/src/service/ionicLoading.js
+++ b/js/ext/angular/src/service/ionicLoading.js
@@ -112,14 +112,17 @@ function($animate, $document, $ionicTemplateLoader, $ionicBackdrop, $timeout, $q
           });
 
           ionic.requestAnimationFrame(function() {
-            $animate.removeClass(self.element, 'ng-hide');
-            //Fix for ios: if we center the element twice, it always gets
-            //position right. Otherwise, it doesn't
-            ionic.DomUtil.centerElementByMargin(self.element[0]);
-            //One frame after it's visible, position it
-            ionic.requestAnimationFrame(function() {
+            if (self.isShown === undefined || self.isShown)
+            {
+              $animate.removeClass(self.element, 'ng-hide');
+              //Fix for ios: if we center the element twice, it always gets
+              //position right. Otherwise, it doesn't
               ionic.DomUtil.centerElementByMargin(self.element[0]);
-            });
+              //One frame after it's visible, position it
+              ionic.requestAnimationFrame(function() {
+                ionic.DomUtil.centerElementByMargin(self.element[0]);
+              });
+            }
           });
 
           this.isShown = true;


### PR DESCRIPTION
Stop the race condition where the loading is hidden, but then the animation frame asynchronously kicks in.
