### PR TITLE
feat(slidebox): Add a callback for valid swipe that encountered resistance because reached the bound and not looping

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -56,7 +56,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
       disableScroll: '@',
       onSlideChanged: '&',
       activeSlide: '=?',
-      onLastSlideSlided: '&',
+      onSlideResisted: '&',
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       var _this = this;
@@ -84,9 +84,9 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
           // Try to trigger a digest
           $timeout(function() {});
         },
-        lastSlideSlided: function() {
-          $scope.onLastSlideSlided();
-          $scope.$parent.$broadcast('slideBox.lastSlideSlided');
+        slideResisted: function() {
+          $scope.onSlideResisted();
+          $scope.$parent.$broadcast('slideBox.slideResisted');
           $timeout(function() {});
         }
       });

--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -34,6 +34,7 @@
  * @param {expression=} pager-click Expression to call when a pager is clicked (if show-pager is true). Is passed the 'index' variable.
  * @param {expression=} on-slide-changed Expression called whenever the slide is changed.  Is passed an '$index' variable.
  * @param {expression=} active-slide Model to bind the current slide to.
+ * @param {expression=} on-last-slide-slided Expression called when the last slide is slided but not looping to first slide.
  */
 IonicModule
 .directive('ionSlideBox', [
@@ -54,7 +55,8 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
-      activeSlide: '=?'
+      activeSlide: '=?',
+      onLastSlideSlided: '&',
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       var _this = this;
@@ -80,6 +82,11 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
           $scope.$parent.$broadcast('slideBox.slideChanged', slideIndex);
           $scope.activeSlide = slideIndex;
           // Try to trigger a digest
+          $timeout(function() {});
+        },
+        lastSlideSlided: function() {
+          $scope.onLastSlideSlided();
+          $scope.$parent.$broadcast('slideBox.lastSlideSlided');
           $timeout(function() {});
         }
       });

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -435,6 +435,7 @@ ionic.views.Slider = ionic.views.View.inherit({
               move(index-1, -width, speed);
               move(index, 0, speed);
               move(index+1, width, speed);
+              offloadFn(options.lastSlideSlided && options.lastSlideSlided());
             }
 
           }

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -345,15 +345,17 @@ ionic.views.Slider = ionic.views.View.inherit({
             translate(circle(index+1), delta.x + slidePos[circle(index+1)], 0);
 
           } else {
-
-            delta.x =
-              delta.x /
-                ( (!index && delta.x > 0 ||         // if first slide and sliding left
+            var resistance = (!index && delta.x > 0 ||         // if first slide and sliding left
                   index == slides.length - 1 &&     // or if last slide and sliding right
                   delta.x < 0                       // and if sliding at all
-                ) ?
-                ( Math.abs(delta.x) / width + 1 )      // determine resistance level
-                : 1 );                                 // no resistance if false
+                );
+
+            if(resistance){
+              delta.xBeforeResistance = delta.x;
+              // determine resistance level
+              // no resistance if false
+              delta.x = delta.x / ( Math.abs(delta.x) / width + 1 ); 
+            }
 
             // translate 1:1
             translate(index-1, delta.x + slidePos[index-1], 0);
@@ -369,11 +371,14 @@ ionic.views.Slider = ionic.views.View.inherit({
         // measure duration
         var duration = +new Date() - start.time;
 
+        // if slide duration is less than 250ms and slide amt is greater than 20px
+        var isValidFastSlide = Number(duration) < 250 && Math.abs(delta.x) > 20;
+
+        // if slided amt (or amt before resistence) past half of the width
+        var isValidSlowSlide = Math.abs(delta.x) > width/2;
+
         // determine if slide attempt triggers next/prev slide
-        var isValidSlide =
-              Number(duration) < 250 &&         // if slide duration is less than 250ms
-              Math.abs(delta.x) > 20 ||         // and if slide amt is greater than 20px
-              Math.abs(delta.x) > width/2;      // or if slide amt is greater than half the width
+        var isValidSlide = isValidFastSlide || isValidSlowSlide;
 
         // determine if slide attempt is past start and end
         var isPastBounds = (!index && delta.x > 0) ||      // if first slide and slide amt is greater than 0
@@ -435,7 +440,20 @@ ionic.views.Slider = ionic.views.View.inherit({
               move(index-1, -width, speed);
               move(index, 0, speed);
               move(index+1, width, speed);
-              offloadFn(options.lastSlideSlided && options.lastSlideSlided());
+
+              if (delta.xBeforeResistance) {
+                // if slide duration is less than 250ms and slide amt is greater than 20px
+                var isValidFastSlideBeforeResistance = Number(duration) < 250 && Math.abs(delta.xBeforeResistance) > 20;
+
+                // if slided amt (or amt before resistence) past half of the width
+                var isValidSlowSlideBeforeResistance = Math.abs(delta.xBeforeResistance) > width/2;
+
+                var isValidSlideBeforeResistance = isValidFastSlideBeforeResistance || isValidSlowSlideBeforeResistance;
+                
+                if (isValidSlideBeforeResistance) {
+                  offloadFn(options.slideResisted && options.slideResisted());
+                }
+              }
             }
 
           }


### PR DESCRIPTION
This callback is particular useful to me. I use the slidebox for the tutorial of my app. Unlike the demo, my tutorial is full screen. I do not have place for a button saying "Start using my app". So when user swipe the last slide of the tutorial, they start to use the app. I have observed this behavior in many apps.
My previous pull request was not properly implemented https://github.com/driftyco/ionic/pull/2710 . I had to save the delta.x for before the resistance take effect and then decide if I should fire the callback when an invalid swipe was made.