### PR TITLE
$ionicHistory.clearCache() now returns promise so you can ensure cache is cleared …

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -647,11 +647,12 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
     /**
      * @ngdoc method
      * @name $ionicHistory#clearCache
+	 * @return promise
      * @description Removes all cached views within every {@link ionic.directive:ionNavView}.
      * This both removes the view element from the DOM, and destroy it's scope.
      */
     clearCache: function(stateIds) {
-      $timeout(function() {
+      return $timeout(function() {
         $ionicNavViewDelegate._instances.forEach(function(instance) {
           instance.clearCache(stateIds);
         });


### PR DESCRIPTION
**Enables promise chaining**. Otherwise in the example below, cache would not be clear before $state.go call and app.home would not update. 

Example:
```
// In PreferencesCtrl:
$scope.clearCache().then((function() {
  return knetAccountHelper.updateSettings('preferences');
})).then((function() {
  return $state.go('app.home')
}));
```

Note, app.home is caching its view by default (I have not set cache:false in its state definition). In the scenario above, I want app.home to be cached in most cases except after leaving my preferences view which affects what is displayed at app.home. 