### PR TITLE
IE9+ doesn't support new CustomEvent()

### DIFF
--- a/js/utils/events.js
+++ b/js/utils/events.js
@@ -12,8 +12,12 @@
 
 (function(ionic) {
 
-  // Custom event polyfill
-  if(!window.CustomEvent) {
+  // Custom event polyfill and IE9+ compatibility
+  msie = parseInt(((/msie (\d+)/i.exec(navigator.userAgent) || [])[1]),10);
+  if (isNaN(msie)) {
+    msie = parseInt((/trident\/.*; rv:(\d+)/i.exec(navigator.userAgent) || [])[1], 10);
+  }
+  if(msie >= 9 || !window.CustomEvent) {
     (function() {
       var CustomEvent;
 


### PR DESCRIPTION
Add a check for IE9+ to force us to use 

```
document.createEvent("CustomEvent")
```

as IE9+ does not support 

```
new CustomEvent
```

See 
https://stackoverflow.com/questions/19345392/why-arent-my-parameters-getting-passed-through-to-a-dispatched-event?answertab=active#tab-top
