### PR TITLE
Allow options buttons on both sides of a list item

### DIFF
--- a/js/angular/directive/itemOptionButton.js
+++ b/js/angular/directive/itemOptionButton.js
@@ -1,6 +1,8 @@
 var ITEM_TPL_OPTION_BUTTONS =
-  '<div class="item-options invisible">' +
+  '<div class="invisible">' +
   '</div>';
+var ITEM_OPTIONS_LEFT_CLASS = 'item-options-left';
+var ITEM_OPTIONS_RIGHT_CLASS = 'item-options-right';
 /**
 * @ngdoc directive
 * @name ionOptionButton
@@ -8,8 +10,11 @@ var ITEM_TPL_OPTION_BUTTONS =
 * @module ionic
 * @restrict E
 * Creates an option button inside a list item, that is visible when the item is swiped
-* to the left by the user.  Swiped open option buttons can be hidden with
+* to the side by the user.  Swiped open option buttons can be hidden with
 * {@link ionic.service:$ionicListDelegate#closeOptionButtons $ionicListDelegate#closeOptionButtons}.
+*
+* By default the option buttons will appear on the right-hand side, but can be shown on
+* the left side by setting the "side" attribute to "left".
 *
 * Can be assigned any button class.
 *
@@ -21,6 +26,7 @@ var ITEM_TPL_OPTION_BUTTONS =
 * <ion-list>
 *   <ion-item>
 *     I love kittens!
+*     <ion-option-button class="button-royal" side="left">Meow</ion-option-button>
 *     <ion-option-button class="button-positive">Share</ion-option-button>
 *     <ion-option-button class="button-assertive">Edit</ion-option-button>
 *   </ion-item>
@@ -37,13 +43,24 @@ IonicModule
     require: '^ionItem',
     priority: Number.MAX_VALUE,
     compile: function($element, $attr) {
+      var side = $attr['side'] == 'left' ? 'left' : 'right';
       $attr.$set('class', ($attr['class'] || '') + ' button', true);
       return function($scope, $element, $attr, itemCtrl) {
-        if (!itemCtrl.optionsContainer) {
-          itemCtrl.optionsContainer = jqLite(ITEM_TPL_OPTION_BUTTONS);
-          itemCtrl.$element.append(itemCtrl.optionsContainer);
+        if (side == 'left') {
+          if (!itemCtrl.optionsContainerLeft) {
+            itemCtrl.optionsContainerLeft = jqLite(ITEM_TPL_OPTION_BUTTONS);
+            itemCtrl.optionsContainerLeft.addClass(ITEM_OPTIONS_LEFT_CLASS);
+            itemCtrl.$element.append(itemCtrl.optionsContainerLeft);
+          }
+          itemCtrl.optionsContainerLeft.append($element);
+        } else {
+          if (!itemCtrl.optionsContainerRight) {
+            itemCtrl.optionsContainerRight = jqLite(ITEM_TPL_OPTION_BUTTONS);
+            itemCtrl.optionsContainerRight.addClass(ITEM_OPTIONS_RIGHT_CLASS);
+            itemCtrl.$element.append(itemCtrl.optionsContainerRight);
+          }
+          itemCtrl.optionsContainerRight.append($element);
         }
-        itemCtrl.optionsContainer.append($element);
 
         //Don't bubble click up to main .item
         $element.on('click', stopPropagation);

--- a/js/views/listView.js
+++ b/js/views/listView.js
@@ -4,10 +4,24 @@
   var ITEM_CLASS = 'item';
   var ITEM_CONTENT_CLASS = 'item-content';
   var ITEM_SLIDING_CLASS = 'item-sliding';
-  var ITEM_OPTIONS_CLASS = 'item-options';
+  var ITEM_OPTIONS_LEFT_CLASS = 'item-options-left';
+  var ITEM_OPTIONS_RIGHT_CLASS = 'item-options-right';
   var ITEM_PLACEHOLDER_CLASS = 'item-placeholder';
   var ITEM_REORDERING_CLASS = 'item-reordering';
   var ITEM_REORDER_BTN_CLASS = 'item-reorder';
+
+  var RUBBER_COEFFICIENT = 0.4;
+  var VELOCITY_TRESHOLD = 0.3;
+
+  function grabButtons(content, cls) {
+    var buttons = content.parentNode.querySelector('.' + cls);
+    if(!buttons) {
+      return {width: 0};
+    }
+    buttons.classList.remove('invisible');
+
+    return {el: buttons, width: buttons.offsetWidth};
+  }
 
   var DragOp = function() {};
   DragOp.prototype = {
@@ -31,7 +45,7 @@
   SlideDrag.prototype = new DragOp();
 
   SlideDrag.prototype.start = function(e) {
-    var content, buttons, offsetX, buttonsWidth;
+    var content, buttonsLeft, buttonsRight, offsetX;
 
     if (!this.canSwipe()) {
       return;
@@ -57,17 +71,15 @@
     offsetX = parseFloat(content.style[ionic.CSS.TRANSFORM].replace('translate3d(', '').split(',')[0]) || 0;
 
     // Grab the buttons
-    buttons = content.parentNode.querySelector('.' + ITEM_OPTIONS_CLASS);
-    if(!buttons) {
+    buttonsLeft = grabButtons(content, ITEM_OPTIONS_LEFT_CLASS);
+    buttonsRight = grabButtons(content, ITEM_OPTIONS_RIGHT_CLASS);
+    if(!buttonsLeft.el && !buttonsRight.el) {
       return;
     }
-    buttons.classList.remove('invisible');
-
-    buttonsWidth = buttons.offsetWidth;
 
     this._currentDrag = {
-      buttons: buttons,
-      buttonsWidth: buttonsWidth,
+      buttonsLeft: buttonsLeft,
+      buttonsRight: buttonsRight,
       content: content,
       startOffsetX: offsetX
     };
@@ -92,13 +104,14 @@
     lastDrag.content.style[ionic.CSS.TRANSFORM] = '';
     ionic.requestAnimationFrame(function() {
       setTimeout(function() {
-        lastDrag.buttons && lastDrag.buttons.classList.add('invisible');
+        lastDrag.buttonsLeft.el && lastDrag.buttonsLeft.el.classList.add('invisible');
+        lastDrag.buttonsRight.el && lastDrag.buttonsRight.el.classList.add('invisible');
       }, 250);
     });
   };
 
   SlideDrag.prototype.drag = ionic.animationFrameThrottle(function(e) {
-    var buttonsWidth;
+    var leftWidth, rightWidth;
 
     // We really aren't dragging
     if(!this._currentDrag) {
@@ -115,15 +128,20 @@
     }
 
     if(this._isDragging) {
-      buttonsWidth = this._currentDrag.buttonsWidth;
+      leftWidth = this._currentDrag.buttonsLeft.width;
+      rightWidth = this._currentDrag.buttonsRight.width;
 
-      // Grab the new X point, capping it at zero
-      var newX = Math.min(0, this._currentDrag.startOffsetX + e.gesture.deltaX);
+      // Grab the new X point, capping it at zero if applicable
+      var newX = this._currentDrag.startOffsetX + e.gesture.deltaX;
+      if (!leftWidth && newX > 0) newX = 0;
+      if (!rightWidth && newX < 0) newX = 0;
 
       // If the new X position is past the buttons, we need to slow down the drag (rubber band style)
-      if(newX < -buttonsWidth) {
-        // Calculate the new X position, capped at the top of the buttons
-        newX = Math.min(-buttonsWidth, -buttonsWidth + (((e.gesture.deltaX + buttonsWidth) * 0.4)));
+      if(newX > leftWidth) {
+        newX = Math.max(leftWidth, leftWidth + (e.gesture.deltaX - leftWidth) * RUBBER_COEFFICIENT);
+      }
+      if(newX < -rightWidth) {
+        newX = Math.min(-rightWidth, -rightWidth + (e.gesture.deltaX + rightWidth) * RUBBER_COEFFICIENT);
       }
 
       this._currentDrag.content.style[ionic.CSS.TRANSFORM] = 'translate3d(' + newX + 'px, 0, 0)';
@@ -132,7 +150,7 @@
   });
 
   SlideDrag.prototype.end = function(e, doneCallback) {
-    var _this = this;
+    var _this = this, offsetX, leftWidth, rightWidth, restingPoint, tooSlow;
 
     // There is no drag, just end immediately
     if(!this._currentDrag) {
@@ -142,27 +160,32 @@
 
     // If we are currently dragging, we want to snap back into place
     // The final resting point X will be the width of the exposed buttons
-    var restingPoint = -this._currentDrag.buttonsWidth;
+    offsetX = this._currentDrag.startOffsetX;
+    leftWidth = this._currentDrag.buttonsLeft.width;
+    rightWidth = this._currentDrag.buttonsRight.width;
 
     // Check if the drag didn't clear the buttons mid-point
     // and we aren't moving fast enough to swipe open
-    if(e.gesture.deltaX > -(this._currentDrag.buttonsWidth/2)) {
-
-      // If we are going left but too slow, or going right, go back to resting
-      if(e.gesture.direction == "left" && Math.abs(e.gesture.velocityX) < 0.3) {
-        restingPoint = 0;
-      } else if(e.gesture.direction == "right") {
+    tooSlow = Math.abs(e.gesture.velocityX) < VELOCITY_TRESHOLD;
+    if(e.gesture.direction == 'left') {
+      restingPoint = -rightWidth;
+      if (e.gesture.deltaX + offsetX > -rightWidth / 2 && tooSlow) {
         restingPoint = 0;
       }
-
+    } else {
+      restingPoint = leftWidth;
+      if (e.gesture.deltaX + offsetX < leftWidth / 2 && tooSlow) {
+        restingPoint = 0;
+      }
     }
 
     ionic.requestAnimationFrame(function() {
       if(restingPoint === 0) {
         _this._currentDrag.content.style[ionic.CSS.TRANSFORM] = '';
-        var buttons = _this._currentDrag.buttons;
+        var drag = _this._currentDrag;
         setTimeout(function() {
-          buttons && buttons.classList.add('invisible');
+          drag.buttonsLeft.el && drag.buttonsLeft.el.classList.add('invisible');
+          drag.buttonsRight.el && drag.buttonsRight.el.classList.add('invisible');
         }, 250);
       } else {
         _this._currentDrag.content.style[ionic.CSS.TRANSFORM] = 'translate3d(' + restingPoint + 'px, 0, 0)';
@@ -508,7 +531,7 @@
 
         // Make sure this is an item with buttons
         item = this._getItem(e.target);
-        if(item && item.querySelector('.item-options')) {
+        if(item && (item.querySelector('.' + ITEM_OPTIONS_LEFT_CLASS) || item.querySelector('.' + ITEM_OPTIONS_RIGHT_CLASS))) {
           this._dragOp = new SlideDrag({ el: this.el, canSwipe: this.canSwipe });
           this._dragOp.start(e);
           e.preventDefault();
@@ -541,8 +564,6 @@
      * Process the drag event to move the item to the left or right.
      */
     _handleDrag: function(e) {
-      var _this = this, content, buttons;
-
       if(Math.abs(e.gesture.deltaY) > 5) {
         this._didDragUpOrDown = true;
       }

--- a/scss/_items.scss
+++ b/scss/_items.scss
@@ -740,13 +740,12 @@ button.item.item-button-right {
 
 
 /**
- * The hidden right-side buttons that can be exposed under a list item
- * with dragging.
+ * The hidden side buttons that can be exposed under a list item with
+ * dragging.
  */
-.item-options {
+.item-options-left, .item-options-right {
   position: absolute;
   top: 0;
-  right: 0;
   z-index: $z-index-item-options;
   height: 100%;
 
@@ -755,4 +754,12 @@ button.item.item-button-right {
     border: none;
     border-radius: 0;
   }
+}
+
+.item-options-left {
+  left: 0;
+}
+
+.item-options-right {
+  right: 0;
 }


### PR DESCRIPTION
Today you can only swipe left to show hidden buttons. This pull request enables options to appear when you swipe right (on the left side) by setting `side="left"` on the `<ion-option-button>` element. It's possible to have buttons on both sides simultaneously, or just on one of the sides (probably a better idea).

This is my first pull request, so please let me know if there's additional stuff I have to do before it is merged in.
