### PR TITLE
support zoom level for $ionicScrollDelegate.scrollTo()

### DIFF
--- a/js/angular/controller/scrollController.js
+++ b/js/angular/controller/scrollController.js
@@ -132,9 +132,9 @@ function($scope, scrollViewOptions, $timeout, $window, $$scrollValueCache, $loca
     });
   };
 
-  this.scrollTo = function(left, top, shouldAnimate) {
+  this.scrollTo = function(left, top, shouldAnimate, zoom) {
     this.resize().then(function() {
-      scrollView.scrollTo(left, top, !!shouldAnimate);
+      scrollView.scrollTo(left, top, !!shouldAnimate, zoom);
     });
   };
 

--- a/js/angular/service/scrollDelegate.js
+++ b/js/angular/service/scrollDelegate.js
@@ -91,6 +91,7 @@ IonicModule
    * @param {number} left The x-offset to scroll by.
    * @param {number} top The y-offset to scroll by.
    * @param {boolean=} shouldAnimate Whether the scroll should animate.
+   * @param {number=} zoom the expected zoom level after scroll
    */
   'scrollBy',
   /**


### PR DESCRIPTION
I got a situation when i use ion-scroll as the Image Viewer, enable pinch-to-zoom.
However, there's no option to reset zoom level, so when i change to the next image. The zoom level still be the previous one.

This pull request will help to solve that problem.
