### PR TITLE
bower.json: Remove font files from `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,6 @@
   "description": "Advanced HTML5 hybrid mobile app development framework.",
   "main": [
     "release/css/ionic.css",
-    "release/fonts/*",
     "release/js/ionic.js",
     "release/js/ionic-angular.js"
   ],


### PR DESCRIPTION
Per bower/bower.json-spec#43 :
> font files [...] are not `main` files as they are not entry-points. [...]
> * Globs [...] are not allowed.