### PR TITLE
feat: delegateService function should be exposed

### DIFF
--- a/js/angular/controller/listController.js
+++ b/js/angular/controller/listController.js
@@ -33,7 +33,7 @@
  * ```
  */
 IonicModule
-.service('$ionicListDelegate', delegateService([
+.service('$ionicListDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicListDelegate#showReorder

--- a/js/angular/service/delegateService.js
+++ b/js/angular/service/delegateService.js
@@ -1,110 +1,115 @@
-function delegateService(methodNames) {
-  return ['$log', function($log) {
-    var delegate = this;
 
-    var instances = this._instances = [];
-    this._registerInstance = function(instance, handle) {
-      instance.$$delegateHandle = handle;
-      instances.push(instance);
+(function (ionic) {
 
-      return function deregister() {
-        var index = instances.indexOf(instance);
-        if (index !== -1) {
-          instances.splice(index, 1);
-        }
+  ionic.delegateService = function(methodNames) {
+    return ['$log', function($log) {
+      var delegate = this;
+
+      var instances = this._instances = [];
+      this._registerInstance = function(instance, handle) {
+        instance.$$delegateHandle = handle;
+        instances.push(instance);
+
+        return function deregister() {
+          var index = instances.indexOf(instance);
+          if (index !== -1) {
+            instances.splice(index, 1);
+          }
+        };
       };
-    };
 
-    this.$getByHandle = function(handle) {
-      if (!handle) {
-        return delegate;
+      this.$getByHandle = function(handle) {
+        if (!handle) {
+          return delegate;
+        }
+        return new InstanceForHandle(handle);
+      };
+
+      /*
+       * Creates a new object that will have all the methodNames given,
+       * and call them on the given the controller instance matching given
+       * handle.
+       * The reason we don't just let $getByHandle return the controller instance
+       * itself is that the controller instance might not exist yet.
+       *
+       * We want people to be able to do
+       * `var instance = $ionicScrollDelegate.$getByHandle('foo')` on controller
+       * instantiation, but on controller instantiation a child directive
+       * may not have been compiled yet!
+       *
+       * So this is our way of solving this problem: we create an object
+       * that will only try to fetch the controller with given handle
+       * once the methods are actually called.
+       */
+      function InstanceForHandle(handle) {
+        this.handle = handle;
       }
-      return new InstanceForHandle(handle);
-    };
+      methodNames.forEach(function(methodName) {
+        InstanceForHandle.prototype[methodName] = function() {
+          var handle = this.handle;
+          var args = arguments;
+          var matchingInstancesFound = 0;
+          var finalResult;
+          var result;
 
-    /*
-     * Creates a new object that will have all the methodNames given,
-     * and call them on the given the controller instance matching given
-     * handle.
-     * The reason we don't just let $getByHandle return the controller instance
-     * itself is that the controller instance might not exist yet.
-     *
-     * We want people to be able to do
-     * `var instance = $ionicScrollDelegate.$getByHandle('foo')` on controller
-     * instantiation, but on controller instantiation a child directive
-     * may not have been compiled yet!
-     *
-     * So this is our way of solving this problem: we create an object
-     * that will only try to fetch the controller with given handle
-     * once the methods are actually called.
-     */
-    function InstanceForHandle(handle) {
-      this.handle = handle;
-    }
-    methodNames.forEach(function(methodName) {
-      InstanceForHandle.prototype[methodName] = function() {
-        var handle = this.handle;
-        var args = arguments;
-        var matchingInstancesFound = 0;
-        var finalResult;
-        var result;
+          //This logic is repeated below; we could factor some of it out to a function
+          //but don't because it lets this method be more performant (one loop versus 2)
+          instances.forEach(function(instance) {
+            if (instance.$$delegateHandle === handle) {
+              matchingInstancesFound++;
+              result = instance[methodName].apply(instance, args);
+              //Only return the value from the first call
+              if (matchingInstancesFound === 1) {
+                finalResult = result;
+              }
+            }
+          });
 
-        //This logic is repeated below; we could factor some of it out to a function
-        //but don't because it lets this method be more performant (one loop versus 2)
-        instances.forEach(function(instance) {
-          if (instance.$$delegateHandle === handle) {
-            matchingInstancesFound++;
+          if (!matchingInstancesFound) {
+            return $log.warn(
+              'Delegate for handle "'+this.handle+'" could not find a ' +
+              'corresponding element with delegate-handle="'+this.handle+'"! ' +
+              methodName + '() was not called!\n' +
+              'Possible cause: If you are calling ' + methodName + '() immediately, and ' +
+              'your element with delegate-handle="' + this.handle + '" is a child of your ' +
+              'controller, then your element may not be compiled yet. Put a $timeout ' +
+              'around your call to ' + methodName + '() and try again.'
+            );
+          }
+
+          return finalResult;
+        };
+        delegate[methodName] = function() {
+          var args = arguments;
+          var finalResult;
+          var result;
+
+          //This logic is repeated above
+          instances.forEach(function(instance, index) {
             result = instance[methodName].apply(instance, args);
             //Only return the value from the first call
-            if (matchingInstancesFound === 1) {
+            if (index === 0) {
               finalResult = result;
             }
-          }
-        });
+          });
 
-        if (!matchingInstancesFound) {
-          return $log.warn(
-            'Delegate for handle "'+this.handle+'" could not find a ' +
-            'corresponding element with delegate-handle="'+this.handle+'"! ' +
-            methodName + '() was not called!\n' +
-            'Possible cause: If you are calling ' + methodName + '() immediately, and ' +
-            'your element with delegate-handle="' + this.handle + '" is a child of your ' +
-            'controller, then your element may not be compiled yet. Put a $timeout ' +
-            'around your call to ' + methodName + '() and try again.'
-          );
+          return finalResult;
+        };
+
+        function callMethod(instancesToUse, methodName, args) {
+          var finalResult;
+          var result;
+          instancesToUse.forEach(function(instance, index) {
+            result = instance[methodName].apply(instance, args);
+            //Make it so the first result is the one returned
+            if (index === 0) {
+              finalResult = result;
+            }
+          });
+          return finalResult;
         }
+      });
+    }];
+  };
 
-        return finalResult;
-      };
-      delegate[methodName] = function() {
-        var args = arguments;
-        var finalResult;
-        var result;
-
-        //This logic is repeated above
-        instances.forEach(function(instance, index) {
-          result = instance[methodName].apply(instance, args);
-          //Only return the value from the first call
-          if (index === 0) {
-            finalResult = result;
-          }
-        });
-
-        return finalResult;
-      };
-
-      function callMethod(instancesToUse, methodName, args) {
-        var finalResult;
-        var result;
-        instancesToUse.forEach(function(instance, index) {
-          result = instance[methodName].apply(instance, args);
-          //Make it so the first result is the one returned
-          if (index === 0) {
-            finalResult = result;
-          }
-        });
-        return finalResult;
-      }
-    });
-  }];
-}
+})(window.ionic);

--- a/js/angular/service/navBarDelegate.js
+++ b/js/angular/service/navBarDelegate.js
@@ -26,7 +26,7 @@
  * ```
  */
 IonicModule
