### PR TITLE
Fix ion-nav-back-button document

### DIFF
--- a/js/angular/directive/navBackButton.js
+++ b/js/angular/directive/navBackButton.js
@@ -29,7 +29,7 @@
  * ```html
  * <ion-nav-bar ng-controller="MyCtrl">
  *   <ion-nav-back-button class="button-clear"
- *     ng-click="doSomethingCool()">
+ *     ng-click="goBack()">
  *     <i class="ion-arrow-left-c"></i> Back
  *   </ion-nav-back-button>
  * </ion-nav-bar>


### PR DESCRIPTION
The html code in "custom click action" example should call "goBack" method, not "doSomethingCool".
