### PR TITLE
Disable keyboard hacks for iOS WKWebview

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -726,6 +726,10 @@ function keyboardHasPlugin() {
 }
 
 ionic.Platform.ready(function() {
+  
+  // if using https://github.com/apache/cordova-plugins/tree/master/keyboard
+  if (ionic.Platform.isIOS() && window.Keyboard) return;
+  
   keyboardInitViewportHeight();
 
   window.addEventListener('orientationchange', keyboardOrientationChange);


### PR DESCRIPTION
The WKWebView + cordova keyboard plugin do a fantastic job on controlling scrolling, especially when using non-js scrolling.

I think a default should go towards *not* trying to to disable iOS defaults on up to date browsers.