### PR TITLE
feat ($ionicActionSheet): pass button object to buttonClicked

### DIFF
--- a/js/angular/service/actionSheet.js
+++ b/js/angular/service/actionSheet.js
@@ -69,8 +69,8 @@ function($rootScope, $document, $compile, $animate, $timeout, $ionicTemplateLoad
      *  - `{string=}` `destructiveText` The text for a 'danger' on the action sheet.
      *  - `{function=}` `cancel` Called if the cancel button is pressed or the backdrop is tapped.
      *  - `{function=}` `buttonClicked` Called when one of the non-destructive buttons is clicked,
-     *     with the index of the button that was clicked. Return true to close the action sheet,
-     *     or false to keep it opened.
+     *     with the index of the button that was clicked and the button object. Return true to close
+     *     the action sheet, or false to keep it opened.
      *  - `{function=}` `destructiveButtonClicked` Called when the destructive button is clicked.
      *     Return true to close the action sheet, or false to keep it opened.
      */
@@ -121,7 +121,7 @@ function($rootScope, $document, $compile, $animate, $timeout, $ionicTemplateLoad
       scope.buttonClicked = function(index) {
         // Check if the button click event returned true, which means
         // we can close the action sheet
-        if((opts.buttonClicked && opts.buttonClicked(index)) === true) {
+        if((opts.buttonClicked && opts.buttonClicked(index, opts.buttons[index])) === true) {
           hideSheet(false);
         }
       };


### PR DESCRIPTION
Right now `buttonClicked` accepts only the index of the pressed button that means you have to work with indices to decide which one it is. In case you move buttons around to get better UX, you'd have to be very careful with those indices. It would be easier to add `id` property to buttons and simply check for it. Index-agnostic solution is more maintainable and leads to less changes to the code when the buttons order is being changed. You could even have something like that:

```
var profileButton = {text: profile};
...
buttonClicked: function (index, button) {
  if (button === profileButton) {
    ...
  }
}
```

I wish we could pass button as a first argument, but that would break a compatibility with previous versions.
