### PR TITLE
fix: fixed the nested tabs selected, initialize property $tabSelected.

### DIFF
--- a/js/angular/directive/item.js
+++ b/js/angular/directive/item.js
@@ -1,5 +1,5 @@
 var ITEM_TPL_CONTENT_ANCHOR =
-  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}"></a>';
+  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}" nav-direction="{{$navDirection()}}"></a>';
 var ITEM_TPL_CONTENT =
   '<div class="item-content"></div>';
 /**
@@ -61,6 +61,9 @@ IonicModule
         };
         $scope.$target = function() {
           return $attrs.target || '_self';
+        };
+        $scope.$navDirection = function() {
+          return $attrs.navDirection || '';
         };
 
         $scope.$on('$ionic.disconnectScope', cleanupDragOp);

--- a/js/angular/directive/item.js
+++ b/js/angular/directive/item.js
@@ -1,5 +1,5 @@
 var ITEM_TPL_CONTENT_ANCHOR =
-  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}" nav-direction="{{$navDirection()}}"></a>';
+  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}"></a>';
 var ITEM_TPL_CONTENT =
   '<div class="item-content"></div>';
 /**
@@ -61,9 +61,6 @@ IonicModule
         };
         $scope.$target = function() {
           return $attrs.target || '_self';
-        };
-        $scope.$navDirection = function() {
-          return $attrs.navDirection || '';
         };
 
         $scope.$on('$ionic.disconnectScope', cleanupDragOp);

--- a/js/angular/directive/tab.js
+++ b/js/angular/directive/tab.js
@@ -100,6 +100,7 @@ function($compile, $ionicConfig, $ionicBind, $ionicViewSwitcher) {
         var tabsCtrl = ctrls[0];
         var tabCtrl = ctrls[1];
         var isTabContentAttached = false;
+        $scope.$tabSelected = false;
 
         $ionicBind($scope, $attr, {
           onSelect: '&',


### PR DESCRIPTION
Like the issue https://github.com/driftyco/ionic/issues/1276
if you have some nested tabs, you select a sub-tab item, and you will
active some other siblings, because when tabCtrl add every new $scope,
it does't has a initial attr $scope.$tabSelected, so every
unselected item will read the $tabSelected from inherited
$parent, but if the parent-tab has been actived, the all of its
sub-tabs will read this true property in $scope.$tabSelected.

So I think we should initialize the property $scope.$tabSelected before
invoking tabsCtrl.add(), and every tab-item will has a 'false' status
for a initial $scope.$tabSelected.