### PR TITLE
Improved iOS 7 Animation: Iteration #1

### DIFF
--- a/scss/_animations.scss
+++ b/scss/_animations.scss
@@ -332,8 +332,8 @@ $slide-in-up-function: cubic-bezier(.1, .7, .1, 1);
  * iOS7 style slide left to right
  * --------------------------------------------------
  */
-$ios7-timing-function: ease-in-out;
-$ios7-transition-duration: 250ms;
+$ios7-timing-function: cubic-bezier(0.4, 0.6, 0.2, 1);
+$ios7-transition-duration: 340ms;
 
 .slide-left-right-ios7,
 .slide-right-left-ios7.reverse {
@@ -354,6 +354,10 @@ $ios7-transition-duration: 250ms;
   > .ng-enter, &.ng-enter {
     /* NEW content placed far RIGHT BEFORE it slides IN from the RIGHT */
     @include translate3d(100%, 0, 0);
+    z-index: 2;
+  }
+  > .ng-leave, &.ng-leave {
+    z-index: 1;
   }
   > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active {
     /* NEW content ACTIVELY sliding IN from the RIGHT */
@@ -379,7 +383,11 @@ $ios7-transition-duration: 250ms;
   }
   > .ng-enter, &.ng-enter {
     /* NEW content placed far LEFT BEFORE it slides IN from the LEFT */
-    @include translate3d(-100%, 0, 0);
+    @include translate3d(-15%, 0, 0);
+    z-index: 1;
+  }
+  > .ng-leave, &.ng-leave {
+    z-index: 2;
   }
   > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active {
     /* NEW content ACTIVELY sliding IN from the LEFT */
@@ -387,7 +395,7 @@ $ios7-transition-duration: 250ms;
   }
   > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active {
     /* OLD content ACTIVELY sliding OUT to the RIGHT */
-    @include translate3d(15%, 0, 0);
+    @include translate3d(100%, 0, 0);
   }
 }
 
@@ -547,7 +555,7 @@ $ios7-transition-duration: 250ms;
 /**
  * Some component specific animations
  */
