### PR TITLE
Update modal.js example to properly handle the response

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -35,11 +35,9 @@
  * ```js
  * angular.module('testApp', ['ionic'])
  * .controller('MyController', function($scope, $ionicModal) {
- *   $ionicModal.fromTemplateUrl('my-modal.html', {
+ *   $scope.modal = $ionicModal.fromTemplateUrl('my-modal.html', {
  *     scope: $scope,
  *     animation: 'slide-in-up'
- *   }).then(function(modal) {
- *     $scope.modal = modal;
  *   });
  *   $scope.openModal = function() {
  *     $scope.modal.show();


### PR DESCRIPTION
The $ionicModal constructor seems to return the new modal controller instance but the docs showed that it returned a promise. Using the example from the docs, you will get 'undefined is not a function'. This is an updated example code snippet that will work for people implementing $ionicModal.