### PR TITLE
Attempt to address https://github.com/driftyco/ionic/issues/2682.

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -14,7 +14,13 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody) {
 
   self.initialize = function(options) {
     self.left = options.left;
+    if (!isAsideExposed && self.left.hideWhenClosed) {
+    	self.left.hide();
+    }
     self.right = options.right;
+    if (!isAsideExposed && self.right.hideWhenClosed) {
+    	self.right.hide();
+    }
     self.setContent(options.content);
     self.dragThresholdX = options.dragThresholdX || 10;
   };
@@ -176,10 +182,16 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody) {
       rightShowing = false;
 
       if(amount > 0) {
+      	if (self.left.hideWhenClosed) {
+      		self.left.unhide();
+      	}
         // Push the z-index of the right menu down
         self.right && self.right.pushDown && self.right.pushDown();
         // Bring the z-index of the left menu up
         self.left && self.left.bringUp && self.left.bringUp();
+      }
+      else if(self.left.hideWhenClosed) {
+      	self.left.hide();
       }
     } else {
       rightShowing = true;
@@ -268,6 +280,9 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody) {
     // otherwise set false so there's no left margin
     self.content.setMarginLeft( isAsideExposed ? self.left.width : 0 );
 
+    if(self.left.hideWhenClosed) {
+      self.left.unhide();
+    }
     self.$scope.$emit('$ionicExposeAside', isAsideExposed);
   };
 

--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -13,7 +13,8 @@
  * <ion-side-menu
  *   side="left"
  *   width="myWidthValue + 20"
- *   is-enabled="shouldLeftSideMenuBeEnabled()">
+ *   is-enabled="shouldLeftSideMenuBeEnabled()"
+ *   hide-when-closed="true">
  * </ion-side-menu>
  * ```
  * For a complete side menu example, see the
@@ -22,6 +23,8 @@
  * @param {string} side Which side the side menu is currently on.  Allowed values: 'left' or 'right'.
  * @param {boolean=} is-enabled Whether this side menu is enabled.
  * @param {number=} width How many pixels wide the side menu should be.  Defaults to 275.
+ * @param {boolean=} hide-when-closed If true the menu will have visibility set to hidden whenever it is closed. Defaults to false.
+ * 
  */
 IonicModule
 .directive('ionSideMenu', function() {
@@ -32,7 +35,8 @@ IonicModule
     compile: function(element, attr) {
       angular.isUndefined(attr.isEnabled) && attr.$set('isEnabled', 'true');
       angular.isUndefined(attr.width) && attr.$set('width', '275');
-
+      angular.isUndefined(attr.hideWhenClosed) && attr.$set('hideWhenClosed', 'false');
+      
       element.addClass('menu menu-' + attr.side);
 
       return function($scope, $element, $attr, sideMenuCtrl) {
@@ -41,7 +45,8 @@ IonicModule
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
           width: attr.width,
           el: $element[0],
-          isEnabled: true
+          isEnabled: true,
+          hideWhenClosed: false
         });
 
         $scope.$watch($attr.width, function(val) {
@@ -52,6 +57,9 @@ IonicModule
         });
         $scope.$watch($attr.isEnabled, function(val) {
           sideMenu.setIsEnabled(!!val);
+        });
+        $scope.$watch($attr.hideWhenClosed, function(val) {
+          sideMenu.setHideWhenClosed(!!val);
         });
       };
     }

--- a/js/views/sideMenuView.js
+++ b/js/views/sideMenuView.js
@@ -11,6 +11,7 @@
       this.el = opts.el;
       this.isEnabled = (typeof opts.isEnabled === 'undefined') ? true : opts.isEnabled;
       this.setWidth(opts.width);
+      this.setHideWhenClosed((typeof opts.hideWhenClosed === 'undefined') ? false : opts.hideWhenClosed);
     },
     getFullWidth: function() {
       return this.width;
@@ -22,6 +23,12 @@
     setIsEnabled: function(isEnabled) {
       this.isEnabled = isEnabled;
     },
+    setHideWhenClosed: function(hideWhenClosed) {
+    	this.hideWhenClosed = hideWhenClosed;
+        if (this.hideWhenClosed) {
+          this.hide();
+        }
+    },
     bringUp: function() {
       if(this.el.style.zIndex !== '0') {
         this.el.style.zIndex = '0';
@@ -31,6 +38,12 @@
       if(this.el.style.zIndex !== '-1') {
         this.el.style.zIndex = '-1';
       }
+    },
+    hide: function() {
+    	this.el.style.visibility = 'hidden';
+    },
+    unhide: function() {
+    	this.el.style.visibility = 'visible';
     }
   });
 


### PR DESCRIPTION
Adds an optional hide-when-closed attribute to the ion-side-menu
directive. If this attribute is set to "true" the side menu will be
hidden from the document layout whenever it is closed.

This was branched from the v1.0.0.-beta.13 tagged branch

It's my first pull request, so apologies for perhaps not quite adhering to the guidelines yet....