### PR TITLE
Add a broadcast for when the backdrop is shown or hidden

### DIFF
--- a/js/angular/service/backdrop.js
+++ b/js/angular/service/backdrop.js
@@ -18,10 +18,14 @@
  * For example, if `retain` is called three times, the backdrop will be shown until `release`
  * is called three times.
  *
+ * **Notes:**
+ * - The backdrop service will broadcast 'backdrop.shown' and 'backdrop.hidden' events from the root scope,
+ * this is useful for alerting native components not in html.
+ *
  * @usage
  *
  * ```js
- * function MyController($scope, $ionicBackdrop, $timeout) {
+ * function MyController($scope, $ionicBackdrop, $timeout, $rootScope) {
  *   //Show a backdrop for one second
  *   $scope.action = function() {
  *     $ionicBackdrop.retain();
@@ -29,13 +33,24 @@
  *       $ionicBackdrop.release();
  *     }, 1000);
  *   };
+ *
+ *   // Execute action on backdrop disappearing
+ *   $scope.$on('backdrop.hidden', function() {
+ *     // Execute action
+ *   });
+ *
+ *   // Execute action on backdrop appearing
+ *   $scope.$on('backdrop.shown', function() {
+ *     // Execute action
+ *   });
+ *
  * }
  * ```
  */
 IonicModule
 .factory('$ionicBackdrop', [
-  '$document', '$timeout', '$$rAF',
-function($document, $timeout, $$rAF) {
+  '$document', '$timeout', '$$rAF', '$rootScope',
+function($document, $timeout, $$rAF, $rootScope) {
 
   var el = jqLite('<div class="backdrop">');
   var backdropHolds = 0;
@@ -67,6 +82,7 @@ function($document, $timeout, $$rAF) {
     backdropHolds++;
     if (backdropHolds === 1) {
       el.addClass('visible');
+      $rootScope.$broadcast('backdrop.shown');
       $$rAF(function() {
         // If we're still at >0 backdropHolds after async...
         if (backdropHolds >= 1) el.addClass('active');
@@ -76,6 +92,7 @@ function($document, $timeout, $$rAF) {
   function release() {
     if (backdropHolds === 1) {
       el.removeClass('active');
+      $rootScope.$broadcast('backdrop.hidden');
       $timeout(function() {
         // If we're still at 0 backdropHolds after async...
         if (backdropHolds === 0) el.removeClass('visible');


### PR DESCRIPTION
This is to add a rootScope broadcast from the backdrop service. This is really useful in hybrid apps involving native views. E.g. native maps or camera.

Generally any time the backdrop is shown the developers wants this to be on top of everything and nothing below it to be clickable or receive input, this generally means sending a cordova message to native components telling them something is on top. This broadcast allows that to be easily implemented once for whenever the backdrop appears. Ionic already has something similar for modals.