### PR TITLE
feat $ionicSideMenus: add '$ionicSideMenuOpen'/ '$ionicSideMenuClose' event

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -8,7 +8,8 @@ IonicModule
   '$ionicHistory',
   '$ionicScrollDelegate',
   'IONIC_BACK_PRIORITY',
-function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $ionicHistory, $ionicScrollDelegate, IONIC_BACK_PRIORITY) {
+  '$rootScope',
+function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $ionicHistory, $ionicScrollDelegate, IONIC_BACK_PRIORITY, $rootScope) {
   var self = this;
   var rightShowing, leftShowing, isDragging;
   var startX, lastX, offsetX, isAsideExposed;
@@ -63,8 +64,10 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     self.content.enableAnimation();
     if (!shouldOpen) {
       self.openPercentage(0);
+      $rootScope.$emit('$ionicSideMenuClose', 'left');
     } else {
       self.openPercentage(100);
+      $rootScope.$emit('$ionicSideMenuOpen', 'left');
     }
   };
 
@@ -80,8 +83,10 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     self.content.enableAnimation();
     if (!shouldOpen) {
       self.openPercentage(0);
+      $rootScope.$emit('$ionicSideMenuClose', 'right');
     } else {
       self.openPercentage(-100);
+      $rootScope.$emit('$ionicSideMenuOpen', 'right');
     }
   };
 
@@ -98,6 +103,8 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
    */
   self.close = function() {
     self.openPercentage(0);
+    $rootScope.$emit('$ionicSideMenuClose', 'left');
+    $rootScope.$emit('$ionicSideMenuClose', 'right');
   };
 
   /**

--- a/test/unit/angular/controller/sideMenuController.unit.js
+++ b/test/unit/angular/controller/sideMenuController.unit.js
@@ -322,6 +322,43 @@ describe('$ionicSideMenus controller', function() {
     expect(deregSpy).toHaveBeenCalled();
   }));
 
+  it('should emit $ionicSideMenuOpen on open and $ionicSideMenuClose on close', inject(function($rootScope){
+    // create spies and event listeners
+    var openSpy = jasmine.createSpy('openSpy');
+    $rootScope.$on('$ionicSideMenuOpen', openSpy);
+    var closeSpy = jasmine.createSpy('openSpy');
+    $rootScope.$on('$ionicSideMenuClose', closeSpy);
+
+    // left open
+    ctrl.toggleLeft();
+    expect(ctrl.getOpenPercentage()).toEqual(100);
+    ctrl.$scope.$apply();
+    expect(openSpy).toHaveBeenCalled();
+    expect(openSpy.mostRecentCall.args[1]).toEqual("left");
+
+    // left close
+    ctrl.toggleLeft();
+    expect(ctrl.getOpenPercentage()).toEqual(0);
+    ctrl.$scope.$apply();
+    expect(closeSpy).toHaveBeenCalled();
+    expect(closeSpy.mostRecentCall.args[1]).toEqual("left");
+
+    // right open
+    ctrl.toggleRight();
+    expect(ctrl.getOpenPercentage()).toEqual(-100);
+    ctrl.$scope.$apply();
+    expect(openSpy).toHaveBeenCalled();
+    expect(openSpy.mostRecentCall.args[1]).toEqual("right");
+
+    // right close
+    ctrl.toggleRight();
+    expect(ctrl.getOpenPercentage()).toEqual(0);
+    ctrl.$scope.$apply();
+    expect(closeSpy).toHaveBeenCalled();
+    expect(closeSpy.mostRecentCall.args[1]).toEqual("right");
+  }));
+
+
   it('should deregister back button action on $destroy', inject(function($ionicPlatform) {
     var openAmount = 0;
     var deregSpy = jasmine.createSpy('deregister');


### PR DESCRIPTION
feat $ionicSideMenus: add '$ionicSideMenuOpen'/ '$ionicSideMenuClose' event

add an event ($ionicSideMenuOpen or $ionicSideMenuClose) broadcast on menu open/close.
$ionicSideMenuOpen and $ionicSideMenuClose include the menu side (ie. 'left' or 'right').

fixes #3579