### PR TITLE
Fixed border-radius when only one button exists in a button-bar

### DIFF
--- a/scss/_button-bar.scss
+++ b/scss/_button-bar.scss
@@ -26,7 +26,7 @@
 .button-bar > .button {
   @include flex(1);
   display: block;
-  
+
   overflow: hidden;
 
   padding: 0 16px;
@@ -50,5 +50,8 @@
   &:last-child {
     border-right-width: 1px;
     border-radius: 0px $button-border-radius $button-border-radius 0px;
+  }
+  &:only-child {
+    border-radius: $button-border-radius;
   }
 }


### PR DESCRIPTION
When having only one button in a buttonbar the left border had no radius