### PR TITLE
fix(slidebox): sliderView.js no "data-tap-disabled" rule respected

### DIFF
--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -309,7 +309,8 @@ ionic.views.Slider = ionic.views.View.inherit({
         // ensure sliding is enabled
         if (event.touches.length > 1 ||
             event.scale && event.scale !== 1 ||
-            slider.slideIsDisabled) {
+            slider.slideIsDisabled ||
+            event.target.getAttribute('data-tap-disabled') == 'true') {
           return;
         }
 


### PR DESCRIPTION
No data-tap-disabled rule is respected inside the slidebox.
With this fix the slide wont scroll if a data-tap-disabled is set.