### PR TITLE
Disable Back button anim. for certain transitions

### DIFF
--- a/js/angular/directive/navBackButton.js
+++ b/js/angular/directive/navBackButton.js
@@ -102,8 +102,13 @@ function($animate, $rootScope, $sanitize, $ionicNavBarConfig, $ionicNgClick) {
           }
           return !!(backIsShown && $scope.backButtonShown);
         }, ionic.animationFrameThrottle(function(show) {
-          if (show) $animate.removeClass($element, 'ng-hide');
-          else $animate.addClass($element, 'ng-hide');
+          if($scope.shouldAnimate) {
+            if (show) $animate.removeClass($element, 'ng-hide');
+            else $animate.addClass($element, 'ng-hide');
+          } else {
+            if (show) $element.removeClass('ng-hide');
+            else $element.addClass('ng-hide');
+          }
         }));
       };
     }


### PR DESCRIPTION
The Ion Nav Back Button is designed to be shown and hidden using the add/remove class animation, to ensure an iOS 7 style transition when going forward/back through a navigation structure (e.g. overview page > detail page.)

This transition works fine, except when transitioning from one view (e.g. detail page) to another view (e.g. a different tab page) where the back button should be hidden. This causes the 'Back' button to be animated out of existence, when in fact it should be immediately removed.

E.g. In the Ionic Default Tab app, open 'Friends > Scruff McGruff', and then tab to 'Account'. You will notice a small delay before the 'Back' button is hidden, which is (noticeably) at a different time to when the Title is updated to 'Account' - both the title and the Back button should be updated/removed at the same time.

Ionic's ionNavBackButton directive should take account of the 'shouldAnimate' bool, so that the animation is not used when an immediate transition is required.

This pull request is an example of a potential fix to demonstrate how the back button transition animation should be disabled in certain circumstances.
