### PR TITLE
fix(slidebox): removing an item breaks slidebox

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -37,12 +37,13 @@
  */
 IonicModule
 .directive('ionSlideBox', [
+  '$animate',
   '$timeout',
   '$compile',
   '$ionicSlideBoxDelegate',
   '$ionicHistory',
   '$ionicScrollDelegate',
-function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScrollDelegate) {
+function($animate, $timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScrollDelegate) {
   return {
     restrict: 'E',
     replace: true,
@@ -153,6 +154,9 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
     '</div>',
 
     link: function($scope, $element, $attr) {
+      // Disable ngAnimate for slidebox and its children
+      $animate.enabled(false, $element);
+
       // if showPager is undefined, show the pager
       if (!isDefined($attr.showPager)) {
         $scope.showPager = true;


### PR DESCRIPTION
By default, because Ionic is using ngAnimate, when you use ngRepeat, angular will not destroy the DOM of the element straight away, but it will first add the css class: ng-leave to give the user a chance to set animation when deleting an item from the array.

This commit disables $animate for the slideBox element.