### PR TITLE
Fix "'Cannot set property 'forwardViewId' of undefined'"

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -391,6 +391,10 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
           if (hist.stack[x].viewId == viewId) {
             action = 'dupNav';
             direction = DIRECTION_NONE;
+            if (x != 0) {
+              hist.stack[x - 1].forwardViewId = null;
+            }
+            viewHistory.forwardView = null;
             hist.stack[x - 1].forwardViewId = viewHistory.forwardView = null;
             viewHistory.currentView.index = viewHistory.backView.index;
             viewHistory.currentView.backViewId = viewHistory.backView.backViewId;


### PR DESCRIPTION
We were getting the bug found [here](http://forum.ionicframework.com/t/cannot-set-property-forwardviewid-of-undefined/15512/2) occasionally. We could not create a reliable steps to reproduce.

I don't fully understand what the code I have edited is doing, but I can see a logical error.

It starts with `for (x=0 ...)` then does `hist.stack[x - 1]` (depending on an `if`). Negative array indexes are not allowed, so I have surrounded that part in an if statement - I assume it's ok to not set anything to null if the `hist.stack` array is going to be empty.