### PR TITLE
line height android is not updated when setting a custom bar height. 

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -272,7 +272,7 @@
 
     .title {
       font-size: 19px;
-      line-height: 43px;
+      line-height: $bar-height;
     }
   }
 


### PR DESCRIPTION
iOS is ok

On android the title is not correctly centered vertically when setting a custom bar height (e.g $bar-height: 64px;)