### PR TITLE
fix : focus on first input in popUp

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -416,17 +416,17 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $docume
   function focusInputOrButton(element) {
     var focusOn;
     var inputs = element[0].querySelectorAll('input[autofocus]');
-		if (inputs.length) {
-			focusOn = inputs[0];
-		} else {
-			var inputs = element[0].querySelectorAll('input');
-			if (inputs.length) {
-				focusOn = inputs[0];
-			} else {
-				inputs = element[0].querySelectorAll('button');
-				focusOn = inputs[inputs.length-1];
-			}
-		}
+	if (inputs.length) {
+	  focusOn = inputs[0];
+	} else {
+	  var inputs = element[0].querySelectorAll('input');
+	  if (inputs.length) {
+	  	focusOn = inputs[0];
+	  } else {
+	  	inputs = element[0].querySelectorAll('button');
+	  	focusOn = inputs[inputs.length-1];
+	  }
+    }
     if(focusOn) {
       focusOn.focus();
     }


### PR DESCRIPTION
instead of focusing on last input, focus on first input if exists or focus on last button.

RE : Issue #822

Signed-off-by: Justin Noel github@calendee.com
