### PR TITLE
Fixed issue where tabs in card showed wrong border style

### DIFF
--- a/scss/_tabs.scss
+++ b/scss/_tabs.scss
@@ -26,21 +26,30 @@
 
   background-size: 0;
   line-height: $tabs-height;
+}
 
-  @media (min--moz-device-pixel-ratio: 1.5),
-         (-webkit-min-device-pixel-ratio: 1.5),
-         (min-device-pixel-ratio: 1.5),
-         (min-resolution: 144dpi),
-         (min-resolution: 1.5dppx) {
+@media (min--moz-device-pixel-ratio: 1.5),
+       (-webkit-min-device-pixel-ratio: 1.5),
+       (min-device-pixel-ratio: 1.5),
+       (min-resolution: 144dpi),
+       (min-resolution: 1.5dppx) {
+  .card .tabs.item {
+    border-top-width: $item-border-width !important;
+    background-size: 0;
+  }
+  .card .tabs.item:first-child {
+    border-top-width: initial !important;
+  }
+  .tabs {
     padding-top: 2px;
-    border-top: none !important;
+    border-top-width: 0 !important;
     border-bottom: none;
     background-position: top;
     background-size: 100% 1px;
     background-repeat: no-repeat;
   }
-
 }
+
 /* Allow parent element of tabs to define color, or just the tab itself */
 .tabs-light > .tabs,
 .tabs.tabs-light {


### PR DESCRIPTION
When you have [tabs in cards](http://ionicframework.com/docs/components/#card-showcase), the border looks off.

This is what tabs look like (best viewed full-size).
Top (has a top border):
![top-old](https://cloud.githubusercontent.com/assets/864507/7639721/07597494-fa4c-11e4-88e7-b7b833a4b581.png)

Bottom (has a hard 1px top border):
![bottom-old](https://cloud.githubusercontent.com/assets/864507/7639693/d73397cc-fa4b-11e4-8875-01abc5c59c6b.png)

This is what they should look like.
Top (no top border):
![top-new](https://cloud.githubusercontent.com/assets/864507/7639704/e5c9608c-fa4b-11e4-8158-08402cced4b1.png)

Bottom (soft 2px top border):
![bottom-new](https://cloud.githubusercontent.com/assets/864507/7639709/eb407abe-fa4b-11e4-8763-e0317ceb75cb.png)