### PR TITLE
Included name property in the radio directive (credits to perryg)

### DIFF
--- a/js/angular/directive/radio.js
+++ b/js/angular/directive/radio.js
@@ -26,7 +26,8 @@ IonicModule
       ngModel: '=?',
       ngValue: '=?',
       ngChange: '&',
-      icon: '@'
+      icon: '@',
+      name: '@'
     },
     transclude: true,
     template: '<label class="item item-radio">' +


### PR DESCRIPTION
While populating multiple lists of radio buttons, I noticed that only a single radio from all lists could be selected.
Turns out the culprit was the name property, which was missing from the directive. All credits go to perryg I just discovered the bug, he implemented the solution.
