### PR TITLE
fix(viewService): Corrects showBack logic

### DIFF
--- a/js/angular/directive/navView.js
+++ b/js/angular/directive/navView.js
@@ -144,6 +144,8 @@ function( $ionicViewService,   $state,   $compile,   $controller,   $animate) {
           viewIsUpdating = false;
         };
 
+        $ionicViewService.registerHistory(scope);
+
         scope.$on('$stateChangeSuccess', eventHook);
         // scope.$on('$viewContentLoading', eventHook);
         updateView(false);

--- a/js/angular/service/viewService.js
+++ b/js/angular/service/viewService.js
@@ -301,7 +301,7 @@ function($rootScope, $state, $location, $window, $injector, $animate, $ionicNavV
       viewHistory.forwardView = this._getForwardView(viewHistory.currentView);
 
       $rootScope.$broadcast('$viewHistory.historyChange', {
-        showBack: (viewHistory.backView && viewHistory.backView.historyId === viewHistory.currentView.historyId)
+        showBack: (viewHistory.backView && viewHistory.backView.historyId !== viewHistory.currentView.historyId)
       });
     },
 

--- a/test/unit/angular/directive/navView.unit.js
+++ b/test/unit/angular/directive/navView.unit.js
@@ -15,6 +15,16 @@ describe('Ionic nav-view', function() {
     expect(view.controller('ionNavView')).toBeTruthy();
   });
 
+  it('should register the history', inject(function($ionicViewService) {
+    spyOn($ionicViewService, 'registerHistory');
+
+    var view = angular.element('<ion-nav-view></ion-nav-view>');
+    compile(view)(scope)
+    scope.$apply();
+
+    expect($ionicViewService.registerHistory).toHaveBeenCalled();
+  }));
+
   /*
    * TODO adapt the tests from uiRouter
    */

--- a/test/unit/angular/service/viewService.unit.js
+++ b/test/unit/angular/service/viewService.unit.js
@@ -41,6 +41,66 @@ describe('Ionic View Service', function() {
     window.history.go = function(val) { return val; };
   }));
 
+  it('should fire the $viewHistory.historyChange event with showBack falsy', function() {
+    var eventData;
+    rootScope.$on('$viewHistory.historyChange', function (e, data) {
+      eventData = data;
+    });
+    var viewHistory = rootScope.$viewHistory;
+
+    viewHistory.views.a = {
+      historyId: '1',
+      viewId: 'a'
+    };
+    viewService.setNavViews('a');
+
+    expect(viewHistory.currentView).toBe(viewHistory.views.a);
+    expect(viewHistory.backView).toBe(null);
+    expect(viewHistory.forwardView).toBe(null);
+    rootScope.$apply();
+    expect(eventData).toBeDefined();
+    expect(eventData.showBack).toBe(viewHistory.backView);
+
+    viewHistory.views.b = {
+      historyId: '1',
+      backViewId: 'a',
+      viewId: 'b'
+    };
+
+    viewService.setNavViews('b');
+    rootScope.$apply();
+
+    expect(eventData.showBack).toBe(false);
+  });
+
+  it('should fire the $viewHistory.historyChange event with showBack true', function() {
+    var eventData;
+    rootScope.$on('$viewHistory.historyChange', function (e, data) {
+      eventData = data;
+    });
+    var viewHistory = rootScope.$viewHistory;
+
+    viewHistory.views.a = {
+      historyId: '1',
+      viewId: 'a'
+    };
+
+    viewHistory.views.b = {
+      historyId: '2',
+      backViewId: 'a',
+      viewId: 'b'
+    };
+
+    viewService.setNavViews('b');
+
+    expect(viewHistory.currentView).toBe(viewHistory.views.b);
+    expect(viewHistory.backView).toBe(viewHistory.views.a);
+    expect(viewHistory.forwardView).toBe(null);
+    rootScope.$apply();
+    expect(eventData).toBeDefined();
+    expect(eventData.showBack).toBe(true);
+  });
+
   it('should do nothing if the same state happens', inject(function($state) {
     var uiViewScope = {};
     $state.go('home');


### PR DESCRIPTION
- Corrects the logic used to determine showBack in the event broadcast
  of `$viewHistory.historyChange`
- Registers ion-nav-view with a `$historyId` in order to correctly
  detect back state when element instance is registered

This addresses #2366 naively.  It fixes the bug, but doesn't fix the architecture flaw (IMO).
