### PR TITLE
fix(slideBox): disable dragging on slide boxes

### DIFF
--- a/js/angular/controller/slideBoxController.js
+++ b/js/angular/controller/slideBoxController.js
@@ -24,6 +24,7 @@ function(scope, element, $$ionicAttachDrag, $interval) {
 
   $$ionicAttachDrag(scope, element, {
     getDistance: function() { return slidesParent.prop('offsetWidth'); },
+    onDragStart: onDragStart,
     onDrag: onDrag,
     onDragEnd: onDragEnd
   });


### PR DESCRIPTION
Fixes #2436 - $ionicSlideBoxDelegate.enableSlide(false) was not working due to a missing onDragStart function being passed to the ionicAttachDrag service
