### PR TITLE
fix(header): Start counting right width on title element rather than h1 Fixes #1356

### DIFF
--- a/js/views/headerBarView.js
+++ b/js/views/headerBarView.js
@@ -36,7 +36,7 @@
         // Once we encounter a titleEl, realize we are now counting the right-buttons, not left
         for(i = 0; i < childNodes.length; i++) {
           c = childNodes[i];
-          if (c.tagName && c.tagName.toLowerCase() == 'h1') {
+          if (c == titleEl) {
             isCountingRightWidth = true;
             continue;
           }


### PR DESCRIPTION
When calculating the left/right title offsets, if the title element was not an `<h1>` element, the `isCountingRightWidth` flag would never be set. This would cause the widths of all elements, including the title element itself, to be included in the computed left offset, subsequently placing the title out of view. To address this, I simply updated the condition that determines if the title element has been found to compare each node against the title element (`titleEl`) that had already been procured a few lines prior. Now the left/right offsets are properly computed regardless of what tag the `title` class is applied to.
