### PR TITLE
Collection Repeat: Use root scope when checking for in-progress digest

### DIFF
--- a/js/angular/service/collectionRepeatDataSource.js
+++ b/js/angular/service/collectionRepeatDataSource.js
@@ -2,7 +2,8 @@ IonicModule
 .factory('$collectionDataSource', [
   '$cacheFactory',
   '$parse',
-function($cacheFactory, $parse) {
+  '$rootScope',
+function($cacheFactory, $parse, $rootScope) {
   var nextCacheId = 0;
   function CollectionRepeatDataSource(options) {
     var self = this;
@@ -119,7 +120,7 @@ function($cacheFactory, $parse) {
         this.transcludeParent[0].appendChild(item.element[0]);
       }
       reconnectScope(item.scope);
-      !item.scope.$root.$$phase && item.scope.$digest();
+      !$rootScope.$$phase && item.scope.$digest();
     },
     getLength: function() {
       return this.data && this.data.length || 0;


### PR DESCRIPTION
I was having an issue using collection-repeat when a digest was in-progress. The in-progress digest was reflected on the root scope by checking `$$phase`, but not when checking `$$phase` on the child scope that collection-repeat was using. This was causing the ol' "digest already in progress" error.

This pull request is to update collection-repeat to use the root scope when checking for an in-progress digest.

_Note: I tried to recreate this bug in smaller codepen example that I could share but was unfortunately unable to do so. I am actually unsure of the exact conditions that cause this issue._ :-/
