### PR TITLE
Fixes #2649: text not vertically centered when using .button on an ancho...

### DIFF
--- a/scss/_button.scss
+++ b/scss/_button.scss
@@ -25,7 +25,7 @@
 
   text-overflow: ellipsis;
   font-size: $button-font-size;
-  line-height: $button-height - $button-border-width + 1px;
+  line-height: $button-height + 5px;
 
   cursor: pointer;
 


### PR DESCRIPTION
Using a smaller line-height than actual height causes misalignment on anchors. This commit changes the line-height of .button to match the min-height.
