### PR TITLE
Added swipe open menu from the edge of the screen

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -22,6 +22,13 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform) {
     return $scope.dragContent;
   };
 
+  this.doDragFromEdge = function(doEdgeDrag) {
+    if (arguments.length) {
+      $scope.dragFromEdge = !!doEdgeDrag;
+    }
+    return $scope.dragFromEdge;
+  };
+
   this.isDraggableTarget = function(e) {
     return $scope.dragContent &&
            (!e.gesture.srcEvent.defaultPrevented &&

--- a/js/angular/directive/sideMenuContent.js
+++ b/js/angular/directive/sideMenuContent.js
@@ -45,6 +45,14 @@ function($timeout, $ionicGesture) {
           sideMenuCtrl.canDragContent(true);
         }
 
+        if (angular.isDefined(attr.dragFromEdge)) {
+            $scope.$watch(attr.dragFromEdge, function(value) {
+              sideMenuCtrl.doDragFromEdge(value);
+            });
+         } else {
+            sideMenuCtrl.doDragFromEdge(true);
+         }
+
         var defaultPrevented = false;
         var isDragging = false;
 

--- a/js/angular/service/sideMenuDelegate.js
+++ b/js/angular/service/sideMenuDelegate.js
@@ -89,7 +89,15 @@ IonicModule
    * side menus.
    * @returns {boolean} Whether the content can be dragged to open side menus.
    */
-  'canDragContent'
+  'canDragContent',
+  /**
+   * @ngdoc method
+   * @name $ionicSideMenuDelegate#doDragFromEdge
+   * @param {boolean=} doEdgeDrag Set whether de drag open action can only be done from the edge of the screen
+   * side menus.
+   * @returns {boolean} Whether the drag can only happen from the edge of the scren.
+   */
+  'doDragFromEdge'
   /**
    * @ngdoc method
    * @name $ionicSideMenuDelegate#$getByHandle

--- a/js/controllers/sideMenuController.js
+++ b/js/controllers/sideMenuController.js
@@ -278,10 +278,25 @@
       this._startX = null;
       this._lastX = null;
       this._offsetX = null;
+      this._firstX = null;
+      this._doDrag = false;
     },
 
     // Handle a drag event
     _handleDrag: function(e) {
+
+      //Get the start position of the drag
+      if(!this._firstX) {
+       this._firstX = e.gesture.touches[0].pageX;
+      }
+
+      // Check if user has dradFromEdge enabled
+      if(!this.doDragFromEdge()) {
+        this._doDrag = true;
+      } else if(this._firstX <= 20 || this._firstX >= window.innerWidth-20) {
+        this._doDrag = true;
+      }
+
       // If we don't have start coords, grab and store them
       if(!this._startX) {
         this._startX = e.gesture.touches[0].pageX;
@@ -292,7 +307,7 @@
       }
 
       // Calculate difference from the tap points
-      if(!this._isDragging && Math.abs(this._lastX - this._startX) > this.dragThresholdX) {
+      if(!this._isDragging && this._doDrag && Math.abs(this._lastX - this._startX) > this.dragThresholdX) {
         // if the difference is greater than threshold, start dragging using the current
         // point as the starting point
         this._startX = this._lastX;


### PR DESCRIPTION
Added an optional functionality where the slide menu open functionality
can be set to only open the side menu when a swipe from the edge of the
screen is done. This option can be set with
`<ion-side-menu-content
drag-from-edge="true”>`
`</ion-side-menu-content>`
