### PR TITLE
let ionicons load for WP8

### DIFF
--- a/scss/ionicons/_ionicons-font.scss
+++ b/scss/ionicons/_ionicons-font.scss
@@ -7,6 +7,7 @@
  src:url("#{$ionicons-font-path}/ionicons.eot?v=#{$ionicons-version}#iefix") format("embedded-opentype"),
   url("#{$ionicons-font-path}/ionicons.ttf?v=#{$ionicons-version}") format("truetype"),
   url("#{$ionicons-font-path}/ionicons.woff?v=#{$ionicons-version}") format("woff"),
+  url("#{$ionicons-font-path}/ionicons.woff") format("woff"), /* for WP8 */
   url("#{$ionicons-font-path}/ionicons.svg?v=#{$ionicons-version}#Ionicons") format("svg");
  font-weight: normal;
  font-style: normal;


### PR DESCRIPTION
This is a minimalist short term fix before a complete solution be implemented as was discussed in #2599.
