### PR TITLE
Update sliderView.js

### DIFF
--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -551,7 +551,7 @@ ionic.views.Slider = ionic.views.View.inherit({
       element.style.left = '';
 
       // reset slides so no refs are held on to
-      slides && (slides.length = 0);
+      if (slides && slides.length) slides = undefined;
 
       // removed event listeners
       if (browser.addEventListener) {


### PR DESCRIPTION
Errors out in iOS since setting length is a readonly attributes:

```
246   468715   error    Error: Attempted to assign to readonly property.
kill@http://192.168.1.110:8100/cordovaBundle.js:8423:26
http://192.168.1.110:8100/cordovaBundle.js:54186:22
$broadcast@http://192.168.1.110:8100/cordovaBundle.js:23356:35
$destroy@http://192.168.1.110:8100/cordovaBundle.js:22976:26
destroyViewEle@http://192.168.1.110:8100/cordovaBundle.js:46673:29
cleanup@http://192.168.1.110:8100/cordovaBundle.js:46520:29
transitionComplete@http://192.168.1.110:8100/cordovaBundle.js:46461:33
completeOnTransitionEnd@http://192.168.1.110:8100/cordovaBundle.js:46440:33
eventHandler@http://192.168.1.110:8100/cordovaBundle.js:11650:27
```