### PR TITLE
fix(sideMenu, exposeAsideWhen): set default width

### DIFF
--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -39,7 +39,7 @@ IonicModule
         $scope.side = $attr.side || 'left';
 
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
-          width: 275,
+          width: attr.width,
           el: $element[0],
           isEnabled: true
         });


### PR DESCRIPTION
ion-side-menu with explicit width and expose-aside-when="large”
previously loaded the sidebar with a fixed width of 275px.
