### PR TITLE
Add missing tick that was causing minor doc rendering issue

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -86,7 +86,7 @@ function($rootScope, $document, $compile, $timeout, $ionicPlatform, $ionicTempla
      *    Default: 'slide-in-up'
      *  - `{boolean=}` `focusFirstInput` Whether to autofocus the first input of
      *    the modal when shown.  Default: false.
-     *  - `{boolean=} `backdropClickToClose` Whether to close the modal on clicking the backdrop.
+     *  - `{boolean=}` `backdropClickToClose` Whether to close the modal on clicking the backdrop.
      *    Default: true.
      */
     initialize: function(opts) {


### PR DESCRIPTION
Fixes minor formatting issue on 'backdropClickToClose' for ionicModal docs. 
![image](https://cloud.githubusercontent.com/assets/794198/3134195/e9735dd2-e822-11e3-82e2-8317c2dfecd0.png)
