### PR TITLE
fix: add nav-direction to ionItem anchor template.

### DIFF
--- a/js/angular/directive/item.js
+++ b/js/angular/directive/item.js
@@ -1,5 +1,5 @@
 var ITEM_TPL_CONTENT_ANCHOR =
-  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}"></a>';
+  '<a class="item-content" ng-href="{{$href()}}" target="{{$target()}}" nav-direction="{{$navDirection()}}"></a>';
 var ITEM_TPL_CONTENT =
   '<div class="item-content"></div>';
 /**
@@ -62,6 +62,9 @@ IonicModule
         };
         $scope.$target = function() {
           return $attrs.target || '_self';
+        };
+        $scope.$navDirection = function() {
+          return $attrs.navDirection || '';
         };
 
         var content = $element[0].querySelector('.item-content');


### PR DESCRIPTION
In general a element, it is available to use the directive
nav-direction, but in directive ion-item, it will build an anchor
element by its template ITEM_TPL_CONTENT_ANCHOR, it doesn't has the
nav-direction attribute, so I updated the ITEM_TPL_CONTENT_ANCHOR and
add a proxy function $navDirection in directive ion-item.