### PR TITLE
Fixing requestAnimationFrame & cancelAnimationFrame

### DIFF
--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -26,14 +26,13 @@
             };
   })();
 
-  var vendors = ['webkit', 'moz'];
-  for(var x = 0; x < vendors.length && !window.requestAnimationFrame; ++x) {
-    window.requestAnimationFrame = window[vendors[x]+'RequestAnimationFrame'];
-    window.cancelAnimationFrame =
-      window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
-  }
-  window.cancelAnimationFrame =
-        window[vendors[x]+'CancelAnimationFrame'] || window[vendors[x]+'CancelRequestAnimationFrame'];
+  var cancelAnimationFrame = window.cancelAnimationFrame ||
+    window.webkitCancelAnimationFrame ||
+    window.mozCancelAnimationFrame ||
+    window.webkitCancelRequestAnimationFrame;
+
+  window.requestAnimationFrame = window._rAF;
+  window.cancelAnimationFrame = cancelAnimationFrame;
 
   /**
   * @ngdoc utility


### PR DESCRIPTION
With the previous implementation, Chrome complains:
    "'webkitCancelAnimationFrame' is vendor-specific. Please use the standard 'cancelAnimationFrame' instead."
This fixes that by reusing (copy-paste) the code from angular.js
A better way would be to use ionic.requestAnimationFrame and ionic.cancelAnimationFrame everywhere, but that is more involved and risky...
