### PR TITLE
feat(on-slide-move): add callback to ion-slide-box on slide move

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -54,6 +54,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
+      onSlideMove: '&',
       activeSlide: '=?'
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
@@ -81,6 +82,13 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory) {
           $scope.activeSlide = slideIndex;
           // Try to trigger a digest
           $timeout(function() {});
+        },
+        transitionCallback: function(slideIndex, distance, duration) {
+          $scope.onSlideMove({
+            index: slideIndex, $index: slideIndex,
+            distance: distance, $distance: distance,
+            duration: duration, $duration: duration
+          });
         }
       });
 

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -182,6 +182,7 @@ ionic.views.Slider = ionic.views.View.inherit({
       style.MozTransform =
       style.OTransform = 'translateX(' + dist + 'px)';
 
+      offloadFn(options.transitionCallback && options.transitionCallback(index, dist, speed));
     }
 
     function animate(from, to, speed) {


### PR DESCRIPTION
Hi,

I wanted to implement some kind of parallax effect during dragging of `ion-slide-box`, then I searched for a functionality that invokes a callback on slide move, but there seems not to be such a callback.

Could you please consider adding `on-slide-move` callback to `ion-slide-box`?