### PR TITLE
feat(scss): add left box shadow for transition back/forward

### DIFF
--- a/scss/_transitions.scss
+++ b/scss/_transitions.scss
@@ -5,6 +5,7 @@
 $ios-transition-duration:              500ms !default;
 $ios-transition-timing-function:       cubic-bezier(.36, .66, .04, 1) !default;
 $ios-transition-container-bg-color:    #000 !default;
+$ios-transition-box-shadow:            -5px 0px 20px 0px rgba(150, 150, 150, 0.5) !default;
 
 
 [nav-view-transition="ios"] {
@@ -15,6 +16,8 @@ $ios-transition-container-bg-color:    #000 !default;
     @include transition-timing-function( $ios-transition-timing-function );
     -webkit-transition-property: opacity, -webkit-transform;
             transition-property: opacity, transform;
+    -webkit-box-shadow: $ios-transition-box-shadow;
+            box-shadow: $ios-transition-box-shadow;
   }
 
   &[nav-view-direction="forward"],


### PR DESCRIPTION
In all iOS apps I've seen a slight left box-shadow between back and forward transitions:

**As an example:**

 ![](http://i.stack.imgur.com/rkPuC.png)

As a result, I've made a small addition to the `entering` and `leaving` transitions. **Here is a codepen demonstrating the box-shadow:** http://codepen.io/anon/pen/wBdvwr

**And an image of the transition effect:**

![nav-shadow-example](https://cloud.githubusercontent.com/assets/1716394/5790365/ebfe13e8-9e62-11e4-80a2-c8b5519fac42.png)

I can confirm that this change working on my iPhone 6 without any jumpy errors. While this is very **iOS like**, it is still missing an addition effect, where the box-shadow fades away as the page goes further right. So at the far left of the screen, the box-shadow is much heavier and prevalent. As the transition to the right moves forward, the box-shadow becomes light, until it is no longer visible and the page have fully transitioned.
