### PR TITLE
Modal backdrop performance

### DIFF
--- a/js/angular/directive/modal.js
+++ b/js/angular/directive/modal.js
@@ -9,8 +9,10 @@ IonicModule
     transclude: true,
     replace: true,
     controller: [function() {}],
-    template: '<div class="modal-backdrop">' +
+    template: 	'<div class="modal-fix">' +
+    			'<div class="modal-backdrop">' +
                 '<div class="modal-wrapper" ng-transclude></div>' +
+                '</div>' +
                 '</div>'
   };
 }]);

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -74,7 +74,7 @@
       background-color: black;
       opacity: 0;
     }
-    .active{
+    &.active{
       .modal-backdrop{
         background-color: $modal-backdrop-bg-active;
         opacity: .5;

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -68,13 +68,17 @@
       top: $bar-height + $bar-subheader-height + $tabs-height;
     }
   }
-
-  .modal-backdrop {
-    @include transition(background-color 300ms ease-in-out);
-    background-color: $modal-backdrop-bg-inactive;
-
-    &.active {
-      background-color: $modal-backdrop-bg-active;
+  .modal-fix{
+    .modal-backdrop {
+      @include transition(opacity 300ms ease-in-out);
+      background-color: black;
+      opacity: 0;
+    }
+    .active{
+      .modal-backdrop{
+        background-color: $modal-backdrop-bg-active;
+        opacity: .5;
+      }
     }
   }
 }

--- a/scss/_modal.scss
+++ b/scss/_modal.scss
@@ -76,7 +76,6 @@
     }
     &.active{
       .modal-backdrop{
-        background-color: $modal-backdrop-bg-active;
         opacity: .5;
       }
     }

--- a/test/unit/angular/service/modal.unit.js
+++ b/test/unit/angular/service/modal.unit.js
@@ -17,7 +17,7 @@ describe('Ionic Modal', function() {
     var template = '<div class="modal"></div>';
     var instance = modal.fromTemplate(template);
     instance.show();
-    expect(instance.el.classList.contains('modal-backdrop')).toBe(true);
+    expect(instance.el.classList.contains('modal-fix')).toBe(true);
     expect(instance.modalEl.classList.contains('modal')).toBe(true);
     expect(instance.modalEl.classList.contains('slide-in-up')).toBe(true);
   });
@@ -30,7 +30,7 @@ describe('Ionic Modal', function() {
     var instance = modal.fromTemplateUrl('modal.html', function(instance) {
       done = true;
       instance.show();
-      expect(instance.el.classList.contains('modal-backdrop')).toBe(true);
+      expect(instance.el.classList.contains('modal-fix')).toBe(true);
       expect(instance.modalEl.classList.contains('modal')).toBe(true);
       expect(instance.modalEl.classList.contains('active')).toBe(true);
     });


### PR DESCRIPTION
I'm working on a huge ionic project for a large company and they're sticklers about android performance. I found switching the modal backdrop animation from relying on an rgba alpha channel animation to an opacity animation smoothed it out noticeably and reduced CPU load for the modal ease in animation. I believe it's because the opacity animation happens at the compositing level and is therefore much cheaper.

All the tests are passing, please verify my results re: performance improvement.