### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -47,7 +47,7 @@
     "js/_license.js",
     "js/ionic.js"
   ],
-  "dependencies": {
+  "devDependencies": {
     "angular": "~1.2.17",
     "angular-animate": "~1.2.17",
     "angular-sanitize": "~1.2.17",


### PR DESCRIPTION
Make dependencies only devDependencies, so bower doesn't install them. Since Ionic provides this in the bundle files, these shouldn't be needed.
