### PR TITLE
android sidemenu collapse

### DIFF
--- a/js/angular/directive/exposeAsideWhen.js
+++ b/js/angular/directive/exposeAsideWhen.js
@@ -53,8 +53,10 @@ IonicModule
       }
 
       function onResize() {
-        sideMenuCtrl.activeAsideResizing(true);
-        debouncedCheck();
+        if(!ionic.keyboard.isOpen) {
+          sideMenuCtrl.activeAsideResizing(true);
+          debouncedCheck();
+        }
       }
 
       var debouncedCheck = ionic.debounce(function() {


### PR DESCRIPTION
Having a form in a sidemenu and using exposeAsideWhen.
On small screens on android the sidemenu collapse when the keyboard is
shown.