### PR TITLE
Documentation update.

### DIFF
--- a/js/angular/service/popover.js
+++ b/js/angular/service/popover.js
@@ -188,7 +188,7 @@ function($ionicModal, $ionicPosition, $document, $window) {
      * content.
      * @param {object} options Options to be passed to the initialize method.
      * @returns {object} An instance of an {@link ionic.controller:ionicPopover}
-     * controller (ionicPopover is built on top of $ionicPopover).
+     * controller (ionicPopover is built on top of $ionicPopup).
      */
     fromTemplate: function(templateString, options) {
       return $ionicModal.fromTemplate(templateString, ionic.Utils.extend(options || {}, POPOVER_OPTIONS) );
@@ -199,7 +199,7 @@ function($ionicModal, $ionicPosition, $document, $window) {
      * @param {string} templateUrl The url to load the template from.
      * @param {object} options Options to be passed to the initialize method.
      * @returns {promise} A promise that will be resolved with an instance of
-     * an {@link ionic.controller:ionicPopover} controller (ionicPopover is built on top of $ionicPopover).
+     * an {@link ionic.controller:ionicPopover} controller (ionicPopover is built on top of $ionicPopup).
      */
     fromTemplateUrl: function(url, options, _) {
       return $ionicModal.fromTemplateUrl(url, options, ionic.Utils.extend(options || {}, POPOVER_OPTIONS) );


### PR DESCRIPTION
Changed docs to say "ionicPopover is built on top of $ionicPopup" instead of "ionicPopover is built on top of $ionicPopover". I believe that's what was originally intended.
