### PR TITLE
Fixed incorrect order of $ionicView and $ionicNavView events.

### DIFF
--- a/js/angular/service/viewSwitcher.js
+++ b/js/angular/service/viewSwitcher.js
@@ -297,28 +297,31 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
         },
 
         emit: function(step, enteringData, leavingData) {
-          var scope = enteringEle.scope();
-          if (scope) {
-            scope.$emit('$ionicView.' + step + 'Enter', enteringData);
-            if (step == 'after') {
-              scope.$emit('$ionicView.enter', enteringData);
+          var enteringScope = enteringEle.scope(),
+            leavingScope = leavingEle && leavingEle.scope();
+          
+          if (step == 'after') {
+            if (enteringScope) {
+              enteringScope.$emit('$ionicView.enter', enteringData);
+            }
+            
+            if (leavingScope) {
+              leavingScope.$emit('$ionicView.leave', leavingData);
+              
+            } else if (enteringScope && leavingData && leavingData.viewId) {
+              enteringScope.$emit('$ionicNavView.leave', leavingData);
             }
           }
-
-          if (leavingEle) {
-            scope = leavingEle.scope();
-            if (scope) {
-              scope.$emit('$ionicView.' + step + 'Leave', leavingData);
-              if (step == 'after') {
-                scope.$emit('$ionicView.leave', leavingData);
-              }
-            }
-
-          } else if (scope && leavingData && leavingData.viewId) {
-            scope.$emit('$ionicNavView.' + step + 'Leave', leavingData);
-            if (step == 'after') {
-              scope.$emit('$ionicNavView.leave', leavingData);
-            }
+          
+          if (enteringScope) {
+            enteringScope.$emit('$ionicView.' + step + 'Enter', enteringData);
+          }
+          
+          if (leavingScope) {
+            leavingScope.$emit('$ionicView.' + step + 'Leave', leavingData);
+            
+          } else if (enteringScope && leavingData && leavingData.viewId) {
+            enteringScope.$emit('$ionicNavView.' + step + 'Leave', leavingData);
           }
         },
 

--- a/js/angular/service/viewSwitcher.js
+++ b/js/angular/service/viewSwitcher.js
@@ -299,27 +299,27 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
         emit: function(step, enteringData, leavingData) {
           var enteringScope = enteringEle.scope(),
             leavingScope = leavingEle && leavingEle.scope();
-          
+
           if (step == 'after') {
             if (enteringScope) {
               enteringScope.$emit('$ionicView.enter', enteringData);
             }
-            
+
             if (leavingScope) {
               leavingScope.$emit('$ionicView.leave', leavingData);
-              
+
             } else if (enteringScope && leavingData && leavingData.viewId) {
               enteringScope.$emit('$ionicNavView.leave', leavingData);
             }
           }
-          
+
           if (enteringScope) {
             enteringScope.$emit('$ionicView.' + step + 'Enter', enteringData);
           }
-          
+
           if (leavingScope) {
             leavingScope.$emit('$ionicView.' + step + 'Leave', leavingData);
-            
+
           } else if (enteringScope && leavingData && leavingData.viewId) {
             enteringScope.$emit('$ionicNavView.' + step + 'Leave', leavingData);
           }

--- a/test/unit/angular/directive/navView.unit.js
+++ b/test/unit/angular/directive/navView.unit.js
@@ -900,7 +900,7 @@ describe('Ionic nav-view', function() {
     expect(afterLeave.stateName).toEqual('page1');
     expect(leave.stateName).toEqual('page1');
     expect(leave.transitionId).toEqual(2);
-
+    
     $state.go(page1State);
     $q.flush();
     $timeout.flush();
@@ -1008,6 +1008,59 @@ describe('Ionic nav-view', function() {
     $timeout.flush();
 
     expect(unloadedEvent.stateName).toEqual('tabAbstract.tab3page1');
+  }));
+  
+  it('should emit $ionicView events in correct order', inject(function ($state, $q, $timeout, $compile, $ionicConfig) {
+    $ionicConfig.views.maxCache(0);
+  
+    var order = [];
+    scope.$on('$ionicView.loaded', function(ev, d){
+      order.push('$ionicView.loaded');
+    });
+    scope.$on('$ionicView.beforeEnter', function(ev, d){
+      order.push('$ionicView.beforeEnter');
+    });
+    scope.$on('$ionicView.enter', function(ev, d){
+      order.push('$ionicView.enter');
+    });
+    scope.$on('$ionicView.afterEnter', function(ev, d){
+      order.push('$ionicView.afterEnter');
+    });
+    scope.$on('$ionicView.beforeLeave', function(ev, d){
+      order.push('$ionicView.beforeLeave');
+    });
+    scope.$on('$ionicView.leave', function(ev, d){
+      order.push('$ionicView.leave');
+    });
+    scope.$on('$ionicView.afterLeave', function(ev, d){
+      order.push('$ionicView.afterLeave');
+    });
+    scope.$on('$ionicView.unloaded', function(ev, d){
+      order.push('$ionicView.unloaded');
+    });
+
+    elem.append($compile('<div><ion-nav-view></ion-nav-view></div>')(scope));
+
+    $state.go(page1State);
+    $q.flush();
+    $timeout.flush();
+
+    $state.go(page2State);
+    $q.flush();
+    $timeout.flush();
+
+    expect(order[0]).toEqual('$ionicView.loaded');
+    expect(order[1]).toEqual('$ionicView.beforeEnter');
+    expect(order[2]).toEqual('$ionicView.enter');
+    expect(order[3]).toEqual('$ionicView.afterEnter');
+    expect(order[4]).toEqual('$ionicView.loaded');
+    expect(order[5]).toEqual('$ionicView.beforeEnter');
+    expect(order[6]).toEqual('$ionicView.beforeLeave');
+    expect(order[7]).toEqual('$ionicView.enter');
+    expect(order[8]).toEqual('$ionicView.leave');
+    expect(order[9]).toEqual('$ionicView.afterEnter');
+    expect(order[10]).toEqual('$ionicView.afterLeave');
+    expect(order[11]).toEqual('$ionicView.unloaded');
   }));
 
   it('should clear ion-nav-view cache', inject(function ($state, $q, $timeout, $compile, $ionicHistory) {


### PR DESCRIPTION
Solves issue #3800

Based on the original behavior I worked under the assumption that navigating from view 1 to view 2 should trigger events in the following order (given that neither is cached):
```
$ionicView.loaded (view 2)
$ionicView.beforeEnter (view 2)
$ionicView.beforeLeave (view 1)
$ionicView.enter (view 2)
$ionicView.leave (view 1)
$ionicView.afterEnter (view 2)
$ionicView.afterLeave (view 1)
$ionicView.unloaded (view 1)
```