### PR TITLE
ion-content must be nudged when it's content height changes

### DIFF
--- a/js/angular/directive/content.js
+++ b/js/angular/directive/content.js
@@ -21,6 +21,12 @@
  * Be aware that this directive gets its own child scope. If you do not understand why this
  * is important, you can read [https://docs.angularjs.org/guide/scope](https://docs.angularjs.org/guide/scope).
  *
+ * If content is added or removed, hidden or shown that changes the expected height, you must trigger a resize of the scroller.
+ * Do this by giving the ion-conent a delegate-handle and then after the code changes the content : 
+ * 
+ * var scr=$ionicScrollDelegate.$getByHandle('the delegate-handle value'); 
+ * scr.scrollTo(0,scr.getScrollPosition().top,true); 
+ *
  * @param {string=} delegate-handle The handle used to identify this scrollView
  * with {@link ionic.service:$ionicScrollDelegate}.
  * @param {string=} direction Which way to scroll. 'x' or 'y' or 'xy'. Default 'y'.


### PR DESCRIPTION
As noted in #3591 unless ion-content is told that it's contents have changed height, it will continue to be the wrong height until some subsequent scroll event. This causes things like off-screen inaccessible buttons or cut off text.