### PR TITLE
Update exit() to exitApp()

### DIFF
--- a/js/angular/directive/refresher.js
+++ b/js/angular/directive/refresher.js
@@ -48,6 +48,7 @@
  * of the refresher.
  * @param {expression=} on-pulling Called when the user starts to pull down
  * on the refresher.
+ * @param {string=} pulling-text The text to display while the user is pulling down.
  * @param {string=} pulling-icon The icon to display while the user is pulling down.
  * Default: 'ion-android-arrow-down'.
  * @param {string=} spinner The {@link ionic.directive:ionSpinner} icon to display

--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -40,7 +40,7 @@
    *   var currentPlatform = ionic.Platform.platform();
    *   var currentPlatformVersion = ionic.Platform.version();
    *
-   *   ionic.Platform.exit(); // stops the app
+   *   ionic.Platform.exitApp(); // stops the app
    * });
    * ```
    */


### PR DESCRIPTION
Updated exit() to exitApp() for documentation as the name of the function is exitApp.