### PR TITLE
Prevent NPE during ion-slide-box drag

### DIFF
--- a/js/views/listView.js
+++ b/js/views/listView.js
@@ -440,7 +440,7 @@
     // Return the list item from the given target
     _getItem: function(target) {
       while(target) {
-        if(target.classList.contains(ITEM_CLASS)) {
+        if(target.classList && target.classList.contains(ITEM_CLASS)) {
           return target;
         }
         target = target.parentNode;


### PR DESCRIPTION
```
Uncaught TypeError: Cannot read property 'contains' of undefined ionic.bundle.js:6182
ionic.views.ListView.ionic.views.View.inherit._getItem ionic.bundle.js:6182
ionic.views.ListView.ionic.views.View.inherit._startDrag ionic.bundle.js:6223
ionic.views.ListView.ionic.views.View.inherit._handleDrag ionic.bundle.js:6266
(anonymous function) ionic.bundle.js:6088
triggerEvent ionic.bundle.js:769
dragGesture ionic.bundle.js:1804
detect ionic.bundle.js:1347
bindDomOnTouch ionic.bundle.js:896
```
