### PR TITLE
feat(keyboard): option to keep the keyboard opened when changing route

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -692,7 +692,9 @@ function($rootScope, $state, $location, $document, $ionicPlatform, $ionicHistory
 
   // always reset the keyboard state when change stage
   $rootScope.$on('$stateChangeStart', function() {
-    ionic.keyboard && ionic.keyboard.hide && ionic.keyboard.hide();
+    if ( !toState || !toState.data || !toState.data.keepKeyboard ) {
+      ionic.keyboard && ionic.keyboard.hide && ionic.keyboard.hide();
+    }
   });
 
   $rootScope.$on('$ionicHistory.change', function(e, data) {


### PR DESCRIPTION
You add:
data : { keepKeyboard: true }

and the keyboard stays when you change route.
usefull with search bar in the header.
