### PR TITLE
feat(on-slide-moved): add on-slide-moved expression to slideBox

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -33,6 +33,7 @@
  * @param {boolean=} show-pager Whether a pager should be shown for this slide box. Accepts expressions via `show-pager="{{shouldShow()}}"`. Defaults to true.
  * @param {expression=} pager-click Expression to call when a pager is clicked (if show-pager is true). Is passed the 'index' variable.
  * @param {expression=} on-slide-changed Expression called whenever the slide is changed.  Is passed an '$index' variable.
+ * @param {expression=} on-slide-moved Expression called whenever the current slide is moved.  Is passed a 'fromSlide' variable of the current slide index and a 'toSlide' variable with the index of the slide it's moving to. The third variable 'position' is a float value between 0 and 1 and describes the position of the movement. 0 means the slider shows the fromSlide, 1 means the slider shows the toSlide.
  * @param {expression=} active-slide Model to bind the current slide to.
  */
 IonicModule
@@ -55,6 +56,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
+      onSlideMoved: '&',
       activeSlide: '=?'
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
@@ -82,6 +84,9 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
           $scope.activeSlide = slideIndex;
           // Try to trigger a digest
           $timeout(function() {});
+        },
+        onSlideMoved: function(from, to, slidePosition) {
+          $scope.onSlideMoved({fromSlide: from, toSlide: to, position: slidePosition});
         },
         onDrag: function() {
           freezeAllScrolls(true);

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -367,6 +367,14 @@ ionic.views.Slider = ionic.views.View.inherit({
           }
 
           options.onDrag && options.onDrag();
+
+          var movePosition = delta.x  / width;
+          if(movePosition < 0) {
+            options.onSlideMoved && options.onSlideMoved(index, circle(index+1), Math.abs(movePosition));
+          }
+          else {
+            options.onSlideMoved && options.onSlideMoved(index, circle(index-1), movePosition);
+          }
         }
 
       },

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -368,7 +368,7 @@ ionic.views.Slider = ionic.views.View.inherit({
 
           options.onDrag && options.onDrag();
 
-          var movePosition = (delta.x  / width);
+          var movePosition = (delta.x / width);
           if(movePosition < 0) {
             options.onSlideMoved && options.onSlideMoved(index, circle(index+1), Math.abs(movePosition));
           }

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -370,10 +370,10 @@ ionic.views.Slider = ionic.views.View.inherit({
 
           var movePosition = (delta.x / width);
           if(movePosition < 0) {
-            options.onSlideMoved && options.onSlideMoved(index, circle(index+1), Math.abs(movePosition));
+            options.onSlideMoved && options.onSlideMoved(index, circle(index + 1), Math.abs(movePosition));
           }
           else {
-            options.onSlideMoved && options.onSlideMoved(index, circle(index-1), movePosition);
+            options.onSlideMoved && options.onSlideMoved(index, circle(index - 1), movePosition);
           }
         }
 

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -368,7 +368,7 @@ ionic.views.Slider = ionic.views.View.inherit({
 
           options.onDrag && options.onDrag();
 
-          var movePosition = delta.x  / width;
+          var movePosition = (delta.x  / width);
           if(movePosition < 0) {
             options.onSlideMoved && options.onSlideMoved(index, circle(index+1), Math.abs(movePosition));
           }

--- a/test/html/slideBox.html
+++ b/test/html/slideBox.html
@@ -53,6 +53,7 @@
           </ion-header-bar>
           <ion-slide-box ng-if="!$root.hideSlideBox"
                          on-slide-changed="slideChanged(index)"
+                         on-slide-moved="slideMoved(fromSlide, toSlide, position)"
                          show-pager="{{$root.showPager}}"
                          pager-click="pagerClick(index)"
                          does-continue="true"
@@ -178,6 +179,10 @@
             $scope.rightButtons = rightButtons;
           }
         };
+
+        $scope.slideMoved = function(from, to, pos) {
+            console.log("Slide moved", from, to, pos);
+        }
       })
 
       .controller('FirstSlideCtrl', function($scope, $ionicSlideBoxDelegate) {


### PR DESCRIPTION
Hello,

kuwabarahiroshi already tried to add an on-slide-moved callback here: https://github.com/driftyco/ionic/pull/2766

There was no new comment since 2 months, so i decided to make a similiar pull request. I'm passing the currentSlide, the targetSlide and a paramenter for the relative Position between the currentSlide and the targetSlide. This parameter is a float value between 0 and 1. I would love to see it in the Ionic core, because it allows, for example, to easily add slidingTabs to the slideBox, like i'm doing it in this example: http://knorr.ruhr/ionic/
In a future pull request i would add an directive that brings the native Android sliding Tabs(from Material Design Sepcs) to ionic.
That these sliding Tabs are wished you can see here:
http://forum.ionicframework.com/t/ionic-sliding-tabs/18917

I'm sure you want me to add some unit test, but i couldn't find a similiar unit test for the on-slide-changed expression (for example). So i just added an example to the HTML tests, where you can see the behaviour of the feature in the console. 