### PR TITLE
Added start position to collection repeat

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -164,6 +164,7 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
 
       var heightParsed = $parse($attr.collectionItemHeight || '"100%"');
       var widthParsed = $parse($attr.collectionItemWidth || '"100%"');
+      var startPos = $parse($attr.collectionStartPos || '0')($scope,{});
 
       var heightGetter = function(scope, locals) {
         var result = heightParsed(scope, locals);
@@ -200,6 +201,7 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
         widthGetter: widthGetter
       });
       var collectionRepeatManager = new $collectionRepeatManager({
+        startPos:startPos,
         dataSource: dataSource,
         element: scrollCtrl.$element,
         scrollView: scrollCtrl.scrollView,

--- a/js/angular/service/collectionRepeatManager.js
+++ b/js/angular/service/collectionRepeatManager.js
@@ -13,6 +13,7 @@ function($rootScope, $timeout) {
     this.dataSource = options.dataSource;
     this.element = options.element;
     this.scrollView = options.scrollView;
+    this.startPos = options.startPos;
 
     this.isVertical = !!this.scrollView.options.scrollingY;
     this.renderedItems = {};
@@ -108,7 +109,7 @@ function($rootScope, $timeout) {
 
 
       var dimensions = this.dataSource.dimensions.map(calculateSize, this);
-      var totalSize = primaryPos + (previousItem ? previousItem.primarySize : 0);
+      var totalSize = primaryPos + (previousItem ? previousItem.primarySize : 0) + this.startPos;
 
       return {
         beforeSize: beforeSize,


### PR DESCRIPTION
Because collection repeat is absolute, you couldn't put something before
it.
Added "collection-start-pos" attr to change the start position of the
list, so you can put something before it.

Code Example - search bar before collection list : 

``` html
<div class="list">
            <div id="search-box" class="bar bar-header item-input-inset">
                <div class="item-input-wrapper">
                    <i class="icon ion-ios7-search placeholder-icon"></i>
                    <input type="search" placeholder="search" ng-model="query">
                    <img class="clear-search" src="img/x.png" ng-click="clearSearch()">
                </div>
            </div>
            <a class="item my-item"
               collection-repeat="word in words"
               collection-item-height="70"
               collection-item-width="'100%'"
               collection-start-pos="44">
               {{word.text}}
            </a>
</div>
```
