### PR TITLE
fix(collectionRepeat): Remove pixel padding for old display bug

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -641,7 +641,7 @@ function RepeatManagerFactory($rootScope, $window, $$rAF) {
         if (item.secondarySize !== dim.secondarySize || item.primarySize !== dim.primarySize) {
           item.node.style.cssText = item.node.style.cssText
             .replace(WIDTH_HEIGHT_REGEX, WIDTH_HEIGHT_TEMPLATE_STR
-              .replace(PRIMARY, (item.primarySize = dim.primarySize) + 1)
+              .replace(PRIMARY, (item.primarySize = dim.primarySize))
               .replace(SECONDARY, (item.secondarySize = dim.secondarySize))
             );
         }


### PR DESCRIPTION
This padding is causing some issues with item placement and borders. Removing it makes things add up correctly.

https://github.com/driftyco/ionic/commit/cd5a5ead57e62b8423345b02bbf2ff6cfecbca2e#commitcomment-10329756