### PR TITLE
Fixes #2824 Add 100% width to .button-block when in .bar to correct width

### DIFF
--- a/scss/_button.scss
+++ b/scss/_button.scss
@@ -229,7 +229,8 @@
 button.button-block,
 button.button-full,
 .button-full > button.button,
-input.button.button-block  {
+input.button.button-block,
+.bar .button.button-block {
   width: 100%;
 }
 


### PR DESCRIPTION
Since ``.bar`` is flex, applying ``flex: 1`` to ``.bar .button.button-block`` also works. In the interest of saving a few bytes, decided to use the already present ``width: 100%``.