### PR TITLE
Clone properties for contenteditable divs. Fixes #1897

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -199,6 +199,10 @@ ionic.tap = {
           clonedInput.className = focusInput.className;
           clonedInput.classList.add('cloned-text-input');
           clonedInput.readOnly = true;
+          if (focusInput.isContentEditable) {
+            clonedInput.contentEditable = focusInput.contentEditable;
+            clonedInput.innerHTML = focusInput.innerHTML;
+          }
           focusInput.parentElement.insertBefore(clonedInput, focusInput);
           focusInput.style.top = focusInput.offsetTop;
           focusInput.classList.add('previous-input-focus');


### PR DESCRIPTION
Cloning the contentEditable and innerHTML properties fixes the issue with conteneditable disappearing during scroll
