### PR TITLE
feat(collectionRepeat): huge optimization upgrades

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -158,15 +158,9 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
       } else if (!isVertical && !$attr.collectionItemWidth) {
         throw new Error(COLLECTION_REPEAT_ATTR_WIDTH_ERROR);
       }
-      $attr.collectionItemHeight = $attr.collectionItemHeight || '"100%"';
-      $attr.collectionItemWidth = $attr.collectionItemWidth || '"100%"';
 
-      var heightParsed = $attr.collectionItemHeight ?
-        $parse($attr.collectionItemHeight) :
-        function() { return scrollView.__clientHeight; };
-      var widthParsed = $attr.collectionItemWidth ?
-        $parse($attr.collectionItemWidth) :
-        function() { return scrollView.__clientWidth; };
+      var heightParsed = $parse($attr.collectionItemHeight || '"100%"');
+      var widthParsed = $parse($attr.collectionItemWidth || '"100%"');
 
       var heightGetter = function(scope, locals) {
         var result = heightParsed(scope, locals);

--- a/js/angular/service/collectionRepeatDataSource.js
+++ b/js/angular/service/collectionRepeatDataSource.js
@@ -4,7 +4,7 @@ IonicModule
   '$parse',
   '$rootScope',
 function($cacheFactory, $parse, $rootScope) {
-  var nextCacheId = 0;
+
   function CollectionRepeatDataSource(options) {
     var self = this;
     this.scope = options.scope;
@@ -35,33 +35,28 @@ function($cacheFactory, $parse, $rootScope) {
       };
     }
 
-    var cacheKeys = {};
-    this.itemCache = $cacheFactory(nextCacheId++, {size: 500});
-
-    var _put = this.itemCache.put;
-    this.itemCache.put = function(key, value) {
-      cacheKeys[key] = true;
-      return _put(key, value);
-    };
-
-    var _remove = this.itemCache.remove;
-    this.itemCache.remove = function(key) {
-      delete cacheKeys[key];
-      return _remove(key);
-    };
-    this.itemCache.keys = function() {
-      return Object.keys(cacheKeys);
-    };
+    this.attachedItems = {};
+    this.BACKUP_ITEMS_LENGTH = 10;
+    this.backupItemsArray = [];
   }
   CollectionRepeatDataSource.prototype = {
+    setup: function() {
+      for (var i = 0; i < this.BACKUP_ITEMS_LENGTH; i++) {
+        this.detachItem(this.createItem());
+      }
+    },
     destroy: function() {
       this.dimensions.length = 0;
-      this.itemCache.keys().forEach(function(key) {
-        var item = this.itemCache.get(key);
-        item.element.remove();
-        item.scope.$destroy();
+      this.data = null;
+      forEach(this.backupItemsArray, function(item) {
+        this.destroyItem(item);
       }, this);
-      this.itemCache.removeAll();
+      this.backupItemsArray.length = 0;
+
+      forEach(this.attachedItems, function(item, key) {
+        this.destroyItem(item);
+      }, this);
+      this.attachedItems = {};
     },
     calculateDataDimensions: function() {
       var locals = {};
@@ -74,53 +69,74 @@ function($cacheFactory, $parse, $rootScope) {
         };
       }, this);
     },
-    compileItem: function(index, value) {
-      var key = this.itemHashGetter(index, value);
-      var cachedItem = this.itemCache.get(key);
-      if (cachedItem) return cachedItem;
-
+    createItem: function() {
       var item = {};
       item.scope = this.scope.$new();
-      item.scope[this.keyExpr] = value;
 
       this.transcludeFn(item.scope, function(clone) {
         clone.css('position', 'absolute');
         item.element = clone;
       });
 
-      return this.itemCache.put(key, item);
-    },
-    getItem: function(index) {
-      var value = this.data[index];
-      var item = this.compileItem(index, value);
+      this.transcludeParent.append(item.element);
 
-      if (item.scope.$index !== index) {
+      return item;
+    },
+    getItem: function(hash) {
+      window.AMOUNT = window.AMOUNT || 0;
+      if ( (item = this.attachedItems[hash]) ) {
+        //do nothing, the item is good
+      } else if ( (item = this.backupItemsArray.pop()) ) {
+        reconnectScope(item.scope);
+      } else {
+        AMOUNT++;
+        item = this.createItem();
+      }
+      return item;
+    },
+    attachItemAtIndex: function(index) {
+      var value = this.data[index];
+      var hash = this.itemHashGetter(index, value);
+      var item = this.getItem(hash);
+
+      if (item.scope.$index !== index || item.scope[this.keyExpr] !== value) {
+        item.scope[this.keyExpr] = value;
         item.scope.$index = index;
         item.scope.$first = (index === 0);
         item.scope.$last = (index === (this.getLength() - 1));
         item.scope.$middle = !(item.scope.$first || item.scope.$last);
         item.scope.$odd = !(item.scope.$even = (index&1) === 0);
+
+        //We changed the scope, so digest if needed
+        if (!$rootScope.$$phase) {
+          item.scope.$digest();
+        }
       }
+
+      item.hash = hash;
+      this.attachedItems[hash] = item;
 
       return item;
     },
-    detachItem: function(item) {
-      var i, node, parent;
-      //Don't .remove(), that will destroy element data
-      for (i = 0; i < item.element.length; i++) {
-        node = item.element[i];
-        parent = node.parentNode;
-        parent && parent.removeChild(node);
-      }
-      //Don't .$destroy(), just stop watchers and events firing
-      disconnectScope(item.scope);
+    destroyItem: function(item) {
+      item.element.remove();
+      item.scope.$destroy();
+      item.scope = null;
+      item.element = null;
     },
-    attachItem: function(item) {
-      if (!item.element[0].parentNode) {
-        this.transcludeParent[0].appendChild(item.element[0]);
+    detachItem: function(item) {
+      delete this.attachedItems[item.hash];
+
+      // If we are at the limit of backup items, just get rid of the this element
+      if (this.backupItemsArray.length >= this.BACKUP_ITEMS_LENGTH) {
+        this.destroyItem(item);
+      // Otherwise, add it to our backup items
+      } else {
+        this.backupItemsArray.push(item);
+        item.element.css(ionic.CSS.TRANSFORM, 'translate3d(-2000px,-2000px,0)');
+        //Don't .$destroy(), just stop watchers and events firing
+        disconnectScope(item.scope);
       }
-      reconnectScope(item.scope);
-      !$rootScope.$$phase && item.scope.$digest();
     },
     getLength: function() {
       return this.data && this.data.length || 0;

--- a/test/html/list-fit.html
+++ b/test/html/list-fit.html
@@ -18,48 +18,62 @@
       </a>
     </ion-header-bar>
     <ion-content>
-      <ion-refresher on-refresh="onRefresh()" refreshing-text="Refreshing!"></ion-refresher>
-      <div class="list">
-        <div class="item"
+      <ion-list>
+        <ion-item
+          class="item-avatar-left item-icon-right"
           ng-click="alert(item)"
           collection-repeat="item in items"
-          collection-item-height="52"
-          collection-item-width="120 + 2*($index % 40)"
-          ng-style="{width: 120 + 2*($index % 40)}">
-          {{item}}
-        </div>
-      </div>
+          collection-item-height="85"
+          collection-item-width="'100%'"
+          style="position: absolute; left: 0; right: 0;">
+          <img ng-src="{{item.image}}">
+          <h2>{{item.text}}</h2>
+          <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis porttitor diam urna, vitae consectetur lectus aliquet quis.</p>
+          <i class="icon" style="color:red; font-size: 30px;" ng-class="['ion-ios7-person','ion-person','ion-android-contact','ion-android-social-user','ion-person-stalker'][$index % 5]"></i>
+        </ion-item>
+      </ion-list>
     </ion-content>
   <script>
-function MainCtrl($scope, $ionicScrollDelegate, $timeout) {
-  $scope.items = [];
-  for (var i = 0; i < 5000; i++) {
-    $scope.items.push('item '+i);
+var dataUris = {};
+function convertImgToBase64(url, callback, outputFormat){
+    var canvas = document.createElement('CANVAS'),
+        ctx = canvas.getContext('2d'),
+        img = new Image;
+    img.crossOrigin = 'Anonymous';
+    img.onload = function(){
+        var dataURL;
+        canvas.height = img.height;
+        canvas.width = img.width;
+        ctx.drawImage(img,0,0);
+        dataURL = canvas.toDataURL(outputFormat || 'image/png');
+        callback.call(this, dataURL);
+        canvas = null; 
+    };
+    img.src = url;
+}
+function MainCtrl($scope, $ionicScrollDelegate, $timeout, $q, $ionicLoading) {
+  var images = [];
+
+  $ionicLoading.show({
+      template: 'Loading images...'
+  });
+  var deferred;
+  for (var i = 0; i < 5; i++) {
+    deferred = $q.defer();
+    convertImgToBase64('http://placekitten.com/'+(40+(10*i))+'/'+(40+(10*i)), deferred.resolve);
+    images.push(deferred.promise);      
   }
 
-  $scope.height = function(n) {
-    return 105 + (n % 40);
-  };
-  $scope.width = function(n) {
-    return 105 + (n % 40);
-  };
-
-  //$scope.alert = alert.bind(window);
-
-  $scope.onRefresh = function() {
-    $timeout(function() {
-      var len = $scope.items.length;
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.items.unshift(2999 - $scope.items.length);
-      $scope.$broadcast('scroll.refreshComplete');
-    }, 1500);
-  };
+  $q.all(images).then(function(dataUrls) {
+    $scope.items = [];
+    for (var item = 0; item < 5000; item++) {
+      $scope.items.push({
+        text: 'Item ' + item,
+        image: dataUrls[item % 5]
+      });
+    }
+    $timeout($ionicLoading.hide, 200);
+  });
 
   $scope.scrollBottom = $ionicScrollDelegate.scrollBottom;
 }

--- a/test/unit/angular/service/actionSheet.unit.js
+++ b/test/unit/angular/service/actionSheet.unit.js
@@ -25,14 +25,17 @@ describe('Ionic ActionSheet Service', function() {
     expect(scope.element.hasClass('active')).toBe(true);
   }));
 
-  it('removeSheet should remove classes, remove element and destroy scope', inject(function($document, $timeout) {
+  it('removeSheet should remove classes, remove element and destroy scope', inject(function($document, $timeout, $animate) {
+    spyOn($animate, 'removeClass').andCallFake(function(el, cls, cb) {
+      el.removeClass(cls);
+      cb();
+    });
     var scope = setup();
     spyOn(scope, '$destroy');
     spyOn(scope.element, 'remove');
     scope.removeSheet();
     expect($document[0].body.classList.contains('action-sheet-open')).toBe(false);
     expect(scope.element.hasClass('active')).toBe(false);
-    $timeout.flush();
     expect(scope.$destroy).toHaveBeenCalled();
     expect(scope.element.remove).toHaveBeenCalled();
   }));
@@ -66,7 +69,11 @@ describe('Ionic ActionSheet Service', function() {
     expect(scope.removeSheet).toHaveBeenCalled();
   });
 
-  it('cancel should removeSheet and call opts.cancel', inject(function($timeout) {
+  it('cancel should removeSheet and call opts.cancel', inject(function($timeout, $animate) {
+    spyOn($animate, 'removeClass').andCallFake(function(el, cls, cb) {
+      el.removeClass(cls);
+      cb();
+    });
     var cancelSpy = jasmine.createSpy('opts.cancel');
     var scope = setup({
       cancel: cancelSpy
@@ -74,7 +81,6 @@ describe('Ionic ActionSheet Service', function() {
     spyOn(scope, 'removeSheet').andCallThrough();
     scope.cancel();
     expect(scope.removeSheet).toHaveBeenCalled();
-    $timeout.flush();
     expect(cancelSpy).toHaveBeenCalled();
   }));
 

--- a/test/unit/angular/service/collectionDataSource.unit.js
+++ b/test/unit/angular/service/collectionDataSource.unit.js
@@ -25,7 +25,7 @@ describe('$collectionDataSource service', function() {
     return dataSource;
   }
 
-  it('should have properties', function() {
+  it('should have properties', inject(function($collectionDataSource) {
     var source = setup({
       scope: 1,
       transcludeFn: 2,
@@ -44,7 +44,7 @@ describe('$collectionDataSource service', function() {
     expect(source.trackByExpr).toBe(6);
     expect(source.heightGetter).toBe(7);
     expect(source.widthGetter).toBe(8);
-  });
+  }));
 
   describe('.itemHashGetter()', function() {
 
@@ -70,40 +70,18 @@ describe('$collectionDataSource service', function() {
     });
   });
 
-  describe('itemCache', function() {
-
-    it('should be $cacheFactory', function() {
-      var cache = {};
-      module('ionic', function($provide) {
-        $provide.value('$cacheFactory', function() { return cache; });
-      });
-      var source = setup();
-      expect(source.itemCache).toBe(cache);
-    });
-
-    it('should have added keys() method', function() {
-      var source = setup();
-      source.itemCache.put('a', 1);
-      source.itemCache.put('b', 2);
-      expect(source.itemCache.keys()).toEqual(['a', 'b']);
-      source.itemCache.remove('a');
-      expect(source.itemCache.keys()).toEqual(['b']);
-    });
-
-  });
-
-  it('.destroy() should cleanup dimensions & cache', function() {
+  it('.destroy() should cleanup dimensions backupItemsArray and attachedItems', function() {
     var source = setup();
     source.dimensions = [1,2,3];
-    var cachedItem = {
-      scope: { $destroy: jasmine.createSpy('$destroy') },
-      element: { remove: jasmine.createSpy('remove') }
-    };
-    source.itemCache.put('a', cachedItem);
+    source.attachedItems = {0: 'a'};
+    source.backupItemsArray = ['b'];
+    spyOn(source, 'destroyItem');
     source.destroy();
     expect(source.dimensions.length).toBe(0);
-    expect(cachedItem.scope.$destroy).toHaveBeenCalled();
-    expect(cachedItem.element.remove).toHaveBeenCalled();
+    expect(source.destroyItem).toHaveBeenCalledWith('a');
+    expect(source.destroyItem).toHaveBeenCalledWith('b');
+    expect(source.attachedItems).toEqual({});
+    expect(source.backupItemsArray).toEqual([]);
   });
 
   it('.calculateDataDimensions()', function() {
@@ -135,64 +113,128 @@ describe('$collectionDataSource service', function() {
     });
   });
 
-  describe('.compileItem()', function() {
-    it('should get item from cache if exists', function() {
+  describe('.createItem()', function() {
+    it('should return item with new scope and transclude', function() {
       var source = setup();
-      var hash = source.itemHashGetter(1,2);
-      var item = {};
-      source.itemCache.put(hash, item);
-      expect(source.compileItem(1,2)).toBe(item);
-    });
 
-    it('should give back a compiled item and put in cache', function() {
-      var source = setup({
-        keyExpr: 'key'
-      });
-
-      var item = source.compileItem(1, 2);
+      var item = source.createItem();
 
       expect(item.scope.$parent).toBe(source.scope);
-      expect(item.scope.key).toBe(2);
 
       expect(item.element).toBeTruthy();
       expect(item.element.css('position')).toBe('absolute');
       expect(item.element.scope()).toBe(item.scope);
 
-      expect(source.itemCache.get(source.itemHashGetter(1,2))).toBe(item);
+      expect(item.element.parent()[0]).toBe(source.transcludeParent[0]);
     });
   });
 
   describe('.getItem()', function() {
-    it('should return a value with index values set', function() {
+    it('should return attachedItems[hash] if available', function() {
       var source = setup();
-      source.data = ['a', 'b', 'c'];
-      spyOn(source, 'compileItem').andCallFake(function() { return { scope: {} }; });
+      var item = {};
+      source.attachedItems['123'] = item;
+      expect(source.getItem('123')).toBe(item);
+    });
 
-      var item = source.getItem(0);
-      expect(item.scope.$index).toBe(0);
-      expect(item.scope.$first).toBe(true);
-      expect(item.scope.$last).toBe(false);
-      expect(item.scope.$middle).toBe(false);
-      expect(item.scope.$odd).toBe(false);
+    it('should return backupItemsArray item if available, and reconnect the item', function() {
+      var source = setup();
+      var item = {
+        scope: {},
+      };
+      spyOn(window, 'reconnectScope');
+      source.backupItemsArray = [item];
+      expect(source.getItem('123')).toBe(item);
+      expect(reconnectScope).toHaveBeenCalledWith(item.scope);
+    });
 
-      item = source.getItem(1);
-      expect(item.scope.$index).toBe(1);
-      expect(item.scope.$first).toBe(false);
-      expect(item.scope.$last).toBe(false);
-      expect(item.scope.$middle).toBe(true);
-      expect(item.scope.$odd).toBe(true);
-
-      item = source.getItem(2);
-      expect(item.scope.$index).toBe(2);
-      expect(item.scope.$first).toBe(false);
-      expect(item.scope.$last).toBe(true);
-      expect(item.scope.$middle).toBe(false);
-      expect(item.scope.$odd).toBe(false);
+    it('should last resort create an item', function() {
+      var source = setup();
+      var item = {};
+      spyOn(source, 'createItem').andReturn(item);
+      expect(source.getItem('123')).toBe(item);
     });
   });
 
+  describe('.attachItemAtIndex()', function() {
+    it('should return a value with index values set and put in attachedItems', inject(function($rootScope) {
+      var source = setup({
+        keyExpr: 'value'
+      });
+      source.data = ['a', 'b', 'c'];
+      spyOn(source, 'getItem').andCallFake(function() {
+        return { scope: $rootScope.$new() };
+      });
+      spyOn(source, 'itemHashGetter').andCallFake(function(index, value) {
+        return index + ':' + value;
+      });
+
+      var item1 = source.attachItemAtIndex(0);
+      expect(item1.scope.value).toEqual('a');
+      expect(item1.scope.$index).toBe(0);
+      expect(item1.scope.$first).toBe(true);
+      expect(item1.scope.$last).toBe(false);
+      expect(item1.scope.$middle).toBe(false);
+      expect(item1.scope.$odd).toBe(false);
+      expect(item1.hash).toEqual('0:a');
+
+      var item2 = source.attachItemAtIndex(1);
+      expect(item2.scope.value).toEqual('b');
+      expect(item2.scope.$index).toBe(1);
+      expect(item2.scope.$first).toBe(false);
+      expect(item2.scope.$last).toBe(false);
+      expect(item2.scope.$middle).toBe(true);
+      expect(item2.scope.$odd).toBe(true);
+      expect(item2.hash).toEqual('1:b');
+
+      var item3 = source.attachItemAtIndex(2);
+      expect(item3.scope.value).toEqual('c');
+      expect(item3.scope.$index).toBe(2);
+      expect(item3.scope.$first).toBe(false);
+      expect(item3.scope.$last).toBe(true);
+      expect(item3.scope.$middle).toBe(false);
+      expect(item3.scope.$odd).toBe(false);
+      expect(item3.hash).toEqual('2:c');
+
+      expect(source.attachedItems).toEqual({
+        '0:a': item1,
+        '1:b': item2,
+        '2:c': item3
+      });
+    }));
+  });
+
   describe('.detachItem()', function() {
-    it('should remove element from parent and disconnectScope', function() {
+    it('should detach item and add to backup array if there is room', function() {
+      var source = setup();
+      var item = {
+        element: angular.element('<div>'),
+        scope: {},
+        hash: 'foo'
+      };
+      source.backupItemsArray = [];
+      source.attachedItems[item.hash] = item;
+      spyOn(window, 'disconnectScope');
+      source.detachItem(item);
+      expect(source.attachedItems).toEqual({});
+      expect(source.backupItemsArray).toEqual([item]);
+      expect(disconnectScope).toHaveBeenCalledWith(item.scope);
+    });
+    it('should remove element from parent and disconnectScope if backupItemsArray is full', function() {
+      var source = setup();
+      spyOn(source, 'destroyItem');
+      source.BACKUP_ITEMS_LENGTH = 0;
+
+      var item = { hash: 'abc' };
+      source.attachedItems[item.hash] = item;
+      source.detachItem(item);
+      expect(source.destroyItem).toHaveBeenCalledWith(item);
+      expect(source.attachedItems).toEqual({});
+    });
+  });
+
+  describe('.destroyItem()', function() {
+    it('should remove element and destroy scope', function() {
       var source = setup();
       var element = angular.element('<div>');
       var parent = angular.element('<div>').append(element);
@@ -200,53 +242,15 @@ describe('$collectionDataSource service', function() {
         element: element,
         scope: {}
       };
-      spyOn(window, 'disconnectScope');
+      var destroySpy = item.scope.$destroy = jasmine.createSpy('$destroy');
 
       expect(element[0].parentNode).toBe(parent[0]);
-      source.detachItem(item);
+      source.destroyItem(item);
       expect(element[0].parentNode).toBeFalsy();
-      expect(disconnectScope).toHaveBeenCalledWith(item.scope);
+      expect(destroySpy).toHaveBeenCalled();
+      expect(item.scope).toBe(null);
+      expect(item.element).toBe(null);
     });
-  });
-
-  describe('.attachItem()', function() {
-    it('should add element if it has no parent and digest', inject(function($rootScope) {
-      var source = setup({
-        transcludeParent: angular.element('<div>')
-      });
-      var element = angular.element('<div>');
-      spyOn(window, 'reconnectScope');
-      var item = {
-        element: element,
-        scope: $rootScope.$new()
-      };
-
-      spyOn(item.scope, '$digest');
-      spyOn(source.transcludeParent[0], 'appendChild');
-      source.attachItem(item);
-      expect(source.transcludeParent[0].appendChild).toHaveBeenCalledWith(element[0]);
-      expect(reconnectScope).toHaveBeenCalledWith(item.scope);
-      expect(item.scope.$digest).toHaveBeenCalled();
-    }));
-
-    it('should not append element if it has a parent already', inject(function($rootScope) {
-      var element = angular.element('<div>');
-      var source = setup({
-        transcludeParent: angular.element('<div>')
-          .append(element)
-      });
-      spyOn(window, 'reconnectScope');
-      var item = {
-        element: element,
-        scope: $rootScope.$new()
-      };
-      spyOn(item.scope, '$digest');
-      source.attachItem(item);
-      spyOn(source.transcludeParent[0], 'appendChild');
-      expect(source.transcludeParent[0].appendChild).not.toHaveBeenCalled();
-      expect(reconnectScope).toHaveBeenCalledWith(item.scope);
-      expect(item.scope.$digest).toHaveBeenCalled();
-    }));
   });
 
   describe('.getLength()', function() {


### PR DESCRIPTION
Optimizations done thanks to ideas and questions thrown around by the team:
1. Only compile as many elements as the list needs visible at start, plus 50 for safety (but if more are really needed, they can be compiled)
2. Reuse elements as they go out instead of compiling new ones
3. Reuse scopes - simply extend the existing scope with the new item in the list's value and digest it.
4. Transform the scroller container normally so the items themselves need to only be transformed once. Before, it would scroll the container back up every time an item was scrolled past.
5. Elements that aren't currently visible are kept in the DOM (to save the time wasted by attaching them), but are set to visibility: hidden

TODO:
- [x] Fix .destroy()
- [x] Patch up unit tests
- [x] remove logging statements

What's new?
- Can handle a LOT MORE with no lag. It works as expected now.
