### PR TITLE
$ionicLoading: Add the possibility to have a custom scope

### DIFF
--- a/js/angular/service/loading.js
+++ b/js/angular/service/loading.js
@@ -114,6 +114,9 @@ function($ionicLoadingConfig, $ionicBody, $ionicTemplateLoader, $ionicBackdrop, 
             $ionicTemplateLoader.load(options.templateUrl) :
             //options.content: deprecated
             $q.when(options.template || options.content || '');
+            
+        
+          self.scope = options.scope || self.scope;
 
 
           if (!this.isShown) {


### PR DESCRIPTION
This line adds the possibility to use a custom scope with $ionicLoading 

I found it useful to show the progress of the loading process.

Simplified demo: http://codepen.io/anon/pen/Ltign
