### PR TITLE
docs(popup): increased js readability

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -43,7 +43,7 @@ var POPUP_TPL =
  *
  * // Triggered on a button click, or some other target
  * $scope.showPopup = function() {
- *   $scope.data = {}
+ *   $scope.data = {};
  *
  *   // An elaborate, custom popup
  *   var myPopup = $ionicPopup.show({
@@ -67,19 +67,23 @@ var POPUP_TPL =
  *       }
  *     ]
  *   });
+ * 
  *   myPopup.then(function(res) {
  *     console.log('Tapped!', res);
  *   });
+ * 
  *   $timeout(function() {
  *      myPopup.close(); //close the popup after 3 seconds for some reason
  *   }, 3000);
  *  };
+ * 
  *  // A confirm dialog
  *  $scope.showConfirm = function() {
  *    var confirmPopup = $ionicPopup.confirm({
  *      title: 'Consume Ice Cream',
  *      template: 'Are you sure you want to eat this ice cream?'
  *    });
+ *    
  *    confirmPopup.then(function(res) {
  *      if(res) {
  *        console.log('You are sure');
@@ -95,6 +99,7 @@ var POPUP_TPL =
  *      title: 'Don\'t eat that!',
  *      template: 'It might taste good'
  *    });
+ * 
  *    alertPopup.then(function(res) {
  *      console.log('Thank you for not eating my delicious ice cream cone');
  *    });


### PR DESCRIPTION
While reading the docs, I noticed that the example code was hard to read due to lack of spacing.
![screen shot 2015-06-30 at 1 43 46 pm](https://cloud.githubusercontent.com/assets/8163408/8441576/18758478-1f2e-11e5-9995-857cda9d0224.png)

This spacing was also inconsistent with other examples, which are more readable; for example, from [popover](https://github.com/driftyco/ionic/blob/master/js/angular/service/popover.js#L40-L52):
![screen shot 2015-06-30 at 1 46 32 pm](https://cloud.githubusercontent.com/assets/8163408/8441660/85e87f88-1f2e-11e5-98dc-ca2130b3c7f2.png)

Also, added a missing semicolon to [line 46](https://github.com/driftyco/ionic/blob/master/js/angular/service/popup.js#L46).