### PR TITLE
Ensures that a call to release waits for the active animation to finish.

### DIFF
--- a/js/ext/angular/src/service/ionicBackdrop.js
+++ b/js/ext/angular/src/service/ionicBackdrop.js
@@ -6,10 +6,12 @@ angular.module('ionic')
 .factory('$ionicBackdrop', [
   '$animate',
   '$document',
-function($animate, $document) {
+  '$q',
+function($animate, $document, $q) {
 
   var el;
   var backdropHolds = 0;
+  var showingPromise;
 
   return {
     retain: retain,
@@ -26,12 +28,18 @@ function($animate, $document) {
   }
   function retain() {
     if ( (++backdropHolds) === 1 ) {
-      $animate.removeClass(getElement(), 'ng-hide');
+      var retainDeferred = $q.defer();
+      showingPromise = retainDeferred.promise;
+      $animate.removeClass(getElement(), 'ng-hide', function() {
+        retainDeferred.resolve(null);
+      });
     }
   }
   function release() {
     if ( (--backdropHolds) === 0 ) {
-      $animate.addClass(getElement(), 'ng-hide');
+      showingPromise.then(function() {
+        $animate.addClass(getElement(), 'ng-hide');
+      });
     }
   }
 }]);


### PR DESCRIPTION
If a call to release is made before the animation on retain has finished, then the animation will never be "completed". This can happen if you show busy and get a response from your network in say <0.05 seconds (or always show busy and pull from a cache).

This fix introduces a promise which is created on a call to retain when the backdrop initially shows, and resolves when the animation has finished. If the backdrop is subsequently removed then it waits for the promise to resolve before removing the animation.
