### PR TITLE
(chore): Add packaging for Meteor.js

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,7 @@ dist
 
 .idea
 
+.versions
+
 # Coverage directory used by tools like istanbul
 coverage/

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ $ ionic start myproject
   * The `release` folder of this repository
   * Ionic CDN: [Latest Release](http://code.ionicframework.com/)
   * Using bower: `bower install ionic`
+  * For [Meteor](https://www.meteor.com/) applications: `meteor add driftyco:ionic` 
 - Download the **bleeding edge just-from-master release** from:
   * Ionic CDN: [Nightly Build](http://code.ionicframework.com/#nightly)
   * Using bower: `bower install driftyco/ionic-bower#master`

--- a/package.js
+++ b/package.js
@@ -1,0 +1,34 @@
+// package metadata file for Meteor.js
+var packageName = 'driftyco:ionic'; // https://atmospherejs.com/driftyco/ionic
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+var version = '1.1.0';
+
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: 'Ionic Framework official Meteor package',
+  git: 'git@github.com:driftyco/ionic.git'
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']);
+
+  api.use('angular:angular@1.4.3', where);
+  api.use('angular:angular-animate@1.4.3', where);
+  api.use('angular:angular-sanitize@1.4.3', where);
+  api.use('angularui:angular-ui-router@0.2.13_3', where);
+
+  // In case the Meteor project has the `fastclick` package,
+  // Load it first and cancel it (to use Ionic's one)
+  api.use('urigo:cancel-fastclick@0.0.2', where);
+
+  api.addFiles([
+    'release/css/ionic.css',
+    'release/fonts/ionicons.eot',
+    'release/fonts/ionicons.svg',
+    'release/fonts/ionicons.ttf',
+    'release/fonts/ionicons.woff',
+    'release/js/ionic.js',
+    'release/js/ionic-angular.js'
+  ], where);
+});


### PR DESCRIPTION
Hi @adamdbradley @mlynch

I'm a package maintainer for Meteor.js, a popular [full-stack JavaScript framework](https://www.meteor.com/).

I'm also the creator of [angular-meteor](https://github.com/Urigo/angular-meteor), a library that let's you work with AngularJS on top of Meteor.

A lot of our users use Ionic and it right now there is a separate package and Github repo that simply manually copies your distribution and publish it to Meteor.
There is also a [Blaze copy of Ionic Framework](https://github.com/meteoric/meteor-ionic).

This PR will allow you to directly publish updated versions of Ionic as they become available. All you have to do is create an account at https://meteor.com/ (click SIGN IN, then Create account). After you've done that, please let me know the name of the account, and I'll add you as a maintainer to the driftyco organization there.

I've already published the current version of the package on Atmosphere (Meteor's package directory). When you release new versions of Ionic, you'll be able to publish them easily to Atmosphere.

As discussed by email, usually I also add the build process for automatically publishing the Meteor package but your build process is a little bit more complicated so as you requested, this pull request contains only the Meteor package files without any automatic scripts.

Thanks & best regards,
Uri