### PR TITLE
fix: initialize $scope.$tabSelected when nested tabs selected.

### DIFF
--- a/js/angular/directive/tab.js
+++ b/js/angular/directive/tab.js
@@ -100,6 +100,7 @@ function($compile, $ionicConfig, $ionicBind, $ionicViewSwitcher) {
         var tabsCtrl = ctrls[0];
         var tabCtrl = ctrls[1];
         var isTabContentAttached = false;
+        $scope.$tabSelected = false;
 
         $ionicBind($scope, $attr, {
           onSelect: '&',


### PR DESCRIPTION
Like the issue #1276 if you have some nested tabs, you select a sub-tab
item, and you will active some other siblings, because when tabCtrl add
every new $scope, it does't has a initial attr $scope.$tabSelected, so
every unselected item will read the $tabSelected from inherited $parent,
but if the parent-tab has been actived, the all of its sub-tabs
will read this true property in $scope.$tabSelected. So I think we
should initialize the property $scope.$tabSelected before invoking
tabsCtrl.add(), and every tab-item will has a 'false' status for a
initial $scope.$tabSelected.