### PR TITLE
IE10 ionCheckbox fix

### DIFF
--- a/js/angular/directive/checkbox.js
+++ b/js/angular/directive/checkbox.js
@@ -46,6 +46,37 @@ IonicModule
           input.attr(name, value);
         }
       });
+
+      // function link
+      return function(scope, element, attr2){
+        if(element[0].querySelector){
+        	 // get the elements we need. label and checkboxIcon as event targets
+          var label = element[0].querySelector(".item-content");
+          var checkboxIcon = element[0].querySelector(".checkbox-icon");
+          // input to update the change
+          var input = element[0].querySelector(".checkbox input");
+
+          function performClick(evt){
+          	// stop propagation so other browsers don't re-toggle the checkbox
+            evt.stopPropagation();
+
+            input.checked = !input.checked;
+            // Update the ngModel, if it's available
+            if(attr.ngModel)
+            	scope.$eval(attr.ngModel + "=" + input.checked);
+
+            // And trigger ngChange, if it's available
+            if(attr.ngChange){
+              scope.$apply(function(){
+                scope.$eval(attr.ngChange);
+              });
+            }
+          }
+
+          label.addEventListener('click', performClick);
+          checkboxIcon.addEventListener('click', performClick);
+        }
+      }
     }
 
   };


### PR DESCRIPTION
ionCheckbox in IE10 (i.e., Windows Phone) wasn't changing when the user clicked the checkbox icon or the checkbox label. It did work by pressing the white space of the whole checkbox.

What I did here is to set up event listeners for these two elements (the label and the icon) to trigger a change to the checkbox and the angular model.

It's my first ever pull request. I think it still needs to be tested in many other systems/devices to check it doesn't break in any of them.

edit: I tried in many devices and it seems to work on all of them (Android 2.3, 4.1.1, 4.4.4, iOS 7, iOS 6.1.3)
