### PR TITLE
WP8.1 Update 1’s changes a user agent of a default browser and IE introd...

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -249,12 +249,12 @@
         platformName = n.toLowerCase();
       } else if (getParameterByName('ionicplatform')) {
         platformName = getParameterByName('ionicplatform');
+      } else if (self.ua.indexOf('Windows Phone') > -1) {
+        platformName = WINDOWS_PHONE;
       } else if (self.ua.indexOf('Android') > 0) {
         platformName = ANDROID;
       } else if (/iPhone|iPad|iPod/.test(self.ua)) {
         platformName = IOS;
-      } else if (self.ua.indexOf('Windows Phone') > -1) {
-        platformName = WINDOWS_PHONE;
       } else {
         platformName = self.navigator.platform && navigator.platform.toLowerCase().split(' ')[0] || '';
       }


### PR DESCRIPTION
WP8.1 Update 1’s IE User agent pretends to be Android 4.0 and iOS 7 therefore we should search for 'Windows Phone' prior to 'Android' or 'iOS'. Further details: http://wmpoweruser.com/wp8-1-update-1s-ie-user-agent-pretends-to-be-android-4-0-and-ios-7-good-enough-to-fool-gmail/
However, the user agent of a webview remains unchanged :)