### PR TITLE
Allow native scroll freezing through the $ionicScrollDelegate

### DIFF
--- a/js/views/scrollViewNative.js
+++ b/js/views/scrollViewNative.js
@@ -50,7 +50,20 @@
         }, 80);
       };
 
-      self.freeze = NOOP;
+      self.canScroll = function(e) {
+        if (self.options.freeze) {
+          e.preventDefault();
+          return false;
+        }
+        return true;
+      };
+
+      self.freeze = function(shouldFreeze) {
+        if (arguments.length) {
+          self.options.freeze = shouldFreeze;
+        }
+        return self.options.freeze;
+      };
 
       self.__initEventHandlers();
     },
@@ -249,7 +262,6 @@
     },
 
 
-
     /*
      ---------------------------------------------------------------------------
      PRIVATE API
@@ -308,6 +320,11 @@
         }
       };
 
+      container.addEventListener('touchstart', self.canScroll);
+      container.addEventListener('scroll', self.canScroll);
+      container.addEventListener('mousewheel', self.canScroll);
+      container.addEventListener('onmousewheel', self.canScroll);
+      container.addEventListener('DOMMouseScroll', self.canScroll);
       container.addEventListener('resetScrollView', self.resetScrollView);
       container.addEventListener('scroll', self.onScroll);
 
@@ -320,6 +337,12 @@
     __cleanup: function() {
       var self = this;
       var container = self.__container;
+
+      container.removeEventListener('touchstart', self.canScroll);
+      container.removeEventListener('scroll', self.canScroll);
+      container.removeEventListener('mousewheel', self.canScroll);
+      container.removeEventListener('onmousewheel', self.canScroll);
+      container.removeEventListener('DOMMouseScroll', self.canScroll);
 
       container.removeEventListener('resetScrollView', self.resetScrollView);
       container.removeEventListener('scroll', self.onScroll);

--- a/test/unit/views/scrollViewNative.unit.js
+++ b/test/unit/views/scrollViewNative.unit.js
@@ -19,7 +19,7 @@ describe('Scroll View', function() {
     });
 
     expect(sc.addEventListener).toHaveBeenCalled();
-    expect(sc.addEventListener.callCount).toBe(4);
+    expect(sc.addEventListener.callCount).toBe(9);
     expect(sc.addEventListener.mostRecentCall.args[0]).toBe('resetScrollView');
   });
 
@@ -31,7 +31,7 @@ describe('Scroll View', function() {
     sv.__cleanup();
 
     expect(sc.removeEventListener).toHaveBeenCalled();
-    expect(sc.removeEventListener.callCount).toBe(4);
+    expect(sc.removeEventListener.callCount).toBe(9);
     expect(sc.removeEventListener.mostRecentCall.args[0]).toBe('resetScrollView');
   });
 


### PR DESCRIPTION
This PR allows the $ionicScrollDelegate to freeze the native scroll view. It's been tested on Android 4.0+, iOS 6+ and Windows Phone 8. No API changes, usage is exactly the same:

```js
$ionicScrollDelegate.freezeScroll();
```

Let me know if anything needs changing/updating, or if there is something I have missed in the bigger picture (ionic is still fairly new to me!)