### PR TITLE
fix(scroll): Let WKWebView manage the scroll position

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -310,6 +310,7 @@ function keyboardFocusIn(e) {
   if (!e.target ||
       e.target.readOnly ||
       !ionic.tap.isKeyboardElement(e.target) ||
+      (window.webkit && window.indexedDB) ||
       !(scrollView = ionic.DomUtil.getParentWithClass(e.target, SCROLL_CONTAINER_CSS))) {
     keyboardActiveElement = null;
     return;


### PR DESCRIPTION
The WKWebView tries to scroll the input item into position by itself. Ionic's keyboard code interferes and makes things go a bit crazy.

Checking for webkit and indexedDB tells us we are using WKWebView as UIWebView does not support indexedDB. We then abort added any listeners if we hit this condition.

An improvement would be to get the current scroll view and freeze it. As attempting to scroll still messes a few things up.