### PR TITLE
Fix Scroll Locking in ion-content/ion-scroll

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -731,7 +731,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
       self.__isSelectable = true;
       self.__enableScrollY = true;
       self.__hasStarted = true;
-      self.__scrollLockFix = {direction: null};
+      self.__scrollLockFix = {direction: null, doFix: false};
       self.doTouchStart(getEventTouches(e), e.timeStamp);
       e.preventDefault();
     };
@@ -773,15 +773,21 @@ ionic.views.Scroll = ionic.views.View.inherit({
         }
       }
 
-      if(self.options.locking){
-        if(!self.__scrollLockFix.direction){
-          self.__scrollLockFix.direction = Math.abs(e.touches[0].pageX - self.__initialTouchLeft) > Math.abs(e.touches[0].pageY - self.__initialTouchTop);
+      if(self.options.locking && self.__scrollLockFix.direction === null){
+        var detect = 5,
+            dx = Math.abs(e.touches[0].pageX - self.__initialTouchLeft), dy = Math.abs(e.touches[0].pageY - self.__initialTouchTop);
+        if(dx > detect || dy > detect){
+          self.__scrollLockFix.direction = dx > dy;
+          self.__scrollLockFix.doFix = true;
         }
-        var dir = self.__scrollLockFix.direction;
+      }
+      var dir = self.__scrollLockFix.direction;
+      if(self.__scrollLockFix.doFix){
         self.doTouchMove([{pageX: dir ? e.touches[0].pageX : self.__initialTouchLeft, pageY: dir ? self.__initialTouchTop : e.touches[0].pageY}], e.timeStamp, e.scale);
       }else{
         self.doTouchMove(getEventTouches(e), e.timeStamp, e.scale);
       }
+
       self.__isDown = true;
     };
 

--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -731,7 +731,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
       self.__isSelectable = true;
       self.__enableScrollY = true;
       self.__hasStarted = true;
-      self.__scrollLockFix = {direction: null, doFix: false};
+      if(!ionic.scroll.isScrolling) self.__scrollLockFix = {direction: null, doFix: false};
       self.doTouchStart(getEventTouches(e), e.timeStamp);
       e.preventDefault();
     };
@@ -773,7 +773,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
         }
       }
 
-      if(self.options.locking && self.__scrollLockFix.direction === null){
+      if(self.options.locking && !self.__scrollLockFix.doFix){
         var detect = 5,
             dx = Math.abs(e.touches[0].pageX - self.__initialTouchLeft), dy = Math.abs(e.touches[0].pageY - self.__initialTouchTop);
         if(dx > detect || dy > detect){
@@ -781,9 +781,12 @@ ionic.views.Scroll = ionic.views.View.inherit({
           self.__scrollLockFix.doFix = true;
         }
       }
-      var dir = self.__scrollLockFix.direction;
       if(self.__scrollLockFix.doFix){
-        self.doTouchMove([{pageX: dir ? e.touches[0].pageX : self.__initialTouchLeft, pageY: dir ? self.__initialTouchTop : e.touches[0].pageY}], e.timeStamp, e.scale);
+        var dir = self.__scrollLockFix.direction;
+        self.doTouchMove([{
+          pageX: dir ? e.touches[0].pageX : self.__initialTouchLeft,
+          pageY: dir ? self.__initialTouchTop : e.touches[0].pageY
+        }], e.timeStamp, e.scale);
       }else{
         self.doTouchMove(getEventTouches(e), e.timeStamp, e.scale);
       }

--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -731,6 +731,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
       self.__isSelectable = true;
       self.__enableScrollY = true;
       self.__hasStarted = true;
+      self.__scrollLockFix = {direction: null};
       self.doTouchStart(getEventTouches(e), e.timeStamp);
       e.preventDefault();
     };
@@ -772,7 +773,15 @@ ionic.views.Scroll = ionic.views.View.inherit({
         }
       }
 
-      self.doTouchMove(getEventTouches(e), e.timeStamp, e.scale);
+      if(self.options.locking){
+        if(!self.__scrollLockFix.direction){
+          self.__scrollLockFix.direction = Math.abs(e.touches[0].pageX - self.__initialTouchLeft) > Math.abs(e.touches[0].pageY - self.__initialTouchTop);
+        }
+        var dir = self.__scrollLockFix.direction;
+        self.doTouchMove([{pageX: dir ? e.touches[0].pageX : self.__initialTouchLeft, pageY: dir ? self.__initialTouchTop : e.touches[0].pageY}], e.timeStamp, e.scale);
+      }else{
+        self.doTouchMove(getEventTouches(e), e.timeStamp, e.scale);
+      }
       self.__isDown = true;
     };
 


### PR DESCRIPTION
This is a quick fix for the `locking` property for `ion-content` and `ion-scroll`. In the current version of Ionic, setting `locking` to `true` will not actually lock the scroll direction if dragged with an angle in the beginning.

A more detailed description of the issue can be found here: http://forum.ionicframework.com/t/ion-content-scroll-locking-doesnt-work/14445

This fix is done by modifying the `doTouchMove` invocation to only accept one change in direction at a time, if `locking` is set to `true`. This seems to fix the issue in my tests, however I'm not sure if there's anything else that is affected by this change.