### PR TITLE
iOS menu-side-shadow fix

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -552,7 +552,7 @@ $menu-bg:                         #fff !default;
 $menu-width:                      275px !default;
 $menu-animation-speed:            200ms !default;
 
-$menu-side-shadow:                -1px 0px 2px rgba(0, 0, 0, 0.2), 1px 0px 2px rgba(0,0,0,0.2) !default;
+$menu-side-shadow:                0px 0px 3px rgba(0, 0, 0, 0.2) !default;
 
 
 // Modals


### PR DESCRIPTION
When testing an app with a side menu on iOS, the side-shadow does not appear. It seems iOS has an issue with multiple values for box-shadow, so I've opted instead create a single shadow that extends equally on both sides.

It should look identical to the existing shadow on most devices, but fix the issue with iOS displaying no shadow.

For reference, the device this was tested on was an iPhone 6 Plus.