### PR TITLE
fix(slider): set options.continuous back to original for dynamically bui...

### DIFF
--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -39,6 +39,7 @@ ionic.views.Slider = ionic.views.View.inherit({
     var index = parseInt(options.startSlide, 10) || 0;
     var speed = options.speed || 300;
     options.continuous = options.continuous !== undefined ? options.continuous : true;
+    var continuous = options.continuous;
 
     function setup() {
 
@@ -47,7 +48,11 @@ ionic.views.Slider = ionic.views.View.inherit({
       length = slides.length;
 
       // set continuous to false if only one slide
-      if (slides.length < 2) options.continuous = false;
+      if (slides.length < 2) { 
+        options.continuous = false;
+      } else if (continuous) {
+        options.continuous = true; // reset to original value
+      }
 
       //special case if two slides
       if (browser.transitions && options.continuous && slides.length < 3) {


### PR DESCRIPTION
...ld slider/slideBox

This fixes an issue when trying to dynamically build a slideBox(with ng-repeat) with does-continue set to true.

Fixes this issue:

https://github.com/driftyco/ionic/issues/1890
