### PR TITLE
Add default values for ion-view hide-back-button and hide-nav-bar attributes

### DIFF
--- a/js/angular/directive/view.js
+++ b/js/angular/directive/view.js
@@ -24,9 +24,9 @@
  * ```
  *
  * @param {string=} title The title to display on the parent {@link ionic.directive:ionNavBar}.
- * @param {boolean=} hideBackButton Whether to hide the back button on the parent
+ * @param {boolean=} hideBackButton Whether to hide the back button on the parent (default false)
  * {@link ionic.directive:ionNavBar} by default.
- * @param {boolean=} hideNavBar Whether to hide the parent
+ * @param {boolean=} hideNavBar Whether to hide the parent (default false)
  * {@link ionic.directive:ionNavBar} by default.
  */
 IonicModule
@@ -39,6 +39,8 @@ IonicModule
     compile: function(tElement, tAttrs, transclude) {
       tElement.addClass('pane');
       tElement[0].removeAttribute('title');
+      tAttrs.hideBackButton = tAttrs.hideBackButton || false;
+      tAttrs.hideNavBar = tAttrs.hideNavBar || false;
 
       return function link($scope, $element, $attr, navBarCtrl) {
         if (!navBarCtrl) {


### PR DESCRIPTION
If your view is missing the hide-back-button or hide-nav-bar attributes, we get exceptions from Angular when trying to watch these non-existent properties.

i.e.

```
TypeError: Cannot read property 'exp' of undefined
    at ng.config.$provide.decorator.watchFnToHumanReadableString (<anonymous>:703:19)
    at Scope.ng.config.$provide.decorator.$delegate.__proto__.$watch (<anonymous>:735:28)
    at link (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:37265:16)
    at nodeLinkFn (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:13700:13)
    at compositeLinkFn (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:13110:15)
    at publicLinkFn (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:13015:30)
    at updateView (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:37466:11)
    at angular.module.directive.directive.directive.compile.eventHook (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:37410:17)
    at Scope.$get.Scope.$broadcast (http://localhost:3000/bower_components/ionic/release/js/ionic.bundle.js:19731:28)
    at t.transitionTo.t.transition.N.then.t.transition.t.transition (http://localhost:3000/bower_components/angular-ui-router/release/angular-ui-router.min.js:7:10007) <ion-view class="pane">
```

Fixed by adding default values of false for both attributes (which should stand by undefined == false and that the default behaviour should be to show the nav bar and the back button if possible).
