### PR TITLE
Add line breaks to ionic keyboard documentation

### DIFF
--- a/release/js/ionic.js
+++ b/release/js/ionic.js
@@ -3274,8 +3274,11 @@ ionic.DomUtil.ready(function(){
  * - If your app is running in fullscreen, i.e. you have `<preference name="Fullscreen" value="true" />` in your `config.xml` file
  * you will need to set `ionic.Platform.isFullScreen = true` manually.
  *
- * - You can configure the behavior of the web view when the keyboard shows by setting 
- *   [android:windowSoftInputMode](http://developer.android.com/reference/android/R.attr.html#windowSoftInputMode) to either `adjustPan`, `adjustResize` or `adjustNothing` in your app's activity in `AndroidManifest.xml`. `adjustResize` is the recommended setting for Ionic, but if for some reason you do use `adjustPan` you will need to set `ionic.Platform.isFullScreen = true`.
+ * - You can configure the behavior of the web view when the keyboard shows by setting
+ *   [android:windowSoftInputMode](http://developer.android.com/reference/android/R.attr.html#windowSoftInputMode)
+ *   to either `adjustPan`, `adjustResize` or `adjustNothing` in your app's activity in `AndroidManifest.xml`.
+ *   `adjustResize` is the recommended setting for Ionic, but if for some reason you do use `adjustPan`
+ *   you will need to set `ionic.Platform.isFullScreen = true`.
  *
  *   ```xml
  *   <activity android:windowSoftInputMode="adjustResize">


### PR DESCRIPTION
- Android Notes to web views behaviour on shown keyboard shortend

This was quite a long line, I took the liberty to break it down a bit.
