### PR TITLE
Fix: invalid US-ASCII character \xE2, when watching sass

### DIFF
--- a/scss/ionicons/ionicons.scss
+++ b/scss/ionicons/ionicons.scss
@@ -1,3 +1,4 @@
+@charset "UTF-8";
 @import "ionicons-variables";
 /*!
   Ionicons, v2.0.1


### PR DESCRIPTION
Upon just updating my ionic app to the version ``Ionic Package: nightly 1.0.0-rc.0-nightly-1120 (2015-03-05)``, watching sass didn't seem to cooperate.

Ref: https://github.com/kevincobain2000/listof-app/commit/29a5a6e728838290d6bbb322318d7582fa6451d1


**Before**

```
>>> Change detected to: www/lib/ionic/scss/ionicons/ionicons.scss
      error www/lib/ionic/scss/ionicons/ionicons.scss (Line 8: Invalid US-ASCII character "\xE2")
```

**After**

```
>>> Change detected to: www/lib/ionic/scss/ionicons/ionicons.scss
      write www/css/app.css
      write www/css/app.css.map
```

----

PS: Watching Sass

```
sass --watch scss/ionic.app.scss:www/css/app.css
```