### PR TITLE
feat(slidebox): Add a callback for swipe last slide but not looping.

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -34,6 +34,7 @@
  * @param {expression=} pager-click Expression to call when a pager is clicked (if show-pager is true). Is passed the 'index' variable.
  * @param {expression=} on-slide-changed Expression called whenever the slide is changed.  Is passed an '$index' variable.
  * @param {expression=} active-slide Model to bind the current slide to.
+ * @param {expression=} on-last-slide-slided Expression called when the last slide is slided but not looping to first slide.
  */
 IonicModule
 .directive('ionSlideBox', [
@@ -54,7 +55,8 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
-      activeSlide: '=?'
+      activeSlide: '=?',
+      onLastSlideSlided: '&',
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       var _this = this;
@@ -80,6 +82,11 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
           $scope.$parent.$broadcast('slideBox.slideChanged', slideIndex);
           $scope.activeSlide = slideIndex;
           // Try to trigger a digest
+          $timeout(function() {});
+        },
+        lastSlideSlided: function() {
+          $scope.onLastSlideSlided();
+          $scope.$parent.$broadcast('slideBox.lastSlideSlided');
           $timeout(function() {});
         }
       });

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -435,6 +435,7 @@ ionic.views.Slider = ionic.views.View.inherit({
               move(index-1, -width, speed);
               move(index, 0, speed);
               move(index+1, width, speed);
+              offloadFn(options.lastSlideSlided && options.lastSlideSlided());
             }
 
           }


### PR DESCRIPTION
This callback is particular useful to me. I use the slidebox for the tutorial of my app. Unlike the demo, my tutorial is full screen. I do not have place for a button saying "Start using my app". So when user swipe the last slide of the tutorial, they start to use the app. I have observed this behavior in many apps.
