### PR TITLE
fix(form): Fix incorrectly compiled styles

### DIFF
--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -5,7 +5,7 @@
 
 // Make all forms have space below them
 form {
-  margin: 0 0 $line-height-base;
+  margin: 0 0 $line-height-base + px;
 }
 
 // Groups of fields with labels on top (legends)
@@ -17,11 +17,11 @@ legend {
   border: $input-border-width solid $input-border;
   color: $dark;
   font-size: $font-size-base * 1.5;
-  line-height: $line-height-base * 2;
+  line-height: $line-height-base * 2 + px;
 
   small {
     color: $stable;
-    font-size: $line-height-base * .75;
+    font-size: $line-height-base * .75 + px;
   }
 }
 


### PR DESCRIPTION
Certain styles in the form scss partial are not compiled to valid styles
since it uses numbers without appending `px` to the end
