### PR TITLE
feat(collectionRepeat): No redraw if the list has been appended to

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -164,6 +164,7 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
 
       var heightParsed = $parse($attr.collectionItemHeight || '"100%"');
       var widthParsed = $parse($attr.collectionItemWidth || '"100%"');
+      var shouldRedraw = $parse($attr.collectionRedraw || true)();
 
       var heightGetter = function(scope, locals) {
         var result = heightParsed(scope, locals);
@@ -203,6 +204,7 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
         dataSource: dataSource,
         element: scrollCtrl.$element,
         scrollView: scrollCtrl.scrollView,
+        redraw: shouldRedraw
       });
 
       $scope.$watchCollection(listExpr, function(value) {

--- a/js/angular/service/collectionRepeatManager.js
+++ b/js/angular/service/collectionRepeatManager.js
@@ -13,6 +13,7 @@ function($rootScope, $timeout) {
     this.dataSource = options.dataSource;
     this.element = options.element;
     this.scrollView = options.scrollView;
+    this.redraw = options.redraw || true;
 
     this.isVertical = !!this.scrollView.options.scrollingY;
     this.renderedItems = {};
@@ -153,7 +154,7 @@ function($rootScope, $timeout) {
       this.viewportSize = result.totalSize;
       this.beforeSize = result.beforeSize;
       this.setCurrentIndex(0);
-      this.render(true);
+      this.render(this.redraw);
       this.dataSource.setup();
     },
     /*

--- a/test/unit/angular/directive/collectionRepeat.unit.js
+++ b/test/unit/angular/directive/collectionRepeat.unit.js
@@ -17,7 +17,8 @@ describe('collectionRepeat directive', function() {
       jasmine.createSpy('$repeatManager').andCallFake(function(opts) {
         repeatManager = {
           options: opts,
-          resize: jasmine.createSpy('resize')
+          resize: jasmine.createSpy('resize'),
+          render: jasmine.createSpy('render')
         };
         return repeatManager;
       })
@@ -126,6 +127,25 @@ describe('collectionRepeat directive', function() {
     spyOn(scrollView, 'resize');
     dataSource.setData.reset();
     repeatManager.resize.reset();
+
+    el.scope().$apply('items = [ 1,2,3 ]');
+    expect(dataSource.setData).toHaveBeenCalledWith(el.scope().items, [], []);
+    expect(repeatManager.resize.callCount).toBe(1);
+    expect(scrollView.resize.callCount).toBe(1);
+    el.scope().$apply('items = null');
+    expect(dataSource.setData).toHaveBeenCalledWith(null, [], []);
+    expect(repeatManager.resize.callCount).toBe(2);
+    expect(scrollView.resize.callCount).toBe(2);
+  });
+
+  it('should not rerender on list change if elements have been added', function() {
+    var el = setup('collection-repeat="item in items" collection-item-height="50" collection-redraw="false"');
+    var scrollView = el.controller('$ionicScroll').scrollView;
+    spyOn(scrollView, 'resize');
+    dataSource.setData.reset();
+    repeatManager.resize.reset();
+
+    expect(repeatManager.options.redraw).toBe(false);
 
     el.scope().$apply('items = [ 1,2,3 ]');
     expect(dataSource.setData).toHaveBeenCalledWith(el.scope().items, [], []);

--- a/test/unit/angular/service/collectionRepeatManager.unit.js
+++ b/test/unit/angular/service/collectionRepeatManager.unit.js
@@ -251,7 +251,7 @@ describe('collectionRepeatManager service', function() {
     it('should work without data', function() {
       var manager = setup();
       spyOn(manager, 'render');
-      spyOn(manager, 'calculateDimensions').andReturn({ 
+      spyOn(manager, 'calculateDimensions').andReturn({
         dimensions: [],
         beforeSize: 0,
         totalSize: 0
@@ -265,7 +265,7 @@ describe('collectionRepeatManager service', function() {
     });
     it('should work with data', function() {
       var manager = setup();
-      spyOn(manager, 'calculateDimensions').andReturn({ 
+      spyOn(manager, 'calculateDimensions').andReturn({
         dimensions: [{
           primaryPos: 100, primarySize: 30
         }],


### PR DESCRIPTION
When creating an infinite list using collection repeat the list is redrawn whenever it is appended to. This is normally OK, except when you have any form of animation happening on the list. This PR adds in an attribute called `collection-redraw` which takes an expression so you can control if you want you list to redraw when it's edited. This way we can disable redraw when we know that our lists are only going to be appended to.

Thoughts.