### PR TITLE
menu-toggle attr accepts angular expression, not raw strings

### DIFF
--- a/js/ext/angular/src/directive/ionicSideMenu.js
+++ b/js/ext/angular/src/directive/ionicSideMenu.js
@@ -348,7 +348,7 @@ angular.module('ionic.ui.sideMenu', ['ionic.service.gesture', 'ionic.service.vie
  * @usage
  * ```html
  * <ion-side-menu
- *   side="left"
+ *   side="'left'"
  *   width="myWidthValue + 20"
  *   is-enabled="shouldLeftSideMenuBeEnabled()">
  * </ion-side-menu>


### PR DESCRIPTION
A $scope.$eval() is being done with the value of the menu-toggle attr. So, it should receive an angular expression, not a raw string.
