### PR TITLE
bug: slider on range input has black outline on iOS

### DIFF
--- a/scss/_range.scss
+++ b/scss/_range.scss
@@ -29,6 +29,8 @@ input[type="range"] {
     background-color: $toggle-handle-off-bg-color;
     box-shadow: 0 0 2px rgba(0,0,0,.5), 1px 3px 5px rgba(0,0,0,0.25);
     cursor: pointer;
+    outline: none;
+    border: none;
     -webkit-appearance: none;
   }
 


### PR DESCRIPTION
**Type**: <span ionic-type>bug</span>

**Platform**: <span ionic-platform>ios</span> <span ionic-platform-version>8</span>  <span ionic-webview>webview</span>

<span ionic-description>Slider on range input has a black outline/border on iOS devices. This does not show up in the browser or on Android devices. Fixed by adding:</span>
```
outline: none;
border: none;
```
to  `input[type="range"]::-webkit-slider-thumb` in ionic.css file.

<span is-issue-template></span>
