### PR TITLE
item-content background color cover items color

### DIFF
--- a/scss/_items.scss
+++ b/scss/_items.scss
@@ -194,7 +194,6 @@ button.item.item-complex {
   z-index: $z-index-item;
   padding: $item-padding (ceil( ($item-padding * 3) + ($item-padding / 3) ) - 5) $item-padding $item-padding;
   border: none;
-  background-color: white;
 }
 
 a.item-content {


### PR DESCRIPTION
```
      <ion-list class="dark">
        <ion-item nav-clear class="item-dark" menu-close href="#/app/search">
          Search
        </ion-item>
```

This ion-item will render a <a class="item-content"> which will cover the dark background with his own.
