### PR TITLE
Disable $animate animations to allow correct count of slides

### DIFF
--- a/scss/_slide-box.scss
+++ b/scss/_slide-box.scss
@@ -23,6 +23,17 @@
   width: 100%;
   height: 100%;
   vertical-align: top;
+  //Disable animations
+  &.ng-enter,
+  &.ng-leave,
+  &.ng-animate {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
+  &.ng-animate {
+    -webkit-animation: none 0s;
+    animation: none 0s;
+  }
 }
 
 .slider-slide-image {

--- a/scss/_slide-box.scss
+++ b/scss/_slide-box.scss
@@ -23,17 +23,6 @@
   width: 100%;
   height: 100%;
   vertical-align: top;
-  //Disable animations
-  &.ng-enter,
-  &.ng-leave,
-  &.ng-animate {
-    -webkit-transition: none !important;
-    transition: none !important;
-  }
-  &.ng-animate {
-    -webkit-animation: none 0s;
-    animation: none 0s;
-  }
 }
 
 .slider-slide-image {
@@ -63,5 +52,20 @@
       @include transition(opacity 0.4s ease-in);
       opacity: 1;
     }
+  }
+}
+
+//Disable animate service animations
+.slider-slide,
+.slider-pager-page {
+  &.ng-enter,
+  &.ng-leave,
+  &.ng-animate {
+    -webkit-transition: none !important;
+    transition: none !important;
+  }
+  &.ng-animate {
+    -webkit-animation: none 0s;
+    animation: none 0s;
   }
 }


### PR DESCRIPTION
Fixes issues #3646 and #3076. $animate was delaying the removal of elements. Therefore when the slide-box child elements were counted the reported length would be inaccurate.

Thanks,
Ross