### PR TITLE
Fix incorrect use of title attributes in docs for ionNavView

### DIFF
--- a/js/angular/directive/navView.js
+++ b/js/angular/directive/navView.js
@@ -74,7 +74,7 @@ IonicModule.constant('$ionicNavViewConfig', {
  * ```html
  * <script id="home" type="text/ng-template">
  *   <!-- The title of the ion-view will be shown on the navbar -->
- *   <ion-view title="'Home'">
+ *   <ion-view title="Home">
  *     <ion-content ng-controller="HomeCtrl">
  *       <!-- The content of the page -->
  *       <a href="#/music">Go to music page!</a>


### PR DESCRIPTION
The `title` attribute is no longer evaluated, and should just be a simple string value. It is correct in the ionView docs, but not here.
