### PR TITLE
(fix): remove nested, unclosed comment

### DIFF
--- a/scss/_platform.scss
+++ b/scss/_platform.scss
@@ -78,7 +78,6 @@
     font-weight: normal;
   }
 
-  /*
   font-family: 'Roboto';
 
   h1, h2, h3, h4, h5 {


### PR DESCRIPTION
This nested unclosed comment breaks autoprefixer's parsing and causes
it to spike to 100% cpu.

No breaking changes in this commit. see diegonetto/generator-ionic#38
