### PR TITLE
#1464 ngValue uses a value instead of variable

### DIFF
--- a/js/angular/directive/radio.js
+++ b/js/angular/directive/radio.js
@@ -24,7 +24,7 @@ IonicModule
     require: '?ngModel',
     scope: {
       ngModel: '=?',
-      ngValue: '=?',
+      ngValue: '@',
       ngChange: '&',
       icon: '@',
       name: '@'


### PR DESCRIPTION
https://github.com/driftyco/ionic/issues/1464

ng-value was being scoped as a variable by ion-radio, which would have required you to basically enumerate the values in your $scope and set them using `ng-value='someScopeVaraible'`
