### PR TITLE
Disabled scroll and focus for readonly elements.

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -143,7 +143,7 @@ function keyboardNativeShow(e) {
 }
 
 function keyboardBrowserFocusIn(e) {
-  if( !e.target || !ionic.tap.isTextInput(e.target) || ionic.tap.isDateInput(e.target) || !keyboardIsWithinScroll(e.target) ) return;
+  if( !e.target || e.target.readOnly || !ionic.tap.isTextInput(e.target) || ionic.tap.isDateInput(e.target) || !keyboardIsWithinScroll(e.target) ) return;
 
   document.addEventListener('keydown', keyboardOnKeyDown, false);
 


### PR DESCRIPTION
Hey! 

This fix stops unexpected behaviour illustrated below:

![oct 11 2014 15 35](https://cloud.githubusercontent.com/assets/1904894/4602455/b930cbd8-513a-11e4-8643-bf4688f91629.gif)

The input I've clicked on was readonly. When it was clicked ion-content height became larger. I.e it was scrolled and was waiting for keyboard to show up. But since keyboard wouldn't show content height would stay incorrect.

Thanks!
