### PR TITLE
feature: self-centering for scroll-view content

### DIFF
--- a/release/js/ionic-angular.js
+++ b/release/js/ionic-angular.js
@@ -10278,7 +10278,8 @@ function($timeout, $controller, $ionicBind) {
           scrollbarY: '@',
           zooming: '@',
           minZoom: '@',
-          maxZoom: '@'
+          maxZoom: '@',
+          selfCentre: '@'
         });
         $scope.direction = $scope.direction || 'y';
 
@@ -10307,6 +10308,7 @@ function($timeout, $controller, $ionicBind) {
           zooming: $scope.$eval($scope.zooming) === true,
           maxZoom: $scope.$eval($scope.maxZoom) || 3,
           minZoom: $scope.$eval($scope.minZoom) || 0.5,
+          selfCentre: $scope.$eval($scope.selfCentre) === true,
           preventDefault: true
         };
         if (isPaging) {

--- a/release/js/ionic.bundle.js
+++ b/release/js/ionic.bundle.js
@@ -4228,7 +4228,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.options = {
  
       /** Enable self centering when the content is smaller in dimension than client */
-      selfCentre: false,
+      selfCenter: false,
 
       /** Disable scrolling on x-axis by default */
       scrollingX: false,
@@ -4489,9 +4489,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
   __scheduledZoom: 0,
 
   /* Self centering offsets */
-  __selfCentreLeftOffset : 0,
+  __selfCenterLeftOffset : 0,
 
-  __selfCentreTopOffset : 0,
+  __selfCenterTopOffset : 0,
 
 
   /*
@@ -5103,7 +5103,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     if (!self.__container || !self.options) return;
 
      //if selfcentering is on, content width should not be stretched to 100% (which is the default behaviour of display:block)
-    if(self.options.selfCentre)
+    if(self.options.selfCenter)
       self.__content.style.display="inline-block";
     
     // Update Scroller dimensions for changed content
@@ -5842,9 +5842,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
 /** calculate selfcentering offsets @oxylab
   */
-  calcSelfCentre : function(zoom)
+  calcSelfCenter : function(zoom)
   {         var self=this;
-    if(!self.options.selfCentre)return;
+    if(!self.options.selfCenter)return;
             var xoffset = 0;
             var yoffset = 0;
 
@@ -5859,8 +5859,8 @@ ionic.views.Scroll = ionic.views.View.inherit({
                 }else{
                     yoffset = 0;
                 }
-            self.__selfCentreLeftOffset = xoffset;
-            self.__selfCentreTopOffset = yoffset;
+            self.__selfCenterLeftOffset = xoffset;
+            self.__selfCenterTopOffset = yoffset;
         },
 
   /**
@@ -6034,7 +6034,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
           // Push values out
           if (self.__callback) {
-           self.__callback(self.__scrollLeft-self.__selfCentreLeftOffset,self.__scrollTop-self.__selfCentreTopOffset,
+           self.__callback(self.__scrollLeft-self.__selfCenterLeftOffset,self.__scrollTop-self.__selfCenterTopOffset,
               self.__zoomLevel, wasResize);
          }
 
@@ -6069,7 +6069,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
       // Push values out
       if (self.__callback) {
-        self.__callback(left-self.__selfCentreLeftOffset, top-self.__selfCentreTopOffset, zoom, wasResize);
+        self.__callback(left-self.__selfCenterLeftOffset, top-self.__selfCenterTopOffset, zoom, wasResize);
       }
 
       // Fix max scroll ranges
@@ -6098,7 +6098,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
       self.__waitForSize();
     }
      //Recompute deadOffsets @oxylab
-          self.calcSelfCentre(zoomLevel);
+          self.calcSelfCenter(zoomLevel);
    
   },
 
@@ -51221,7 +51221,7 @@ function($timeout, $controller, $ionicBind) {
           zooming: '@',
           minZoom: '@',
           maxZoom: '@',
-          selfCentre: '@'
+          selfCenter: '@'
         
         });
         $scope.direction = $scope.direction || 'y';
@@ -51251,7 +51251,7 @@ function($timeout, $controller, $ionicBind) {
           zooming: $scope.$eval($scope.zooming) === true,
           maxZoom: $scope.$eval($scope.maxZoom) || 3,
           minZoom: $scope.$eval($scope.minZoom) || 0.5,
-          selfCentre: $scope.$eval($scope.selfCentre) === true,
+          selfCenter: $scope.$eval($scope.selfCenter) === true,
           preventDefault: true
         };
         if (isPaging) {

--- a/release/js/ionic.bundle.js
+++ b/release/js/ionic.bundle.js
@@ -5707,8 +5707,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
           var currentTouchTopRel = currentTouchTop - self.__clientTop;
 
           // Recompute left and top coordinates based on new zoom level
-          scrollLeft = ((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
-          scrollTop = ((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
+          // if self-centering enabled and dimension of content less than client , set cordinate as zero
+          scrollLeft = (self.__clientWidth>(self.__contentWidth*level))?0:((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
+          scrollTop = (self.__clientHeight>(self.__contentHeight*level))?0:((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
 
           // Recompute max scroll values
           self.__computeScrollMax(level);

--- a/release/js/ionic.js
+++ b/release/js/ionic.js
@@ -4221,7 +4221,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.options = {
 
       /** Enable self centering when the content is smaller in dimension than client */
-      selfCentre: false,
+      selfCenter: false,
 
       /** Disable scrolling on x-axis by default */
       scrollingX: false,
@@ -4482,9 +4482,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
   __scheduledZoom: 0,
 
   /* Self centering offsets */
-  __selfCentreLeftOffset : 0,
+  __selfCenterLeftOffset : 0,
 
-  __selfCentreTopOffset : 0,
+  __selfCenterTopOffset : 0,
 
 
 
@@ -5097,7 +5097,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     if (!self.__container || !self.options) return;
      
      //if selfcentering is on, content width should not be stretched to 100% (which is the default behaviour of display:block)
-    if(self.options.selfCentre)
+    if(self.options.selfCenter)
       self.__content.style.display="inline-block";
     
     // Update Scroller dimensions for changed content
@@ -5836,9 +5836,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
 /** calculate selfcentering offsets @oxylab
   */
-  calcSelfCentre : function(zoom)
+  calcSelfCenter : function(zoom)
   {         var self=this;
-    if(!self.options.selfCentre)return;
+    if(!self.options.selfCenter)return;
             var xoffset = 0;
             var yoffset = 0;
 
@@ -5853,8 +5853,8 @@ ionic.views.Scroll = ionic.views.View.inherit({
                 }else{
                     yoffset = 0;
                 }
-            self.__selfCentreLeftOffset = xoffset;
-            self.__selfCentreTopOffset = yoffset;
+            self.__selfCenterLeftOffset = xoffset;
+            self.__selfCenterTopOffset = yoffset;
         },
 
 
@@ -6029,7 +6029,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
           // Push values out
           if (self.__callback) {
-            self.__callback(self.__scrollLeft-self.__selfCentreLeftOffset,self.__scrollTop-self.__selfCentreTopOffset,
+            self.__callback(self.__scrollLeft-self.__selfCenterLeftOffset,self.__scrollTop-self.__selfCenterTopOffset,
               self.__zoomLevel, wasResize);
          }
 
@@ -6064,7 +6064,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
       // Push values out
       if (self.__callback) {
-        self.__callback(left-self.__selfCentreLeftOffset, top-self.__selfCentreTopOffset, zoom, wasResize);
+        self.__callback(left-self.__selfCenterLeftOffset, top-self.__selfCenterTopOffset, zoom, wasResize);
       }
 
       // Fix max scroll ranges
@@ -6094,7 +6094,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     }
     
     //Recompute deadOffsets @oxylab
-          self.calcSelfCentre(zoomLevel);
+          self.calcSelfCenter(zoomLevel);
     
   },
 

--- a/release/js/ionic.js
+++ b/release/js/ionic.js
@@ -5701,8 +5701,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
           var currentTouchTopRel = currentTouchTop - self.__clientTop;
 
           // Recompute left and top coordinates based on new zoom level
-          scrollLeft = ((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
-          scrollTop = ((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
+          // if self-centering enabled and dimension of content less than client , set cordinate as zero
+          scrollLeft = (self.__clientWidth>(self.__contentWidth*level))?0:((currentTouchLeftRel + scrollLeft) * level / oldLevel) - currentTouchLeftRel;
+          scrollTop = (self.__clientHeight>(self.__contentHeight*level))?0:((currentTouchTopRel + scrollTop) * level / oldLevel) - currentTouchTopRel;
 
           // Recompute max scroll values
           self.__computeScrollMax(level);

--- a/release/js/ionic.js
+++ b/release/js/ionic.js
@@ -4220,6 +4220,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
     self.options = {
 
+      /** Enable self centering when the content is smaller in dimension than client */
+      selfCentre: false,
+
       /** Disable scrolling on x-axis by default */
       scrollingX: false,
       scrollbarX: true,
@@ -4477,6 +4480,11 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
   /* Scheduled zoom level (final scale when animating) */
   __scheduledZoom: 0,
+
+  /* Self centering offsets */
+  __selfCentreLeftOffset : 0,
+
+  __selfCentreTopOffset : 0,
 
 
 
@@ -5087,7 +5095,11 @@ ionic.views.Scroll = ionic.views.View.inherit({
   resize: function() {
     var self = this;
     if (!self.__container || !self.options) return;
-
+     
+     //if selfcentering is on, content width should not be stretched to 100% (which is the default behaviour of display:block)
+    if(self.options.selfCentre)
+      self.__content.style.display="inline-block";
+    
     // Update Scroller dimensions for changed content
     // Add padding to bottom of content
     self.setDimensions(
@@ -5821,6 +5833,29 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
   },
 
+/** calculate selfcentering offsets @oxylab
+  */
+  calcSelfCentre : function(zoom)
+  {         var self=this;
+    if(!self.options.selfCentre)return;
+            var xoffset = 0;
+            var yoffset = 0;
+
+                if (self.__clientWidth>(self.__contentWidth*zoom)){
+                    xoffset = (self.__clientWidth-(self.__contentWidth*zoom))/2;
+                }else{
+                    xoffset = 0;
+                }
+
+                if (self.__clientHeight>(self.__contentHeight*zoom)){
+                    yoffset = (self.__clientHeight-(self.__contentHeight*zoom))/2;
+                }else{
+                    yoffset = 0;
+                }
+            self.__selfCentreLeftOffset = xoffset;
+            self.__selfCentreTopOffset = yoffset;
+        },
+
 
   /**
    * Touch end handler for scrolling support
@@ -5993,8 +6028,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
           // Push values out
           if (self.__callback) {
-            self.__callback(self.__scrollLeft, self.__scrollTop, self.__zoomLevel, wasResize);
-          }
+            self.__callback(self.__scrollLeft-self.__selfCentreLeftOffset,self.__scrollTop-self.__selfCentreTopOffset,
+              self.__zoomLevel, wasResize);
+         }
 
         }
       };
@@ -6027,7 +6063,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
       // Push values out
       if (self.__callback) {
-        self.__callback(left, top, zoom, wasResize);
+        self.__callback(left-self.__selfCentreLeftOffset, top-self.__selfCentreTopOffset, zoom, wasResize);
       }
 
       // Fix max scroll ranges
@@ -6055,6 +6091,10 @@ ionic.views.Scroll = ionic.views.View.inherit({
       self.__didWaitForSize = true;
       self.__waitForSize();
     }
+    
+    //Recompute deadOffsets @oxylab
+          self.calcSelfCentre(zoomLevel);
+    
   },
 
 


### PR DESCRIPTION
Adds a new directive `'self-center'={boolean}` which enables to center align the content (in x or y direction) when the content dimension is less than the client dimension.
Best use would be in an image viewer with zoom enabled.
I don't know how to present this using codepen but as an alternative, this modified sample project might be apt.  https://www.dropbox.com/s/9dmu8659b2kt2ae/www%20-%20Copy.zip?dl=0
Changes made to zynga-scroller code
Copied respective codes to ionic.js, ionic-angular.js and ionic-bundle.js. minified versions weren't modified