### PR TITLE
Fix transitions on iOS

### DIFF
--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -54,14 +54,10 @@ $ios-transition-container-bg-color:    #000 !default;
   [nav-bar="active"],
   [nav-bar="entering"] {
     z-index: $z-index-bar-above;
-
-   .bar {
-      background: transparent;
-    }
   }
 
   [nav-bar="cached"] {
-    display: block;
+    display: none;
   }
 
 }


### PR DESCRIPTION
Cached nav-bar is accidentally sort of visible on top of active nav-bar on iOS only. This is because its display is set to block, I believe, incorrectly. 

In addition, the active nav-bar has background always transparent on iOS only.
