### PR TITLE
Update infiniteScroll Example

### DIFF
--- a/js/angular/directive/infiniteScroll.js
+++ b/js/angular/directive/infiniteScroll.js
@@ -36,6 +36,10 @@
  *       $scope.$broadcast('scroll.infiniteScrollComplete');
  *     });
  *   };
+ * 
+ *   $scope.$on('stateChangeSuccess', function() {
+ *     $scope.loadMore();
+ *   });
  * }
  * ```
  *


### PR DESCRIPTION
Add Sample of Automatically Loading First Set of Data.  Since the new `ion-infinite-scroll` does not automatically load data, devs need to see how to kick it off the first time.
