### PR TITLE
Correctly handle DOM Ready states

### DIFF
--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -1,7 +1,7 @@
 (function(window, document, ionic) {
 
   var readyCallbacks = [];
-  var isDomReady = false;
+  var isDomReady = document.readyState === 'complete' || document.readyState === 'interactive';
 
   function domReady() {
     isDomReady = true;
@@ -11,7 +11,10 @@
     readyCallbacks = [];
     document.removeEventListener('DOMContentLoaded', domReady);
   }
-  document.addEventListener('DOMContentLoaded', domReady);
+  if (!isDomReady){
+    document.addEventListener('DOMContentLoaded', domReady);
+  }
+  
 
   // From the man himself, Mr. Paul Irish.
   // The requestAnimationFrame polyfill
@@ -110,7 +113,7 @@
      * @param {function} callback The function to be called.
      */
     ready: function(cb) {
-      if(isDomReady || document.readyState === "complete") {
+      if(isDomReady) {
         ionic.requestAnimationFrame(cb);
       } else {
         readyCallbacks.push(cb);


### PR DESCRIPTION
Previously, if the script was loaded while in `document.readyState` of `interactive`, the `domReady` function is never called.

See https://developer.mozilla.org/en-US/docs/Web/API/document.readyState for explanation of the proper detection of `DOMContentLoaded`
