### PR TITLE
Ensure element is already existant

### DIFF
--- a/js/angular/directive/infiniteScroll.js
+++ b/js/angular/directive/infiniteScroll.js
@@ -119,7 +119,7 @@ IonicModule
       });
 
       $scope.$on('$destroy', function() {
-        scrollCtrl.$element.off('scroll', checkBounds);
+        scrollCtrl.$element && scrollCtrl.$element.off('scroll', checkBounds);
       });
 
       var checkBounds = ionic.animationFrameThrottle(checkInfiniteBounds);


### PR DESCRIPTION
If i never show the `<ion-infinite-scroll ng-if="!noMoreItemsAvailable" on-infinite="loadMore()" distance="2%"></ion-infinite-scroll>` on scope destroy we have a js error
