### PR TITLE
fix: Fix ngdoc method name, getParentWithClass to getParentOrSelfWithClass

### DIFF
--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -233,7 +233,7 @@
     },
     /**
      * @ngdoc method
-     * @name ionic.DomUtil#getParentWithClass
+     * @name ionic.DomUtil#getParentOrSelfWithClass
      * @param {DOMElement} element
      * @param {string} className
      * @returns {DOMElement} The closest parent or self matching the


### PR DESCRIPTION
Renamed ngdoc @name from `getParentWithClass` to `getParentOrSelfWithClass`, for the `getParentOrSelfWithClass` function.
