### PR TITLE
chore(platform): remove duplicate event listener attachment

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -413,8 +413,6 @@
     window.addEventListener("load", onWindowLoad, false);
   }
 
-  window.addEventListener("load", onWindowLoad, false);
-
   function onPlatformReady() {
     // the device is all set to go, init our own stuff then fire off our event
     self.isReady = true;


### PR DESCRIPTION
It seems to me like either this `addEventlistener` isn't necessary, or the one on line 413.