-$nav-title-slide-ios7-delay: 250ms;
+$nav-title-slide-ios7-delay: $ios7-transition-duration;
 .nav-title-slide-ios7 {
   &:not(.no-animation) .button.back-button {
     @include transition(all $nav-title-slide-ios7-delay);
@@ -579,6 +587,9 @@ $nav-title-slide-ios7-delay: 250ms;
   > .ng-enter, &.ng-enter {
     @include translate3d(30%, 0, 0);
     opacity: 0;
+    &.title {
+      @include translate3d(100%, 0, 0);
+    }
   }
   > .ng-enter.ng-enter-active, &.ng-enter.ng-enter-active {
     @include translate3d(0, 0, 0);
@@ -592,7 +603,8 @@ $nav-title-slide-ios7-delay: 250ms;
   &.reverse {
     > .ng-enter, &.ng-enter,
     > .ng-leave, &.ng-leave {
-      @include transition(all ease-in-out $transition-duration);
+      @include transition(all $nav-title-slide-ios7-delay);
+      @include transition-timing-function($ios7-timing-function);
       opacity: 1;
     }
     > .ng-enter, &.ng-enter {
@@ -604,7 +616,7 @@ $nav-title-slide-ios7-delay: 250ms;
       opacity: 1;
     }
     > .ng-leave.ng-leave-active, &.ng-leave.ng-leave-active {
-      @include translate3d(30%, 0, 0);
+      @include translate3d(100%, 0, 0);
       opacity: 0;
     }
   }

--- a/test/html/platforms.html
+++ b/test/html/platforms.html
@@ -1,0 +1,159 @@
+<html ng-app="navState">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no">
+
+    <title>Platforms</title>
+
+    <link rel="stylesheet" href="../../../../dist/css/ionic.css">
+    <script src="../../../../dist/js/ionic.bundle.js"></script>
+  </head>
+  <body>
+
+    <div ng-controller="AppCtrl">
+      <ion-nav-bar class="nav-title-slide-ios7 bar-positive">
+        <ion-nav-back-button class="button-icon icon ion-ios7-arrow-back">
+          Back
+        </ion-nav-back-button>
+      </ion-nav-bar>
+      <ion-nav-view animation="slide-left-right-ios7"></ion-nav-view>
+    </div>
+
+    <script id="home.html" type="text/ng-template">
+      <ion-view title="Home">
+        <!--
+        <ion-nav-buttons side="left">
+            <button
+                class="button button-icon icon ion-navicon"
+                menu-toggle="left">
+            </button>
+        </ion-nav-buttons>
+        <ion-nav-buttons side="right">
+            <button
+                class="button button-icon icon ion-close-circled"
+                ng-click="requestClearNotifications()">
+            </button>
+            <button
+                class="button button-icon icon ion-alert-circled"
+                ng-show="$root.showButton">
+            </button>
+        </ion-nav-buttons>
+        -->
+
+        <ion-content>
+          <a href="#/friends" class="button button-block button-primary">Friends</a>
+<div class="list">
+
+  <label class="item item-input item-select">
+    <div class="input-label">
+      Lightsaber
+    </div>
+    <select>
+      <option>Blue</option>
+      <option selected>Green</option>
+      <option>Red</option>
+    </select>
+  </label>
+
+</div>
+        </ion-content>
+      </ion-view>
+    </script>
+
+    <script id="friends.html" type="text/ng-template">
+      <ion-view title="Friends">
+        <!--
+        <ion-nav-buttons side="left">
+            <button
+                class="button button-icon icon ion-navicon"
+                menu-toggle="left">
+            </button>
+        </ion-nav-buttons>
+        <ion-nav-buttons side="right">
+            <button
+                class="button button-icon icon ion-close-circled"
+                ng-click="requestClearNotifications()">
+            </button>
+            <button
+                class="button button-icon icon ion-alert-circled"
+                ng-show="$root.showButton">
+            </button>
+        </ion-nav-buttons>
+        -->
+
+        <ion-content>
+<div class="list">
+
+  <label class="item item-input item-select">
+    <div class="input-label">
+      Lightsaber
+    </div>
+    <select>
+      <option>Blue</option>
+      <option selected>Green</option>
+      <option>Red</option>
+    </select>
+  </label>
+
+</div>
+        </ion-content>
+      </ion-view>
+    </script>
+
+    <script id="about.html" type="text/ng-template">
+      <ion-view title="Home">
+        <!--
+        <ion-nav-buttons side="left">
+            <button
+                class="button button-icon icon ion-navicon"
+                menu-toggle="left">
+            </button>
+        </ion-nav-buttons>
+        <ion-nav-buttons side="right">
+            <button
+                class="button button-icon icon ion-close-circled"
+                ng-click="requestClearNotifications()">
+            </button>
+            <button
+                class="button button-icon icon ion-alert-circled"
+                ng-show="$root.showButton">
+            </button>
+        </ion-nav-buttons>
+        -->
+
+        <ion-content>
+          <h1>About</h1>
+        </ion-content>
+      </ion-view>
+    </script>
+
+    <script>
+      angular.module('navState', ['ionic'])
+
+
+      .config(function($stateProvider, $urlRouterProvider) {
+
+        $stateProvider
+          .state('home', {
+            url: "/",
+            templateUrl: "home.html"
+          })
+          .state('friends', {
+            url: "/friends",
+            templateUrl: "friends.html"
+          })
+          .state('about', {
+            url: "/about",
+            templateUrl: "about.html"
+          })
+
+         $urlRouterProvider.otherwise("/");
+
+      })
+
+      .controller('AppCtrl', function($scope) {
+        
+      });
+    </script>
+  </body>
+</html>

--- a/test/html/viewState.html
+++ b/test/html/viewState.html
@@ -17,7 +17,7 @@
           Back
         </ion-nav-back-button>
       </ion-nav-bar>
-      <ion-nav-view animation="slide-left-right"></ion-nav-view>
+      <ion-nav-view animation="slide-left-right-ios7"></ion-nav-view>
     </div>
 
     <script id="sign-in.html" type="text/ng-template">


### PR DESCRIPTION
This is an improved animation for the animation types `slide-left-right-ios7` and `nav-title-slide-ios7`. This one more closely matches the native iOS 7 navigation transition style. Some things I changed:
1. The animation duration has increased
2. The animation now uses a custom `cubic-bezier` easing curve instead of `ease-in-out` which was not accurate
3. The `.title` on the entering view now slides in from all the way on the right instead of 15% over.
4. The reverse animation for this type is fixed. It was not implemented correctly it seems.

This is the smallest set of changes. I am working on more intense changes for fixing the way `nav-buttons` animate (they should fade out), as well as darkening the fading out content area and auto-creating the back button text from the last title (as an optional directive) and fixing that animation. Also, I am working on a better animation for those using Android.
