### PR TITLE
feat(ionicModal): added a variable to know if the modal has been closed from a hide or remove event

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -149,6 +149,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
              .removeClass('ng-leave ng-leave-active');
 
       self._isShown = true;
+      self._triggeredByRemoveEvent = false;
       self._deregisterBackButton = $ionicPlatform.registerBackButtonAction(
         self.hardwareBackButtonClose ? angular.bind(self, self.hide) : noop,
         PLATFORM_BACK_BUTTON_PRIORITY_MODAL
@@ -177,10 +178,11 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
     /**
      * @ngdoc method
      * @name ionicModal#hide
+     * @param {boolean} triggeredByRemoveEvent A boolean to know if the event has been triggered by a previous remove event
      * @description Hide this modal instance.
      * @returns {promise} A promise which is resolved when the modal is finished animating out.
      */
-    hide: function() {
+    hide: function(triggeredByRemoveEvent) {
       var self = this;
       var modalEl = jqLite(self.modalEl);
 
@@ -194,6 +196,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
 
       self.$el.off('click');
       self._isShown = false;
+      self._triggeredByRemoveEvent = triggeredByRemoveEvent || false;
       self.scope.$parent && self.scope.$parent.$broadcast(self.viewType + '.hidden', self);
       self._deregisterBackButton && self._deregisterBackButton();
 
@@ -220,7 +223,7 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       var self = this;
       self.scope.$parent && self.scope.$parent.$broadcast(self.viewType + '.removed', self);
 
-      return self.hide().then(function() {
+      return self.hide(true).then(function() {
         self.scope.$destroy();
         self.$el.remove();
       });
@@ -233,6 +236,15 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
      */
     isShown: function() {
       return !!this._isShown;
+    },
+
+    /**
+     * @ngdoc method
+     * @name ionicModal#triggeredByRemoveEvent
+     * @returns boolean Whether this modal has been hide by a remove event.
+     */
+    triggeredByRemoveEvent: function() {
+      return this._triggeredByRemoveEvent;
     }
   });
 

--- a/test/unit/angular/service/modal.unit.js
+++ b/test/unit/angular/service/modal.unit.js
@@ -217,6 +217,24 @@ describe('Ionic Modal', function() {
     timeout.flush();
   }));
 
+  it('should set "triggeredByRemoveEvent" to true when removed', function() {
+    var template = '<div class="modal"></div>';
+    var instance = modal.fromTemplate(template, {});
+    instance.show();
+    timeout.flush();
+    instance.remove();
+    expect(instance._triggeredByRemoveEvent).toBe(true);
+  });
+
+  it('should set "triggeredByRemoveEvent" to false when hidden', function() {
+    var template = '<div class="modal"></div>';
+    var instance = modal.fromTemplate(template, {});
+    instance.show();
+    timeout.flush();
+    instance.hide();
+    expect(instance._triggeredByRemoveEvent).toBe(false);
+  });
+
   it('show should return a promise resolved on hide', function() {
     var template = '<div class="modal"></div>';
     var instance = modal.fromTemplate(template, {});


### PR DESCRIPTION
This can be a workaround to some edge cases that happen when the app responds to a modal hide event with some action, but that should not be triggered when the modal is destroyed. Indirectly solves #2777 issue.