### PR TITLE
fix(scroll): ignore events during slide-box slide

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -736,7 +736,8 @@ ionic.views.Scroll = ionic.views.View.inherit({
     };
 
     self.touchMove = function(e) {
-      if (!self.__isDown ||
+      if (ionic.slide.isSliding ||
+        !self.__isDown ||
         (!self.__isDown && e.defaultPrevented) ||
         (e.target.tagName === 'TEXTAREA' && e.target.parentElement.querySelector(':focus')) ) {
         return;

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -334,6 +334,8 @@ ionic.views.Slider = ionic.views.View.inherit({
           // prevent native scrolling
           event.preventDefault();
 
+          ionic.slide.isSliding = true;
+
           // stop slideshow
           stop();
 
@@ -365,6 +367,8 @@ ionic.views.Slider = ionic.views.View.inherit({
 
       },
       end: function(event) {
+
+        ionic.slide.isSliding = false;
 
         // measure duration
         var duration = +new Date() - start.time;
@@ -612,5 +616,9 @@ ionic.views.Slider = ionic.views.View.inherit({
 
   }
 });
+
+ionic.slide = {
+  isSliding: false
+};
 
 })(ionic);


### PR DESCRIPTION
I don't expect this PR to be merged. @mhartington [mentioned](http://forum.ionicframework.com/t/beta-14-slide-box-limit-scroll-whilst-sliding/14393/3) there was a refactoring of the slidebox going on, so this probably isn't aligned with those efforts. Nonetheless, I thought it might be helpful for others affected by the "scroll leak" introduced in beta 14.

The details of the bug can be found in various issues on the forum:

- http://forum.ionicframework.com/t/beta14-slide-box-vertical-scroll-behaviour
- http://forum.ionicframework.com/t/beta-14-slide-box-limit-scroll-whilst-sliding
- http://forum.ionicframework.com/t/ion-content-scroll-locking-doesnt-work

The implementation followed the lead of `ionic.scroll.isScrolling` by introducing `ionic.slide.isSliding` so that the two may communicate as necessary. isSliding turns on during a slide view's `touchmove` and off in `touchend`. When isSliding is true, it interrupts any scroll view scrolling events.

Tests didn't break, but I also didn't add any tests (back to not thinking this would be merged). If I was mistaken, or this is terrible for other reasons I cannot see, please let me know!

Thanks, and Happy Holidays ionic team!