### PR TITLE
fix call function on the undefined object 

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -313,7 +313,8 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
               // the forward has a history
               for (x = tmp.stack.length - 1; x >= forwardView.index; x--) {
                 // starting from the end destroy all forwards in this history from this point
-                tmp.stack[x].destroy();
+                var stack_x = tmp.stack[x];
+                stack_x && stack_x.destroy && stack_x.destroy();
                 tmp.stack.splice(x);
               }
               historyId = forwardView.historyId;


### PR DESCRIPTION

 when we upgrade the latest ionic.  it throw error due to  call function on undefined object . so add short circuit can be more robust . 