### PR TITLE
Update platform.js

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -51,6 +51,8 @@
      * When the app is within a WebView (Cordova), it'll fire
      * the callback once the device is ready. If the app is within
      * a web browser, it'll fire the callback after `window.load`.
+     * Please remember that Cordova features (Camera, FileSystem, etc) still
+     * will not work in a web browser.
      * @param {function} callback The function to call.
      */
     ready: function(cb) {


### PR DESCRIPTION
I added a bit of detail to ready function to remind folks that - in the context of a web browser - even though ready has fired it is _NOT_ going to allow for device specific features. It may be too obvious, but I really think a reminder here will help.
