### PR TITLE
fix(navBackButton): Fix back button state

### DIFF
--- a/js/angular/controller/navBarController.js
+++ b/js/angular/controller/navBarController.js
@@ -16,10 +16,6 @@ function($scope, $element, $attrs, $ionicViewService, $animate, $compile, $ionic
 
   $scope.$on('$destroy', deregisterInstance);
 
-  $scope.$on('$viewHistory.historyChange', function(e, data) {
-    backIsShown = !!data.showBack;
-  });
-
   var self = this;
 
   this.leftButtonsElement = jqLite(

--- a/js/angular/directive/navBackButton.js
+++ b/js/angular/directive/navBackButton.js
@@ -100,7 +100,7 @@ function($animate, $rootScope, $sanitize, $ionicNavBarConfig, $ionicNgClick) {
           if(isDefined($attr.fromTitle)) {
             $element[0].innerHTML = '<span class="back-button-title">' + $sanitize($scope.oldTitle) + '</span>';
           }
-          return !!(backIsShown && $scope.backButtonShown);
+          return navBarCtrl.showBackButton(backIsShown);
         }, ionic.animationFrameThrottle(function(show) {
           if (show) $animate.removeClass($element, 'ng-hide');
           else $animate.addClass($element, 'ng-hide');

--- a/test/unit/angular/directive/navBackButton.unit.js
+++ b/test/unit/angular/directive/navBackButton.unit.js
@@ -1,13 +1,17 @@
 describe('ionNavBackButton directive', function() {
+  var ctrl;
+
   beforeEach(module('ionic'));
 
   function setup(attr, content) {
     var el;
+    ctrl = {
+      back: jasmine.createSpy('back'),
+      showBackButton: function (a) { return !!a; }
+    };
     inject(function($compile, $rootScope) {
       el = angular.element('<ion-nav-back-button '+(attr||'')+'>'+(content||'')+'</ion-nav-back-button>');
-      el.data('$ionNavBarController', {
-        back: jasmine.createSpy('back'),
-      });
+      el.data('$ionNavBarController', ctrl);
       el = $compile(el)($rootScope.$new());
       $rootScope.$apply();
     });
@@ -38,20 +42,27 @@ describe('ionNavBackButton directive', function() {
     expect(el.hasClass('ng-hide')).toBe(true);
   }));
 
-  it('should hide based on backButtonShown', inject(function($rootScope) {
+  it('should hide based on navBarCtrl.showBackButton', inject(function($rootScope) {
     ionic.animationFrameThrottle = function(cb) { return cb; };
     var el = setup();
+    spyOn(ctrl, 'showBackButton').andCallThrough();
+    expect(ctrl.showBackButton.calls.length).toBe(0);
     expect(el.hasClass('ng-hide')).toBe(true);
     $rootScope.$broadcast('$viewHistory.historyChange', {showBack:true});
-    el.scope().$apply('backButtonShown = true');
+    el.scope().$apply();
+    expect(ctrl.showBackButton.calls.length).toBe(2);
     expect(el.hasClass('ng-hide')).toBe(false);
-    el.scope().$apply('backButtonShown = false');
-    expect(el.hasClass('ng-hide')).toBe(true);
+    $rootScope.$broadcast('$viewHistory.historyChange', {showBack:true});
+    el.scope().$apply();
+    expect(ctrl.showBackButton.calls.length).toBe(3);
+    expect(el.hasClass('ng-hide')).toBe(false);
     $rootScope.$broadcast('$viewHistory.historyChange', {showBack:false});
-    el.scope().$apply('backButtonShown = true');
+    el.scope().$apply();
+    expect(ctrl.showBackButton.calls.length).toBe(5);
     expect(el.hasClass('ng-hide')).toBe(true);
     $rootScope.$broadcast('$viewHistory.historyChange', {showBack:true});
-    el.scope().$apply('backButtonShown = true');
+    el.scope().$apply();
+    expect(ctrl.showBackButton.calls.length).toBe(7);
     expect(el.hasClass('ng-hide')).toBe(false);
   }));
 


### PR DESCRIPTION
- Removed dead code
- Change watcher in navBackButton to use navBarCtrl.showBackButton

Currently as reported in #2353, the $ionicNavBarDelegate.showBackButton reports false - this is because the back button state is being handled by the navBackButton directive, which never calls the navbar controller to test for when to show the back button, which in turn results in the navbar controller never being notified when the state is changed so that it can notify via the service.