-.service('$ionicNavBarDelegate', delegateService([
+.service('$ionicNavBarDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicNavBarDelegate#align

--- a/js/angular/service/scrollDelegate.js
+++ b/js/angular/service/scrollDelegate.js
@@ -58,7 +58,7 @@
  * ```
  */
 IonicModule
-.service('$ionicScrollDelegate', delegateService([
+.service('$ionicScrollDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicScrollDelegate#resize

--- a/js/angular/service/sideMenuDelegate.js
+++ b/js/angular/service/sideMenuDelegate.js
@@ -36,7 +36,7 @@
  * ```
  */
 IonicModule
-.service('$ionicSideMenuDelegate', delegateService([
+.service('$ionicSideMenuDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicSideMenuDelegate#toggleLeft

--- a/js/angular/service/slideBoxDelegate.js
+++ b/js/angular/service/slideBoxDelegate.js
@@ -35,7 +35,7 @@
  * ```
  */
 IonicModule
-.service('$ionicSlideBoxDelegate', delegateService([
+.service('$ionicSlideBoxDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicSlideBoxDelegate#select

--- a/js/angular/service/tabsDelegate.js
+++ b/js/angular/service/tabsDelegate.js
@@ -34,7 +34,7 @@
  * ```
  */
 IonicModule
-.service('$ionicTabsDelegate', delegateService([
+.service('$ionicTabsDelegate', ionic.delegateService([
   /**
    * @ngdoc method
    * @name $ionicTabsDelegate#select

--- a/test/unit/angular/service/delegateService.unit.js
+++ b/test/unit/angular/service/delegateService.unit.js
@@ -2,7 +2,7 @@ describe('DelegateFactory', function() {
   function setup(methods) {
     var delegate;
     inject(function($log, $injector) {
-      delegate = $injector.instantiate(delegateService(methods || []));
+      delegate = $injector.instantiate(ionic.delegateService(methods || []));
     });
     return delegate;
   }


### PR DESCRIPTION
**Type**: <span ionic-type>feat</span>

**Platform**: <span ionic-platform>all</span>  

<span ionic-description>When creating contributing modules for ionic that make use of the current delegateService style. You have to include that function in your project manually as it's not exposed.

I'd like to see this available under the ionic namespace. Or under an ionic.service namespace or similar.

Thoughts?</span>

<span is-issue-template></span>
