### PR TITLE
Allow drag distance of ion-slide-box to be configured via parameter

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -92,7 +92,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
         onDragEnd: function() {
           freezeAllScrolls(false);
         },
-        dragDistancePercentage:dragDistance
+        rragDistancePercentage: dragDistance
       });
 
       function freezeAllScrolls(shouldFreeze) {

--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -31,8 +31,10 @@
  * @param {boolean=} auto-play Whether the slide box should automatically slide. Default true if does-continue is true.
  * @param {number=} slide-interval How many milliseconds to wait to change slides (if does-continue is true). Defaults to 4000.
  * @param {boolean=} show-pager Whether a pager should be shown for this slide box. Accepts expressions via `show-pager="{{shouldShow()}}"`. Defaults to true.
+ * @param {number=} percentage of width that should be swiped in order to trigger the next slide. Defaults to .5
  * @param {expression=} pager-click Expression to call when a pager is clicked (if show-pager is true). Is passed the 'index' variable.
  * @param {expression=} on-slide-changed Expression called whenever the slide is changed.  Is passed an '$index' variable.
+ * @param {expression=} active-slide Model to bind the current slide to.
  * @param {expression=} active-slide Model to bind the current slide to.
  */
 IonicModule
@@ -52,6 +54,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
       doesContinue: '@',
       slideInterval: '@',
       showPager: '@',
+      dragDistance: '@',
       pagerClick: '&',
       disableScroll: '@',
       onSlideChanged: '&',
@@ -88,7 +91,8 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
         },
         onDragEnd: function() {
           freezeAllScrolls(false);
-        }
+        },
+        dragDistancePercentage:dragDistance
       });
 
       function freezeAllScrolls(shouldFreeze) {

--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -72,6 +72,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
         auto: slideInterval,
         continuous: continuous,
         startSlide: $scope.activeSlide,
+        dragDistancePercentage: $scope.dragDistance,
         slidesChanged: function() {
           $scope.currentSlide = slider.currentIndex();
 
@@ -91,8 +92,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
         },
         onDragEnd: function() {
           freezeAllScrolls(false);
-        },
-        dragDistancePercentage: $scope.dragDistance
+        }
       });
 
       function freezeAllScrolls(shouldFreeze) {

--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -92,7 +92,7 @@ function($timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $ionicScroll
         onDragEnd: function() {
           freezeAllScrolls(false);
         },
-        rragDistancePercentage: dragDistance
+        dragDistancePercentage: $scope.dragDistance
       });
 
       function freezeAllScrolls(shouldFreeze) {

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -34,7 +34,7 @@ ionic.views.Slider = ionic.views.View.inherit({
     // quit if no root element
     if (!container) return;
     var element = container.children[0];
-    var slides, slidePos, width, length, dragDistancePercentage=.5;
+    var slides, slidePos, width, length, dragDistancePercentage = .5;
     options = options || {};
     var index = parseInt(options.startSlide, 10) || 0;
     var speed = options.speed || 300;

--- a/js/views/sliderView.js
+++ b/js/views/sliderView.js
@@ -34,7 +34,7 @@ ionic.views.Slider = ionic.views.View.inherit({
     // quit if no root element
     if (!container) return;
     var element = container.children[0];
-    var slides, slidePos, width, length;
+    var slides, slidePos, width, length, dragDistancePercentage=.5;
     options = options || {};
     var index = parseInt(options.startSlide, 10) || 0;
     var speed = options.speed || 300;
@@ -53,6 +53,11 @@ ionic.views.Slider = ionic.views.View.inherit({
 
       // set continuous to false if only one slide
       if (slides.length < 2) options.continuous = false;
+
+      // set slide distance percentage
+      if(options.hasOwnProperty('dragDistancePercentage')) {
+        dragDistancePercentage = options.dragDistancePercentage;
+      }
 
       //special case if two slides
       if (browser.transitions && options.continuous && slides.length < 3) {
@@ -379,7 +384,7 @@ ionic.views.Slider = ionic.views.View.inherit({
         var isValidSlide =
               Number(duration) < 250 &&         // if slide duration is less than 250ms
               Math.abs(delta.x) > 20 ||         // and if slide amt is greater than 20px
-              Math.abs(delta.x) > width / 2;      // or if slide amt is greater than half the width
+              Math.abs(delta.x) > width * dragDistancePercentage;      // or if slide amt is greater than the specified percentage of the width
 
         // determine if slide attempt is past start and end
         var isPastBounds = (!index && delta.x > 0) ||      // if first slide and slide amt is greater than 0


### PR DESCRIPTION
The default is half of the parent width, which is a bit much. In many instances, something like a third or fourth is totally sufficient.  