### PR TITLE
fix(scrollView): reset scroll view when focusing non-keyboard element

### DIFF
--- a/js/utils/keyboard.js
+++ b/js/utils/keyboard.js
@@ -96,6 +96,12 @@ var keyboardLandscapeViewportHeight = 0;
 var keyboardActiveElement;
 
 /**
+ * The previously focused input used to reset keyboard after focusing on a
+ * new non-keyboard element
+ */
+var lastKeyboardActiveElement;
+
+/**
  * The scroll view containing the currently focused input.
  */
 var scrollView;
@@ -311,6 +317,9 @@ function keyboardFocusIn(e) {
       e.target.readOnly ||
       !ionic.tap.isKeyboardElement(e.target) ||
       !(scrollView = ionic.DomUtil.getParentWithClass(e.target, SCROLL_CONTAINER_CSS))) {
+    if (keyboardActiveElement) {
+        lastKeyboardActiveElement = keyboardActiveElement;
+    }
     keyboardActiveElement = null;
     return;
   }
@@ -546,9 +555,9 @@ function keyboardHide() {
   ionic.keyboard.isOpen = false;
   ionic.keyboard.isClosing = false;
 
-  if (keyboardActiveElement) {
+  if (keyboardActiveElement || lastKeyboardActiveElement) {
     ionic.trigger('resetScrollView', {
-      target: keyboardActiveElement
+      target: keyboardActiveElement || lastKeyboardActiveElement
     }, true);
   }
 
@@ -572,6 +581,7 @@ function keyboardHide() {
   }
 
   keyboardActiveElement = null;
+  lastKeyboardActiveElement = null;
 }
 
 /**


### PR DESCRIPTION
Focusing a keyboard element sets `keyboardActiveElement`. If you blur,
this will trigger `resetScrollView` appropriately.

If you focus a non-keyboard element (such as a checkbox), `keyboardActiveElement` is set to
null *before* `keyboardHide` is called, so `resetScrollView` is not
triggered.

Mitigate this by keeping track of the last focused element to reset the
scroll view.