### PR TITLE
Add width: auto; css to fix multiple buttons overflowing in bar

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -206,7 +206,7 @@
   > .button.pull-right,
   .buttons.pull-right,
   .title + .buttons {
-    display: inherit;
+    width: auto;
     position: absolute;
     top: 5px;
     right: 5px;


### PR DESCRIPTION
Allowing the buttons to use width: auto; allows the multiple right buttons to display correctly alongside one another in the ion-nav-buttons control.

This fixes issue #930 which is still present on Android 4.4.2
