### PR TITLE
fix the bug

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -148,7 +148,7 @@ function keyboardBrowserFocusIn(e) {
   document.addEventListener('keydown', keyboardOnKeyDown, false);
 
   document.body.scrollTop = 0;
-  document.body.querySelector('.scroll-content').scrollTop = 0;
+  document.body.querySelector('.scroll-content:not(.overflow-scroll)').scrollTop = 0;
 
   keyboardActiveElement = e.target;
 


### PR DESCRIPTION
fix the bug: Using overflow-scroll, the page will scroll to the top when tap on the input or textarea.