### PR TITLE
Adds .row-no-padding for padding-less grid layouts

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -18,6 +18,14 @@
   @include flex-wrap(wrap);
 }
 
+.row-no-padding {
+  padding: 0;
+
+  > .col {
+    padding: 0;
+  }
+}
+
 .row + .row {
   margin-top: ($grid-padding-width / 2) * -1;
   padding-top: 0;


### PR DESCRIPTION
I use this class variation all over my ionic projects, so wanted to throw it into a PR.

Paddingless grids can be really useful for columned flexbox layouts - e.g.

<img src="https://cloud.githubusercontent.com/assets/844291/6220577/d0de327c-b5ec-11e4-9df4-9b9d273385ec.png" width="500">
<img src="https://cloud.githubusercontent.com/assets/844291/6220581/d2d032ec-b5ec-11e4-82dc-c473c92997fe.png" width="500">
