### PR TITLE
feat(tooling): add package.json to ionic-bower for jspm support

### DIFF
--- a/bower.package.json
+++ b/bower.package.json
@@ -1,0 +1,38 @@
+{
+  "name": "ionic-bower",
+  "private": false,
+  "version": "1.0.0-beta.14",
+  "codename": "magnesium-mongoose",
+  "repository": {
+    "url": "git://github.com/driftyco/ionic-bower.git"
+  },
+  "licenses": [
+    {
+      "type": "MIT"
+    }
+  ],
+  "jspm": {
+    "main": "js/ionic-angular",
+    "shim": {
+        "js/ionic-angular": {
+            "deps": [
+                "../css/ionic.css!",
+                "./ionic",
+                "angular",
+                "angular-animate",
+                "angular-sanitize",
+                "angular-ui-router"
+            ]
+        }
+    },
+    "dependencies": {
+        "css": "0.1.0",
+        "angular": "1.3.12",
+        "angular-animate": "1.3.12",
+        "angular-sanitize": "1.3.12",
+        "angular-ui-router": "0.2.13",
+        "ionicons": "github:driftyco/ionicons@^2.0.1"
+    }
+  }
+
+}

--- a/scripts/bower/publish.sh
+++ b/scripts/bower/publish.sh
@@ -39,13 +39,20 @@ function run {
     JSON.stringify(b,null,2);" \
     > $BOWER_DIR/bower.json
 
+  echo "-- Copying bower.package.json from project_dir and renaming it to package.json"
+  node -p "var b = require('./bower.package.json');
+    JSON.stringify(b,null,2);" \
+    > $BOWER_DIR/package.json
+
   cd $BOWER_DIR
 
   echo "-- Updating version in ionic-bower to $VERSION"
   replaceJsonProp "bower.json" "version" "$VERSION"
+  replaceJsonProp "package.json" "version" "$VERSION"
 
   echo "-- Updating codename in ionic-bower to $CODENAME"
   replaceJsonProp "bower.json" "codename" "$CODENAME"
+  replaceJsonProp "package.json" "codename" "$CODENAME"
 
   git add -A
   git commit -am "release: v$VERSION"

--- a/scripts/update-angular.sh
+++ b/scripts/update-angular.sh
@@ -21,6 +21,12 @@ function run {
   replaceJsonProp "bower.json" "angular" "$VERSION"
   replaceJsonProp "bower.json" "angular-animate" "$VERSION"
   replaceJsonProp "bower.json" "angular-sanitize" "$VERSION"
+
+  echo "Setting bower.package.json angular versions to $VERSION"
+  
+  replaceJsonProp "bower.package.json" "angular" "$VERSION"
+  replaceJsonProp "bower.package.json" "angular-animate" "$VERSION"
+  replaceJsonProp "bower.package.json" "angular-sanitize" "$VERSION"
 }
 
 source $(dirname $0)/utils.inc


### PR DESCRIPTION
This PR adds functionality for the extremely handy [jspm.io](http://jspm.io/) package manager. 

Currently, ionic-bower has to be shimmed by the jspm registry since no package.json exists in the repo itself. By adding a generated package.json file, jspm will defer to ionic devs for dependency management in much the same way that bower does. 

Once this PR has been merged, someone with write access to the ionic-bower repo will need to run the scripts/bower/publish.sh script to actually create the package.json in that repo. This also adds functionality so that package.json in the bower repo is updated properly when th angular_update script is run.

For more backgroud info, see here: https://github.com/jspm/registry/pull/157