### PR TITLE
Loading popup not hiding

### DIFF
--- a/js/views/loadingView.js
+++ b/js/views/loadingView.js
@@ -32,6 +32,8 @@
         lb.style.marginTop = (-lb.offsetHeight) / 2 + 'px';
 
         // Wait 'showDelay' ms before showing the loading screen
+        if(this._showDelayTimeout)
+          window.clearTimeout(this._showDelayTimeout);
         this._showDelayTimeout = window.setTimeout(function() {
           _this.el.classList.add('active');
         }, _this.showDelay);


### PR DESCRIPTION
Loading doesn't hide when show is called more than once before hide is called.
An example can be found here: http://cdpn.io/ECubl
