### PR TITLE
[tap.js] Allow tapping on children of a contenteditable element on Android

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -162,6 +162,7 @@ ionic.tap = {
     return !!ele &&
            (ele.tagName == 'TEXTAREA' ||
             ele.contentEditable === 'true' ||
+	    ele.contentEditable === 'inherit' ||
             (ele.tagName == 'INPUT' && !(/^(radio|checkbox|range|file|submit|reset)$/i).test(ele.type)));
   },
 


### PR DESCRIPTION
Fixes an issue on Android where tapping on a child element of a `contenteditable` element (e.g. a `<p>`) does not activate the contenteditable element.