### PR TITLE
change transform detection to use not vendor-prefixed style for browsers that support it.

### DIFF
--- a/js/utils/poly.js
+++ b/js/utils/poly.js
@@ -7,7 +7,7 @@
   (function() {
 
     // transform
-    var i, keys = ['webkitTransform', 'transform', '-webkit-transform', 'webkit-transform',
+    var i, keys = ['transform', 'webkitTransform', '-webkit-transform', 'webkit-transform',
                    '-moz-transform', 'moz-transform', 'MozTransform', 'mozTransform', 'msTransform'];
 
     for (i = 0; i < keys.length; i++) {


### PR DESCRIPTION
Hi guys,

First of all I'd like to say thank you for your awesome work on Ionic framework. I really enjoy working with it and I'm really impressed with new version of collection-repeat directive. Awesome work!  

I've got a minor problem with collection-repeat directive and I'd like to suggest a small change in your transform style detection algorithm. The problem appears when I was trying to modify 'transform' style property on an item of collection-repeat array via jqLite which, for Chrome at least, detects that it supports 'transform' style and applies it. Browser does not merge 'transform' and 'webkitTransform' styles and, as a result, element has two transform properties: with vendor-prefix and without.
![inf](https://cloud.githubusercontent.com/assets/1110516/6836613/0142d09a-d301-11e4-9192-24a795e28c48.png)

After that any changes, ionic will try to make with item's position, will be ignored, as browser will reflect only changes in 'transform' style and ionic modifies 'webkitTransform' only. 

So, my suggestion is to use 'transform' style, in case if browser supports it, instead of any vendor-specific one.
