### PR TITLE
Add correct vendor prefix to placeholder mixin for FireFox > 18

### DIFF
--- a/scss/_mixins.scss
+++ b/scss/_mixins.scss
@@ -172,7 +172,10 @@
 // --------------------------------------------------
 
 @mixin placeholder($color: $input-color-placeholder) {
-  &:-moz-placeholder {
+  &:-moz-placeholder { /* Firefox 18- */
+    color: $color;
+  }
+  &::-moz-placeholder { /* Firefox 19+ */
     color: $color;
   }
   &:-ms-input-placeholder {


### PR DESCRIPTION
As per http://css-tricks.com/snippets/css/style-placeholder-text/
