### PR TITLE
feat(slide-box): allow slide-box to use scope variables for delegate handler

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -55,7 +55,8 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
-      activeSlide: '=?'
+      activeSlide: '=?',
+      delegateHandle: '@?'
     },
     controller: ['$scope', '$element', '$attrs', function($scope, $element, $attrs) {
       var _this = this;
@@ -125,7 +126,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
       this.__slider = slider;
 
       var deregisterInstance = $ionicSlideBoxDelegate._registerInstance(
-        slider, $attrs.delegateHandle, function() {
+        slider, $scope.delegateHandle, function() {
           return $ionicHistory.isActiveScope($scope);
         }
       );

--- a/test/unit/angular/directive/slideBox.unit.js
+++ b/test/unit/angular/directive/slideBox.unit.js
@@ -34,7 +34,9 @@ describe('Ionic Angular Slide Box', function() {
     spyOn($ionicSlideBoxDelegate, '_registerInstance').andCallFake(function() {
       return deregisterSpy;
     });
-    var el = $compile('<ion-slide-box delegate-handle="superHandle">')($rootScope.$new());
+    var $scope = $rootScope.$new();
+    $scope.slideBoxHandle = 'superHandle';
+    var el = $compile('<ion-slide-box delegate-handle="{{slideBoxHandle}}">')($scope);
     $rootScope.$apply();
 
     expect($ionicSlideBoxDelegate._registerInstance)


### PR DESCRIPTION
**Use case**: In a list view, I want to show one slide box per row, so there will be N slide boxes for N results in the list.

**Problem**: Currently `delegate-handle` will not accept and interpolate angular variables if you specify `delegate-handle="{{item.id}}"`.  The reason I need to use `delegate-handle` is so that when the user interacts with it, it shouldn't affect slide boxes on other rows.

I'm not sure how else you would achieve this solution, but open to suggestions.

Also, I noticed this pattern for the delegate handler is in other directives, ``content``, ``scroll``, and ``tabs``.  If are happy with this PR, perhaps consider porting this to the other directives to keep it consistent.