### PR TITLE
Added `ui-sref` check for activator

### DIFF
--- a/js/utils/activator.js
+++ b/js/utils/activator.js
@@ -24,7 +24,7 @@
             eleToActivate = ele;
             break;
           }
-          if( ele.tagName == 'A' || ele.tagName == 'BUTTON' || ele.hasAttribute('ng-click') ) {
+          if( ele.tagName == 'A' || ele.tagName == 'BUTTON' || ele.hasAttribute('ng-click') || ele.hasAttribute('ui-sref') ) {
             eleToActivate = ele;
             break;
           }


### PR DESCRIPTION
This allows non-anchor `ui-sref` elements to get the `activated` class.

Most cases involve a `ui-sref` being on an `A` element, but its a safe bet that for some reason ( for instance, if you don't want to inherit the default `A` styles ) you put a `ui-sref` on a `div`, you still get the `activated` class.

But its a safe bet that if you have `ui-sref` on an element, you want it to be activatable :wink:
