### PR TITLE
Popover - remove ios header padding from inset header

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -113,6 +113,33 @@
       top: -6px;
     }
   }
+
+  // remove ios header padding from inset header
+  &.platform-cordova .popover-wrapper .popover {
+    .bar-header:not(.bar-subheader) {
+      height: $bar-height;
+      > * {
+        margin-top: 0;
+      }
+    }
+    .tabs-top > .tabs,
+    .tabs.tabs-top {
+      top: $bar-height;
+    }
+    .has-header,
+    .bar-subheader {
+      top: $bar-height;
+    }
+    .has-subheader {
+      top: $bar-height + $bar-subheader-height;
+    }
+    .has-header.has-tabs-top {
+      top: $bar-height + $tabs-height;
+    }
+    .has-header.has-subheader.has-tabs-top {
+      top: $bar-height + $bar-subheader-height + $tabs-height;
+    }
+  }
 }
 
 


### PR DESCRIPTION
As you can see in the codepen below , when we are in the platform-ios and platform-cordova the popover header have a wrong padding.

http://codepen.io/anon/pen/WvZvvo