### PR TITLE
fix(listView:_startDrag): do not scroll freeze when no scrollView

### DIFF
--- a/js/views/listView.js
+++ b/js/views/listView.js
@@ -552,7 +552,10 @@
           });
           self._dragOp.start(e);
           e.preventDefault();
-          self.isScrollFreeze = self.scrollView.freeze(true);
+
+          if (self.scrollView) {
+            self.isScrollFreeze = self.scrollView.freeze(true);
+          }
         }
       }
 


### PR DESCRIPTION
I was getting "Uncaught TypeError: Cannot read property 'freeze'" when swiping a list item. Similar to driftyco/ionic#3174.