### PR TITLE
Allow navView animation property to be bindable

### DIFF
--- a/js/angular/service/viewService.js
+++ b/js/angular/service/viewService.js
@@ -454,7 +454,7 @@ function($rootScope, $state, $location, $window, $injector, $animate, $ionicNavV
       function getParentAnimationClass(el) {
         var className = '';
         while(!className && el) {
-          className = el.getAttribute('animation');
+          className = navViewScope.$eval(el.getAttribute('animation')) || el.getAttribute('animation');
           el = el.parentElement;
         }
 


### PR DESCRIPTION
Test for a bindable attribute value in the navViewScope, if that fails, allow the default string value.

supports:

```
<ion-nav-view animation="getAnimation()" />
<ion-nav-view animation="scopeAnimationProperty" />
<ion-nav-view animation="slide-left-right" />
```

Let me know if this needs beefing up.
