### PR TITLE
Allow adding custom classes to $ionicPopup, to assist with contextual styling

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -304,7 +304,7 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $docume
         title: options.title,
         buttons: options.buttons,
         subTitle: options.subTitle,
-		class: options.class,
+        class: options.class,
         $buttonTapped: function(button, event) {
           var result = (button.onTap || angular.noop)(event);
           event = event.originalEvent || event; //jquery events


### PR DESCRIPTION
I realised there was no easy way to style contextually different popups. Adding a class for, say error popups, allows me to style them differently from success popups, for instance.

Example usage:

``` javascript
 // An alert dialog
 $scope.showAlert = function() {
   var alertPopup = $ionicPopup.alert({
     class: 'popup-error',
     title: 'Don\'t eat that!',
     template: 'It might taste good'
   });
   alertPopup.then(function(res) {
     console.log('Thank you for not eating my delicious ice cream cone');
   });
 };
```

Not sure if class being a reserved word causes problems? Suggestion for alternatives if so? ('theme' perhaps?)
