### PR TITLE
$ionicGesture.off: updated documentation to match code

### DIFF
--- a/js/angular/service/gesture.js
+++ b/js/angular/service/gesture.js
@@ -16,6 +16,7 @@ IonicModule
      * @param {function(e)} callback The function to call when the gesture
      * happens.
      * @param {element} $element The angular element to listen for the event on.
+     * @returns {ionic.Gesture} The gesture object (use this to remove the gesture later on).
      */
     on: function(eventType, cb, $element) {
       return window.ionic.onGesture(eventType, cb, $element[0]);
@@ -24,9 +25,9 @@ IonicModule
      * @ngdoc method
      * @name $ionicGesture#off
      * @description Remove an event listener for a gesture on an element. See {@link ionic.utility:ionic.EventController#offGesture}.
+     * @param {ionic.Gesture} gesture The gesture that should be removed.
      * @param {string} eventType The gesture event to remove the listener for.
      * @param {function(e)} callback The listener to remove.
-     * @param {element} $element The angular element that was listening for the event.
      */
     off: function(gesture, eventType, cb) {
       return window.ionic.offGesture(gesture, eventType, cb);


### PR DESCRIPTION
Coming from the documentation `$ionicGesture.off` had to be called like `$ionicGesture.off('swipe', mySwipe, myElement)`. Instead, it has to be called with the gesture returned from `$ionicGesture.on` and the type+callback to remove.

I added the `@returns {ionic.Gesture} ...` to `.on` to make clear that this returns the gesture you may want to remove later on. I also made the documentation for `.off` match the function signature.
