### PR TITLE
Changed doc.

### DIFF
--- a/js/angular/service/ionicConfig.js
+++ b/js/angular/service/ionicConfig.js
@@ -143,7 +143,7 @@
 /**
  * @ngdoc method
  * @name $ionicConfigProvider#navBar.alignTitle
- * @description Which side of the navBar to align the title. Default `center`.
+ * @description Which side of the navBar to align the title. Default `platform`.
  *
  * @param {string} value side of the navBar to align the title.
  *


### PR DESCRIPTION
Default value for navBar.alignTitle is 'platform', not 'center'.
