### PR TITLE
feature : allow dynamic ion-nav-view name

### DIFF
--- a/js/angular/directive/navView.js
+++ b/js/angular/directive/navView.js
@@ -114,7 +114,7 @@ function( $ionicViewService,   $state,   $compile,   $controller,   $animate) {
     compile: function (element, attr, transclude) {
       return function(scope, element, attr, navViewCtrl) {
         var viewScope, viewLocals,
-          name = attr[directive.name] || attr.name || '',
+          name = scope.$eval(attr[directive.name]) || scope.$eval(attr.name) || '',
           onloadExp = attr.onload || '',
           initialView = transclude(scope);
 


### PR DESCRIPTION
allow the name attribute to be evaluated as an angularjs expression

Issue #1503

Signed-off-by: Justin Noel github@calendee.com
