### PR TITLE
Clearify Description

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -87,6 +87,7 @@
  *   </div>
  * </ion-content>
  * ```
+ * Percentages are of total screen dimensions. This example shows a 3 by 3 matrix fit on the screen (3 rows and 3 colums)
  * ```css
  * .my-image-item {
  *   height: 33%;


### PR DESCRIPTION
There should be a more clear explanation of the percentages for the item width. It might be good to also have a visual of what comes from the grid usage code. When I try to click on the js or html links on the phone simulation the page either continues to wait or crashes (chrome wait or kill).
