### PR TITLE
Was not using scss variable for menu color

### DIFF
--- a/scss/_menu.scss
+++ b/scss/_menu.scss
@@ -16,7 +16,7 @@
   max-height: 100%;
   width: $menu-width;
 
-  background-color: #fff;
+  background-color: $menu-bg;
 }
 
 .menu-content {


### PR DESCRIPTION
Was not using scss variable for menu color.

TODO: other menu variables don't seem to be used either, such as $menu-inset-border-color.
