### PR TITLE
edge-drag-threshold now works from both sides

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -341,7 +341,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody) {
 
     var dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
       startX <= self.edgeThreshold ||
-      startX >= self.content.offsetWidth - self.edgeThreshold;
+      startX >= self.content.element.offsetWidth - self.edgeThreshold;
 
     return ($scope.dragContent || self.isOpen()) &&
            dragIsWithinBounds &&


### PR DESCRIPTION
Edge-drag-threshold only worked on swipes from the left side of the application. This commit changes this back to the intended behaviour by enabling swipes on the right side of the viewport to open the right side menu.
