### PR TITLE
feat(workers): add worker support via ionic.workers

### DIFF
--- a/config/build.config.js
+++ b/config/build.config.js
@@ -34,6 +34,10 @@ module.exports = {
   closureStart: '(function() {\n',
   closureEnd: '\n})();',
 
+  workerFiles: [
+    'js/workers/**/*.js'
+  ],
+
   ionicFiles: [
     // Base
     'js/ionic.js',
@@ -51,6 +55,7 @@ module.exports = {
     'js/utils/list.js',
     'js/utils/keyboard.js',
     'js/utils/viewport.js',
+    'js/utils/workers.js',
 
     // Views
     'js/views/view.js',

--- a/js/utils/workers.js
+++ b/js/utils/workers.js
@@ -1,0 +1,137 @@
+(function() {
+ionic.workers = {};
+
+// WORKER_SCRIPTS is filled in by the build system with the contents of files from js/workers/
+ionic.WORKER_SCRIPTS = {};
+
+// Instantiated ionic worker wrappers
+var ionicWorkers = {};
+var nextMessageId = 0;
+
+/*
+ * IonicWorker objects are returned from `ionic.workers.get(workerName)`.
+ * Usage:
+ *   var worker = ionic.workers.get('name');
+ *   worker.send({ message: 'message' }, function response(ev) {
+ *   });
+ */
+function IonicWorker(worker) {
+  var pendingResponses = {};
+
+  function onRespond(id, ev) {
+    var callback = pendingResponses[id];
+    if (callback) {
+      callback(ev);
+      delete pendingResponses[id];
+    }
+  }
+
+  this.send = function(data, callback) {
+    var id = data.id || (data.id = nextMessageId++);
+    data.baseUrl = (
+      location.protocol + '//' +
+      location.hostname +
+      (location.port?':'+location.port:'') +
+      location.pathname
+    ).replace(/[^\/]+$/, '');
+
+    worker.postMessage(data);
+
+    if (callback) {
+      pendingResponses[id] = callback;
+    }
+  };
+
+  worker.onmessage = function(ev) {
+    onRespond(ev.data.id, ev);
+  };
+}
+
+ionic.workers.get = function(name) {
+
+  // We lazily find worker support to make sure we only try to detect it after DOMReady
+  if (typeof ionic.workers.nativeSupport === 'undefined') {
+    // Expose this so we can set it to false during tests. Avoids workers being instantiated during
+    // unit tests.
+    ionic.workers.nativeSupport = true;
+    try {
+      new Worker(makeBlobUri(';'));
+    } catch(e) {
+      ionic.workers.nativeSupport = false;
+    }
+  }
+  if (ionicWorkers[name]) {
+    return ionicWorkers[name];
+  }
+  var script = ionic.WORKER_SCRIPTS[name];
+  if (!script) {
+    throw new Error('Worker ' + name + ' does not exist! Available workers: ' +
+                    Object.keys(ionic.WORKER_SCRIPTS).join(', '));
+  }
+
+  //Create a new worker
+  var worker;
+  if (ionic.workers.nativeSupport) {
+    worker = new Worker(makeBlobUri(script));
+  } else {
+    worker = makeFakeWorker(script);
+  }
+
+  return (ionicWorkers[name] = new IonicWorker(worker));
+};
+
+function makeFakeWorker(script) {
+  // FakeWorker() defines all the variables that our mock worker is going to need
+  // We then inject the worker `script` into the end of FakeWorker.toString() and
+  // pass it to `new Function()`.
+  function FakeWorker() {
+    // The contents of `script` can redefine these
+    var close = function(){};
+    var onerror = function(){};
+    var onmessage = function(){};
+
+    // Define the public API for the worker
+    var publicWorker = {
+      onmessage: function(){}
+    };
+
+    // What's in `script` will use postMessage to send us a response
+    var postMessage = function(data) {
+      publicWorker.onmessage({ data: data });
+    };
+    publicWorker.postMessage = function(data) {
+      onmessage({ data: data });
+    };
+    publicWorker.terminate = function() {
+      close();
+    };
+  }
+
+  // Inject the contents of `script` into the above FakeWorker function
+  var fakeWorkerString = FakeWorker.toString()
+    // Get rid of the leading `function FakeWorker() {`
+    .replace(/^.*?{/, '')
+    // Replace the ending brace with our script in an IIFE, then a return statement
+    .replace(/}$/, '(function(){' + script + ';})();\nreturn publicWorker;');
+
+  /* jshint -W054 */
+  var fakeWorkerFn = new Function(fakeWorkerString);
+
+  return fakeWorkerFn();
+}
+
+function makeBlobUri(script) {
+  var URL = window.URL || window.webkitURL;
+  var BlobBuilder = window.BlobBuilder || window.WebKitBlobBuilder || window.MozBlobBuilder;
+  var blob;
+  try {
+    blob = new Blob([script], { type: 'text/javascript' });
+  } catch (e) {
+    blob = new BlobBuilder();
+    blob.append(script);
+    blob = blob.getBlob();
+  }
+  return URL.createObjectURL(blob);
+}
+
+})();

--- a/js/workers/binaryToBase64.js
+++ b/js/workers/binaryToBase64.js
@@ -1,0 +1,78 @@
+onmessage = function(ev) {
+  var id = ev.data.id;
+  var url = ev.data.url;
+
+  if (!/\/\//.test(url)) {
+    url = url.replace(/^\/?/, ev.data.baseUrl);
+  }
+
+  var xhr = new XMLHttpRequest();
+  xhr.responseType = 'arraybuffer';
+  xhr.open('GET', url);
+  xhr.onreadystatechange = onChange;
+  xhr.send();
+
+  function onChange() {
+    if (xhr.readyState === 4 && xhr.status === 200) {
+      var result = base64ArrayBuffer(xhr.response);
+      postMessage({
+        response: result,
+        id: id
+      });
+    }
+  }
+};
+
+// Thanks, jonleighton.
+// https://gist.github.com/jonleighton/958841
+function base64ArrayBuffer(arrayBuffer) {
+  var base64    = '';
+  var encodings = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+  var bytes         = new Uint8Array(arrayBuffer);
+  var byteLength    = bytes.byteLength;
+  var byteRemainder = byteLength % 3;
+  var mainLength    = byteLength - byteRemainder;
+
+  var a, b, c, d;
+  var chunk;
+
+  // Main loop deals with bytes in chunks of 3
+  for (var i = 0; i < mainLength; i = i + 3) {
+    // Combine the three bytes into a single integer
+    chunk = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+
+    // Use bitmasks to extract 6-bit segments from the triplet
+    a = (chunk & 16515072) >> 18; // 16515072 = (2^6 - 1) << 18
+    b = (chunk & 258048)   >> 12; // 258048   = (2^6 - 1) << 12
+    c = (chunk & 4032)     >>  6; // 4032     = (2^6 - 1) << 6
+    d = chunk & 63;               // 63       = 2^6 - 1
+
+    // Convert the raw binary segments to the appropriate ASCII encoding
+    base64 += encodings[a] + encodings[b] + encodings[c] + encodings[d];
+  }
+
+  // Deal with the remaining bytes and padding
+  if (byteRemainder == 1) {
+    chunk = bytes[mainLength];
+
+    a = (chunk & 252) >> 2; // 252 = (2^6 - 1) << 2
+
+    // Set the 4 least significant bits to zero
+    b = (chunk & 3)   << 4; // 3   = 2^2 - 1
+
+    base64 += encodings[a] + encodings[b] + '==';
+  } else if (byteRemainder == 2) {
+    chunk = (bytes[mainLength] << 8) | bytes[mainLength + 1];
+
+    a = (chunk & 64512) >> 10; // 64512 = (2^6 - 1) << 10
+    b = (chunk & 1008)  >>  4; // 1008  = (2^6 - 1) << 4
+
+    // Set the 2 least significant bits to zero
+    c = (chunk & 15)    <<  2; // 15    = 2^4 - 1
+
+    base64 += encodings[a] + encodings[b] + encodings[c] + '=';
+  }
+
+  return base64;
+}

--- a/test/unit/utils/workers.unit.js
+++ b/test/unit/utils/workers.unit.js
@@ -1,0 +1,81 @@
+describe('ionic.workers', function() {
+
+
+  beforeEach(inject(function($timeout) {
+    // Expose so the worker can use
+    ionic.$timeout = $timeout;
+
+    var WORKER_STR = function() {
+      onmessage = function(ev) {
+        ionic.$timeout(function() {
+          postMessage({
+            response: 'done. your message was ' + ev.data.message,
+            id: ev.data.id
+          });
+        }, ev.data.delay || 100);
+      }
+    }.toString().replace(/^.*?{/, '').replace(/}$/, '').trim();
+
+    ionic.workers.nativeSupport = false;
+    ionic.WORKER_SCRIPTS.myWorker = WORKER_STR;
+  }));
+  afterEach(function() {
+    delete ionic.$timeout;
+  });
+
+  it('should get a worker with a valid name', function() {
+    var worker = ionic.workers.get('myWorker');
+    expect(typeof worker.send).toBe('function');
+  });
+
+  it('should error if getting a worker with invalid name', function() {
+    expect(function() {
+      ionic.workers.get('invalid');
+    }).toThrow();
+  });
+
+  it('should send a message and respond with callback', inject(function($timeout) {
+    var responseSpy = jasmine.createSpy('response');
+    var worker = ionic.workers.get('myWorker');
+    worker.send({
+      message: 'work!',
+      delay: 95
+    }, responseSpy);
+    expect(responseSpy).not.toHaveBeenCalled();
+    $timeout.flush(95);
+    expect(responseSpy).toHaveBeenCalled();
+    expect(responseSpy.mostRecentCall.args[0].data.response).toBe('done. your message was work!');
+  }));
+
+  it('should properly respond to multiple messages', inject(function($timeout) {
+    var worker = ionic.workers.get('myWorker');
+    var responseSpies = [
+      jasmine.createSpy('response1'),
+      jasmine.createSpy('response2'),
+      jasmine.createSpy('response3')
+    ];
+    for (var i = 0; i < 3; i++) {
+      worker.send({
+        message: 'work' + i ,
+        delay: 90 + i
+      }, responseSpies[i]);
+    }
+    $timeout.flush(90);
+    expect(responseSpies[0]).toHaveBeenCalled();
+    expect(responseSpies[1]).not.toHaveBeenCalled();
+    expect(responseSpies[2]).not.toHaveBeenCalled();
+    expect(responseSpies[0].mostRecentCall.args[0].data.response).toBe('done. your message was work0');
+
+    $timeout.flush();
+
+    expect(responseSpies[0]).toHaveBeenCalled();
+    expect(responseSpies[0].callCount).toBe(1);
+    expect(responseSpies[1]).toHaveBeenCalled();
+    expect(responseSpies[1].callCount).toBe(1);
+    expect(responseSpies[2]).toHaveBeenCalled();
+    expect(responseSpies[2].callCount).toBe(1);
+    expect(responseSpies[1].mostRecentCall.args[0].data.response).toBe('done. your message was work1');
+    expect(responseSpies[2].mostRecentCall.args[0].data.response).toBe('done. your message was work2');
+  }));
+
+});


### PR DESCRIPTION
To pave the way for #3194.


```js
var worker = ionic.workers.get('binaryToBase64');
worker.send({
  url: 'img3.png'
}, function(ev) {
  var base64 = ev.data.response;
});
```

Synchronously executes the worker script in IE10 and [browsers that don't support workers](http://caniuse.com/#feat=webworkers).