### PR TITLE
fix(button): 'android' overflow: hidden, not work

### DIFF
--- a/scss/_button.scss
+++ b/scss/_button.scss
@@ -33,9 +33,9 @@
     // used to create a larger button "hit" area
     position: absolute;
     top: -6px;
-    right: -8px;
+    right: -6px;
     bottom: -6px;
-    left: -8px;
+    left: -6px;
     content: ' ';
   }
 


### PR DESCRIPTION
Bug on Android and desktop Chrome 
http://youtu.be/7KYbHaQh3XQ
