### PR TITLE
Footer/Subheader/Subfooter title size must respect it's size

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -325,6 +325,13 @@
     border-bottom-width: 0px;
     background-image: none;
   }
+  @if $bar-height != $bar-header-height {
+    height: $bar-header-height;
+    .title {
+      height: $bar-header-height - 1;
+      line-height: $bar-header-height - 1;
+    }
+  }
 }
 
 // Footer at bottom
@@ -338,6 +345,7 @@
   @if $bar-height != $bar-footer-height {
     .title {
       height: $bar-footer-height - 1;
+      line-height: $bar-footer-height - 1;
     }
   }
   
@@ -360,6 +368,7 @@
   @if $bar-height != $bar-subheader-height {
     .title {
       height: $bar-subheader-height - 1;
+      line-height: $bar-subheader-height - 1;
     }
   }
 }
@@ -372,6 +381,7 @@
   @if $bar-height != $bar-subfooter-height {
     .title {
       height: $bar-subfooter-height - 1;
+      line-height: $bar-subfooter-height - 1;
     }
   }
 }

--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -335,7 +335,12 @@
   background-position: top;
 
   height: $bar-footer-height;
-
+  @if $bar-height != $bar-footer-height {
+    .title {
+      height: $bar-footer-height - 1;
+    }
+  }
+  
   &.item-input-inset {
     position: absolute;
   }
@@ -351,12 +356,24 @@
   display: block;
 
   height: $bar-subheader-height;
+  
+  @if $bar-height != $bar-subheader-height {
+    .title {
+      height: $bar-subheader-height - 1;
+    }
+  }
 }
 .bar-subfooter {
   bottom: $bar-footer-height;
   display: block;
 
   height: $bar-subfooter-height;
+  
+  @if $bar-height != $bar-subfooter-height {
+    .title {
+      height: $bar-subfooter-height - 1;
+    }
+  }
 }
 
 .nav-bar-block {

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -162,6 +162,7 @@ $bar-padding-portrait:            5px !default;
 $bar-padding-landscape:           5px !default;
 $bar-transparency:                1 !default;
 
+$bar-header-height:               $bar-height !default;
 $bar-footer-height:               $bar-height !default;
 $bar-subheader-height:            $bar-height !default;
 $bar-subfooter-height:            $bar-height !default;


### PR DESCRIPTION
Currently, the height are all based on `.bar`