### PR TITLE
Added support for .item-stacked-label and select statements

### DIFF
--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -156,6 +156,15 @@ textarea {
   height: $line-height-computed + $font-size-base + 12px;
 }
 
+.item-stacked-label select {
+  position: relative; 
+  padding: 0px; 
+  max-width: 90%; 
+  direction:ltr; 
+  white-space: pre-wrap;
+  margin: -3px;
+}
+
 .item-floating-label {
   display: block;
   background-color: transparent;

--- a/scss/_form.scss
+++ b/scss/_form.scss
@@ -156,7 +156,7 @@ textarea {
   height: $line-height-computed + $font-size-base + 12px;
 }
 
-.item-stacked-label select {
+.item-select.item-stacked-label select {
   position: relative; 
   padding: 0px; 
   max-width: 90%; 


### PR DESCRIPTION
I have a select statement with long option names that get cut off in the traditional inline select, so I added in support for item-stacked-label and selects that put the select on a new line. 
![screenshot from 2015-05-31 12 45 22](https://cloud.githubusercontent.com/assets/714285/7903185/11d6599a-079a-11e5-8474-898baeb8f170.png)
![screenshot from 2015-05-31 13 37 10](https://cloud.githubusercontent.com/assets/714285/7903191/279caedc-079a-11e5-939b-cb2be0574760.png)


