### PR TITLE
Fix preLink function using compile attributes

### DIFF
--- a/js/angular/directive/content.js
+++ b/js/angular/directive/content.js
@@ -130,7 +130,7 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
 
             scrollViewOptions = {
               el: $element[0],
-              delegateHandle: attr.delegateHandle,
+              delegateHandle: $attr.delegateHandle,
               startX: $scope.$eval($scope.startX) || 0,
               startY: $scope.$eval($scope.startY) || 0,
               nativeScrolling: true
@@ -140,8 +140,8 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
             // Use JS scrolling
             scrollViewOptions = {
               el: $element[0],
-              delegateHandle: attr.delegateHandle,
-              locking: (attr.locking || 'true') === 'true',
+              delegateHandle: $attr.delegateHandle,
+              locking: ($attr.locking || 'true') === 'true',
               bouncing: $scope.$eval($scope.hasBouncing),
               startX: $scope.$eval($scope.startX) || 0,
               startY: $scope.$eval($scope.startY) || 0,
@@ -167,7 +167,7 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
             }
             innerElement = null;
             $element = null;
-            attr.$$element = null;
+            $attr.$$element = null;
           });
         }
 


### PR DESCRIPTION
The preLink function is using the compile attr param not the preLink $attr param for delegate-handle and locking attributes. This causes problems when using ion-content in an ng-repeat. The delegate-handle is properly set using the preLink attributes in other directives like ion-scroll. This does not address the issue of interpolation for delegate-handle but allows an additional directive to do so.