### PR TITLE
Align multiple header buttons correctly (4.4)

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -195,8 +195,8 @@
   
   // Android 4.4 messes with the display property
   .buttons,
-  .buttons .left-buttons,
-  .buttons .right-buttons {
+  .buttons.left-buttons,
+  .buttons.right-buttons {
     display: inherit;
   }
   // Place the last button in a bar on the right of the bar


### PR DESCRIPTION
Android doesn't render multiple buttons in the `ion-nav-bar` or `ion-header-bar` correctly. The browser overrides the display property. 

On Android 4.4:
<img src="http://forum.ionicframework.com//uploads/default/695/9bd823af5d800f95.png" > 
<br><br>
On Android 4.3 it is not happening:
<img src="http://forum.ionicframework.com//uploads/default/696/4bfd99c5cf2b9575.png"> 
