### PR TITLE
Collection Repeat With Search Input

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -166,6 +166,7 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
 
       var heightParsed = $parse($attr.collectionItemHeight || '"100%"');
       var widthParsed = $parse($attr.collectionItemWidth || '"100%"');
+      var listTopParsed = $parse($attr.collectionListTop || true);
 
       var heightGetter = function(scope, locals) {
         var result = heightParsed(scope, locals);
@@ -246,6 +247,9 @@ function($collectionRepeatManager, $collectionDataSource, $parse) {
         scrollView.resize();
         dataSource.setData(value, beforeSiblings, afterSiblings);
         collectionRepeatManager.resize();
+        if (listTopParsed) {
+          scrollView.scrollTo(0,0, false, null, true);
+        }
       }
 
       var requiresRerender;

--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -125,6 +125,8 @@
  *
  * @param {expression} collection-item-width The width of the repeated element.  Can be a number (in pixels) or a percentage.
  * @param {expression} collection-item-height The height of the repeated element.  Can be a number (in pixels), or a percentage.
+ * @param {expression} collection-list-top A boolean switch indicating that the list should scroll to the top upon list change or 
+ *   scrollView resize.  Defaults to `true`.
  *
  */
 var COLLECTION_REPEAT_SCROLLVIEW_XY_ERROR = "Cannot create a collection-repeat within a scrollView that is scrollable on both x and y axis.  Choose either x direction or y direction.";

--- a/test/unit/angular/directive/collectionRepeat.unit.js
+++ b/test/unit/angular/directive/collectionRepeat.unit.js
@@ -121,6 +121,7 @@ describe('collectionRepeat directive', function() {
     var el = setup('collection-repeat="item in items" collection-item-height="50"');
     var scrollView = el.controller('$ionicScroll').scrollView;
     spyOn(scrollView, 'resize');
+    spyOn(scrollView, 'scrollTo');
     dataSource.setData.reset();
     repeatManager.resize.reset();
 
@@ -128,16 +129,33 @@ describe('collectionRepeat directive', function() {
     expect(dataSource.setData).toHaveBeenCalledWith(el.scope().items, [], []);
     expect(repeatManager.resize.callCount).toBe(1);
     expect(scrollView.resize.callCount).toBe(1);
+    expect(scrollView.scrollTo).toHaveBeenCalledWith(0, 0, false, null, true);
     el.scope().$apply('items = null');
     expect(dataSource.setData).toHaveBeenCalledWith(null, [], []);
     expect(repeatManager.resize.callCount).toBe(2);
     expect(scrollView.resize.callCount).toBe(2);
+    expect(scrollView.scrollTo).toHaveBeenCalledWith(0, 0, false, null, true);
+  });
+
+  it('should rerender not scroll top of list', function() {
+    var el = setup('collection-repeat="item in items" collection-item-height="50" collection-list-top=false');
+    var scrollView = el.controller('$ionicScroll').scrollView;
+    spyOn(scrollView, 'resize');
+    spyOn(scrollView, 'scrollTo');
+    dataSource.setData.reset();
+    repeatManager.resize.reset();
+
+    el.scope().$apply('items = [ 1,2,3 ]');
+    expect(scrollView.scrollTo).not.toHaveBeenCalled;
+    el.scope().$apply('items = null');
+    expect(scrollView.scrollTo).not.toHaveBeenCalled;
   });
 
   it('should rerender on window resize', function() {
     var el = setup('collection-repeat="item in items" collection-item-height="50"');
     var scrollView = el.controller('$ionicScroll').scrollView;
     spyOn(scrollView, 'resize');
+    spyOn(scrollView, 'scrollTo');
     dataSource.setData.reset();
     repeatManager.resize.reset();
 
@@ -147,6 +165,21 @@ describe('collectionRepeat directive', function() {
     expect(dataSource.setData).toHaveBeenCalledWith(el.scope().items, [], []);
     expect(repeatManager.resize.callCount).toBe(1);
     expect(scrollView.resize.callCount).toBe(1);
+    expect(scrollView.scrollTo).toHaveBeenCalledWith(0, 0, false, null, true);
+  });
+
+  it('should rerender not scroll top on window resize', function() {
+    var el = setup('collection-repeat="item in items" collection-item-height="50" collection-list-top=false');
+    var scrollView = el.controller('$ionicScroll').scrollView;
+    spyOn(scrollView, 'resize');
+    spyOn(scrollView, 'scrollTo');
+    dataSource.setData.reset();
+    repeatManager.resize.reset();
+
+    el.scope().items = [1,2,3];
+
+    ionic.trigger('resize', { target: window });
+    expect(scrollView.scrollTo).not.toHaveBeenCalled;
   });
 
   it('should rerender on scrollCtrl resize', inject(function($timeout) {


### PR DESCRIPTION
See my post on the [forum](http://forum.ionicframework.com/t/issue-filtering-items-in-collection-repeat-with-search-box/11804/1) which outlines an issue with re-rendering a collection-repeat list following a filter being applied through a search input. If I first scroll down the list and then enter the search term, the new filtered list is not scrolled to the top. You can reproduce in this [codepen](http://codepen.io/afq/pen/jiqcu). The items are all there and present but the scroll view doesn't seem to resize. If you delete the search input text and re-enter again, it all works fine as the scroll has been reset to the top of the list.

On a project I was working on, I implemented a temporary fix by adding `scrollView.scrollTo(0,0, false, null, true);` to the end of the `renderer(value)` function within the collectionRepeat directive in ionic.bundle.js.

I'm not sure if this is the best way to resolve this issue but if someone wants to advise/confirm the best solution, I will happily create a PR with a fix.