### PR TITLE
[ionicHistory] add method to remove the back view

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -599,6 +599,37 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
       viewHistory.backView && viewHistory.backView.go();
     },
 
+    /**
+     * @ngdoc method
+     * @name $ionicHistory#removeBackView
+     * @description Remove the previous view from the history completely, including the 
+     * cached element and scope (if they exist).
+     */
+    removeBackView: function () {
+      var self = this;
+      var currentHistory = viewHistory.histories[this.currentHistoryId()];
+      var currentCursor = currentHistory.cursor;
+
+      var currentView = currentHistory.stack[currentCursor];
+      var backView = currentHistory.stack[currentCursor - 1];
+      var replacementView = currentHistory.stack[currentCursor - 2];
+
+      // fail if we dont have enough views in the history
+      if (!backView || !replacementView) {
+        return;
+      }
+
+      // remove the old backView and the cached element/scope
+      currentHistory.stack.splice(currentCursor - 1, 1);
+      self.clearCache([backView.viewId]);
+      // make the replacementView and currentView point to each other (bypass the old backView)
+      currentView.backViewId = replacementView.viewId;
+      currentView.index = currentView.index - 1;
+      replacementView.forwardViewId = currentView.viewId;
+      // update the cursor and set new backView
+      viewHistory.backView = replacementView;
+      currentHistory.currentCursor += -1;
+    },
 
     enabledBack: function(view) {
       var backView = getBackView(view);

--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -602,7 +602,7 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
     /**
      * @ngdoc method
      * @name $ionicHistory#removeBackView
-     * @description Remove the previous view from the history completely, including the 
+     * @description Remove the previous view from the history completely, including the
      * cached element and scope (if they exist).
      */
     removeBackView: function () {


### PR DESCRIPTION
solves issue #3750

Adds a method `$ionicHistory.removeBackView()` which removes the cached view, element, scope, and rejigs the history. I'm already using this in production in various use-cases. 

This predominantly solves the issue where in most angular applications you can use `$state.go('app.foo', { location: 'replace' })` except in ionic, the history is managed manually - this is the solution.

Would be good to have it part of the core!

I'm working on the method `$ionicHistory.removeFromHistory(stateName/id)` which we also need for our app - and the ionic community would also benefit from this going forward. Keep an eye out.