### PR TITLE
docs(ionSlideBox): Adding docs for disable-scroll

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -32,6 +32,7 @@
  * @param {number=} slide-interval How many milliseconds to wait to change slides (if does-continue is true). Defaults to 4000.
  * @param {boolean=} show-pager Whether a pager should be shown for this slide box.
  * @param {expression=} pager-click Expression to call when a pager is clicked (if show-pager is true). Is passed the 'index' variable.
+ * @param {boolean=} disable-scroll Whether swiping between slides is disabled. Default false.
  * @param {expression=} on-slide-changed Expression called whenever the slide is changed.  Is passed an '$index' variable.
  * @param {expression=} active-slide Model to bind the current slide to.
  */


### PR DESCRIPTION
Missing documentation on how to stop the ion-slide-box directive from swiping between slides.
