### PR TITLE
Prevented an $ionicPopup race condition.

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -364,16 +364,15 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
 
   function showPopup(options) {
     var popupPromise = $ionicPopup._createPopup(options);
-    var previousPopup = popupStack[0];
 
-    if (previousPopup) {
-      previousPopup.hide();
-    }
-
-    var resultPromise = $timeout(noop, previousPopup ? config.stackPushDelay : 0)
+    var resultPromise = $timeout(noop, 0)
     .then(function() { return popupPromise; })
     .then(function(popup) {
-      if (!previousPopup) {
+      var previousPopup = popupStack[0];
+
+      if (previousPopup) {
+        previousPopup.hide();
+       } else {
         //Add popup-open & backdrop if this is first popup
         $ionicBody.addClass('popup-open');
         $ionicBackdrop.retain();


### PR DESCRIPTION
This appears to fix an issue I've encountered where posting several popups at once doesn't properly release the backdrop.
I believe this is related to #3131.