### PR TITLE
Incuded forcedNav so user can control transition better

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -553,6 +553,15 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
 
     /**
      * @ngdoc method
+     * @name $ionicHistory#forcedNav
+     * @description Forces the next transition to have the specified direction/action.
+     */
+    forcedNav: function(force){
+      forcedNav = force;
+    },
+
+    /**
+     * @ngdoc method
      * @name $ionicHistory#goBack
      * @description Navigates the app to the back view, if a back view exists.
      */


### PR DESCRIPTION
Sometimes you need to be able to control the next view transition - for example, if you are going back in the history by more than one view. We used to be able to to do this using the $rootScope.viewHistory - put that's no longer possible:

    $ionicHistory.forcedNav({
          viewId: viewId,
          action: 'moveBack',
          direction: 'back'
        });