### PR TITLE
Fix for ion checkbox right alignment issue on android

### DIFF
--- a/scss/_checkbox.scss
+++ b/scss/_checkbox.scss
@@ -127,6 +127,10 @@ input:checked + .checkbox-icon:before {
   height: 7px;
 }
 
+.platform-android .item-checkbox-right .checkbox-square .checkbox-icon::after {
+  top: 31%;
+}
+
 .grade-c .checkbox input:after,
 .grade-c .checkbox-icon:after {
   @include rotate(0);


### PR DESCRIPTION
This contains a fix to issue: https://github.com/driftyco/ionic/issues/3900

Replicated issue in codepen: http://codepen.io/clemmakesapps/pen/WvOPmK
Demonstrated css fix in codepen: http://codepen.io/clemmakesapps/pen/YXQgqx