### PR TITLE
Slightly increased the value of TAP_RELEASE_TOLERANCE constant

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -79,7 +79,7 @@ var tapLastTouchTarget;
 var tapTouchMoveListener = 'touchmove';
 
 // how much the coordinates can be off between start/end, but still a click
-var TAP_RELEASE_TOLERANCE = 6; // default tolerance
+var TAP_RELEASE_TOLERANCE = 12; // default tolerance
 var TAP_RELEASE_BUTTON_TOLERANCE = 50; // button elements should have a larger tolerance
 
 var tapEventListeners = {


### PR DESCRIPTION
While testing Ionic on an iPad Retina, my team (cc @jvelo @louisbeziau) and myself were surprised about the number of “missclicks” we noticed when clicking on elements with an `ng-click` directive. However, [the buttons](http://ionicframework.com/docs/components/#buttons) weren't affected by this behaviour.

After digging into Ionic's code, I found a solution. When you move too much your finger while tapping an element, the tap is cancelled, this is okay but the tolerance is way too low for any elements other than buttons. While buttons have a tolerance of `50px`, other elements only have `6px`. I increased this last value to `12px` without noticing any strange behaviour with other Ionic's components and the missclick problems were solved.

One thing if you want to verify the improvement: this issue was especially encountered when we grazed the iPad.

Maybe this behaviour have been encountered on other devices but we only had an iPad to test this.
