### PR TITLE
Fixed mixin usage for bar elements

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -13,7 +13,7 @@
   left: 0;
   z-index: $z-index-bar;
 
-  box-sizing: border-box;
+  @include box-sizing(border-box);
   padding: $bar-padding-portrait;
 
   width: 100%;


### PR DESCRIPTION
Nothing serious, just a small fix.
That was the only instance where not the provided mixin was used.
