### PR TITLE
Correctly handle window loaded states

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -351,7 +351,8 @@
 
   var platformName = null, // just the name, like iOS or Android
   platformVersion = null, // a float of the major and minor, like 7.1
-  readyCallbacks = [];
+  readyCallbacks = [],
+  windowLoadListenderAttached;
 
   // setup listeners to know when the device is ready to go
   function onWindowLoad() {
@@ -364,8 +365,17 @@
       // cordova/phonegap object, so its just a browser, not a webview wrapped w/ cordova
       onPlatformReady();
     }
-    window.removeEventListener("load", onWindowLoad, false);
+    if (windowLoadListenderAttached){
+      window.removeEventListener("load", onWindowLoad, false);
+    }
   }
+  if (document.readyState === 'complete') {
+    onWindowLoad();
+  } else {
+    windowLoadListenderAttached = true;
+    window.addEventListener("load", onWindowLoad, false);
+  }
+  
   window.addEventListener("load", onWindowLoad, false);
 
   function onPlatformReady() {


### PR DESCRIPTION
Previously if this script was executed after the window was loaded, none of the callbacks would fire.

See https://developer.mozilla.org/en-US/docs/Web/API/document.readyState for definition of detecting the `load` event.

TODO: Potentially this is redundent, since maybe using `ionic.DomUtil.ready` would mean one less listener.  However I don't know if the listeners attached to `ionic.Platform.ready` require the `document.readyState` to be `complete` rather than only `interactive`.

Linked to #2229
