### PR TITLE
Prevent 'cannot read' exception

### DIFF
--- a/js/angular/controller/scrollController.js
+++ b/js/angular/controller/scrollController.js
@@ -41,14 +41,15 @@ function($scope, scrollViewOptions, $timeout, $window, $$scrollValueCache, $loca
 
   if (!angular.isDefined(scrollViewOptions.bouncing)) {
     ionic.Platform.ready(function() {
-      scrollView.options.bouncing = true;
-
-      if(ionic.Platform.isAndroid()) {
-        // No bouncing by default on Android
-        scrollView.options.bouncing = false;
-        // Faster scroll decel
-        scrollView.options.deceleration = 0.95;
-      } else {
+      if (scrollView.options) {
+        scrollView.options.bouncing = true;
+        if(ionic.Platform.isAndroid()) {
+          // No bouncing by default on Android
+          scrollView.options.bouncing = false;
+          // Faster scroll decel
+          scrollView.options.deceleration = 0.95;
+        } else {
+        }
       }
     });
   }


### PR DESCRIPTION
On Android (4.4.4) I'm getting "Cannot read property 'options' of null" each time, 100% reproducible.
This small check will not hurt anyone but will prevent unhandled exception error.
