### PR TITLE
Remove expiration on nextViewOptions

### DIFF
--- a/js/angular/directive/menuClose.js
+++ b/js/angular/directive/menuClose.js
@@ -32,8 +32,7 @@ IonicModule
         if (sideMenuCtrl) {
           $ionicHistory.nextViewOptions({
             historyRoot: true,
-            disableAnimate: true,
-            expire: 300
+            disableAnimate: true
           });
           sideMenuCtrl.close();
         }


### PR DESCRIPTION
Not sure if this is old or necessary for an edge-case, but the expiration breaks states that use a `resolve` that can exceed 300ms. This is a simplistic patch under the assumption that it might be an outdated or unnecessary option.

Fixes ~~#3745~~ #3027