### PR TITLE
Fix border radius for popover bar header on iOS platform

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -74,11 +74,10 @@
 
   .popover {
     box-shadow: $popover-box-shadow-ios;
-  }
-
-  .popover,
-  .popover .bar-header {
     border-radius: $popover-border-radius-ios;
+  }
+  .popover .bar-header {
+    @include border-top-radius($popover-border-radius-ios);
   }
   .popover .scroll-content {
     margin: 8px 0;


### PR DESCRIPTION
Header bar on Popover in iOS platform is better with no border bottom radius:

![capture](https://cloud.githubusercontent.com/assets/659811/6373468/3ef00b08-bd0b-11e4-8809-737659673201.PNG)

Looks better:
![capture1](https://cloud.githubusercontent.com/assets/659811/6373469/409c957a-bd0b-11e4-8109-428bec24ab69.PNG)
