### PR TITLE
fix .has-header.has-tabs-top positioning

### DIFF
--- a/scss/_scaffolding.scss
+++ b/scss/_scaffolding.scss
@@ -313,7 +313,7 @@ ion-infinite-scroll {
 .has-subheader {
   top: $bar-height * 2;
 }
-.has-tabs-top {
+.has-header.has-tabs-top {
   top: $bar-height + $tabs-height;
 }
 .has-header.has-subheader.has-tabs-top {


### PR DESCRIPTION
Refer to this example http://plnkr.co/edit/niNKWksQksgEGUlS8243

When an ion-content has classes `has-tabs-top` and `has-header` and `pane`, the top position is set to `0` because `pane` wins. That makes the tab content hidden under the header and tabs. This fix sets the top positioning correctly