### PR TITLE
fix($ionNavView): prevent read property 'name' of null

### DIFF
--- a/js/angular/directive/navView.js
+++ b/js/angular/directive/navView.js
@@ -125,7 +125,7 @@ function( $ionicViewService,   $state,   $compile,   $controller,   $animate) {
         // to derive our own qualified view name, then hang our own details
         // off the DOM so child directives can find it.
         var parent = element.parent().inheritedData('$uiView');
-        if (name.indexOf('@') < 0) name  = name + '@' + (parent ? parent.state.name : '');
+        if (name.indexOf('@') < 0) name  = name + '@' + ((parent && parent.state) ? parent.state.name : '');
         var view = { name: name, state: null };
         element.data('$uiView', view);
 


### PR DESCRIPTION
Sometimes, absolutely spontaneously, I have the error:

```
TypeError: Cannot read property 'name' of null
    at IonicModule.directive.directive.compile (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:40819:79)
    at nodeLinkFn (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:15111:13)
    at compositeLinkFn (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:14517:15)
    at publicLinkFn (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:14426:30)
    at updateView (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:40883:11)
    at IonicModule.directive.directive.compile.eventHook (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:40827:17)
    at Scope.$get.Scope.$broadcast (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:21142:28)
    at $state.transitionTo.$state.transition.resolved.then.$state.transition (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:33927:22)
    at deferred.promise.then.wrappedCallback (http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:19846:81)
    at http://localhost:8000/ios/www/bower_components/ionic/release/js/ionic.bundle.js:19932:26 <ion-nav-view> 
```

This happens because of attempt to read 'name' property of parent.state where state=null. Looks like not only me have this error (http://forum.ionicframework.com/t/how-do-i-get-rid-of-this/3674). So it will be good to rid of it.
