### PR TITLE
Fix for issue #3004 - bug:  show/hide causes event handler leak

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -137,6 +137,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       }
 
       if (target && self.positionView) {
+        self.positionView(target, modalEl);
         // set up a listener for in case the window size changes
         if (!self.resizeHandler) {
           self.resizeHandler = function() {
@@ -160,7 +161,6 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
 
       $timeout(function() {
         modalEl.addClass('ng-enter-active');
-        ionic.trigger('resize');
         self.scope.$parent && self.scope.$parent.$broadcast(self.viewType + '.shown', self);
         self.el.classList.add('active');
         self.scope.$broadcast('$ionicHeader.align');
@@ -204,6 +204,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       // clean up event listeners
       if (self.positionView) {
         ionic.off('resize',self.resizeHandler,window);
+        self.resizeHandler = null;
       }
 
       return $timeout(function() {

--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -137,12 +137,14 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       }
 
       if (target && self.positionView) {
-        self.positionView(target, modalEl);
         // set up a listener for in case the window size changes
-        ionic.on('resize',function() {
-          ionic.off('resize',null,window);
-          self.positionView(target,modalEl);
-        },window);
+        if (!self.resizeHandler) {
+          self.resizeHandler = function() {
+            self.positionView(target, modalEl);
+          };
+        }
+
+        ionic.on('resize',self.resizeHandler,window);
       }
 
       modalEl.addClass('ng-enter active')
@@ -201,7 +203,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
 
       // clean up event listeners
       if (self.positionView) {
-        ionic.off('resize',null,window);
+        ionic.off('resize',self.resizeHandler,window);
       }
 
       return $timeout(function() {


### PR DESCRIPTION
Here by a fix for issue #3004.

The fix is fairly straightforward - when adding the resize event handler, simply use a named function instead of an anonymous, so that it can be referenced when removing the event handler again.