### PR TITLE
Update navBarController to support ngClass

### DIFF
--- a/js/angular/controller/navBarController.js
+++ b/js/angular/controller/navBarController.js
@@ -48,7 +48,7 @@ function($scope, $element, $attrs, $compile, $timeout, $ionicNavBarDelegate, $io
     ionic.DomUtil.cachedAttr(containerEle, 'nav-bar', isActive ? 'active' : 'cached');
 
     var alignTitle = $attrs.alignTitle || $ionicConfig.navBar.alignTitle();
-    var headerBarEle = jqLite('<ion-header-bar>').addClass($attrs['class']).attr('align-title', alignTitle);
+    var headerBarEle = jqLite('<ion-header-bar>').addClass($attrs['class']).attr('ng-class', $attrs.ngClass).attr('align-title', alignTitle);
     if (isDefined($attrs.noTapScroll)) headerBarEle.attr('no-tap-scroll', $attrs.noTapScroll);
     var titleEle = jqLite('<div class="title title-' + alignTitle + '">');
     var navEle = {};


### PR DESCRIPTION
Fixes #2732

When ionNavBar creates an ionHeaderBar, this change will copy not just $attrs['class'] from the ionNavBar element but also its $attrs['ngClass'] if defined. This allows us to use ngClass on ionNavBar.