### PR TITLE
- fixed ion re-ordering support for collection-repeat

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -639,6 +639,7 @@ function RepeatManagerFactory($rootScope, $window, $$rAF) {
         scope.$last = (i === (data.length - 1));
         scope.$middle = !(scope.$first || scope.$last);
         scope.$odd = !(scope.$even = (i & 1) === 0);
+        scope.$repeatReorder = {keyExpression : keyExpression, toItem: null, fromItem: null };
 
         if (scope.$$disconnected) ionic.Utils.reconnectScope(item.scope);
 

--- a/js/views/listView.js
+++ b/js/views/listView.js
@@ -345,26 +345,14 @@
     finalIndex = this._currentDrag.startIndex + (adiff >= 1 ? diff : 0);
     return finalIndex;
   }
-  
+
   ReorderDrag.prototype._getColDropVirtWinIdx = function(e, siblings) {
-    var ret = -1;
-    var stackObj = [], stackDisp =[], x = e.gesture.center.pageX, y = e.gesture.center.pageY, cnt = 1;
-    var elem;
-    while ((elem = this._getParentIonItem(document.elementFromPoint(x, y))) !== null) {
-    	if (elem === this.el) {
-      	stackObj.push(elem);
-      	stackDisp.push(elem.style.display);
-      	elem.style.display = "none";
-      	continue;
-    	}
-    	break;
-    }
-    for (var i=0; i< stackObj.length; i++) 
-    	stackObj[i].style.display = stackDisp[i];
-    if (elem !== null) {
-      for (var i = 0, len = siblings.length; i < len; i++) {
+    var ret = -1, x = e.gesture.center.pageX, y = e.gesture.center.pageY;
+    var fromToIonItems = this._getIonItemsAtPoint(x, y);
+    if (fromToIonItems.length === 2) {
+      for (var i = 0; i < siblings.length; i++) {
         var cmp = siblings[i];
-      	if (elem === cmp) {
+      	if (fromToIonItems[1] === cmp) {
       		ret = i;
       		break;
       	}
@@ -372,6 +360,29 @@
     } 
     return ret;   
   }
+  
+  ReorderDrag.prototype._getIonItemsAtPoint = function(x,y) {
+    var stackObj = [], stackDisp =[], ionItems = [];
+    while (true) {
+			var hit = document.elementFromPoint(x, y);
+			if (!hit || hit === document.documentElement)
+				break;
+			stackObj.push(hit);
+			stackDisp.push(hit.style.display);
+			hit.style.display = "none";
+			if (hit.tagName === "ION-REORDER-BUTTON") {
+				var ion = this._getParentIonItem(hit);
+				if (ion) {
+					ionItems.push(ion);
+					if (ionItems.length === 2)
+						break;
+				}
+			}
+    }
+    for (var i = 0; i < stackObj.length; i++) 
+    	stackObj[i].style.display = stackDisp[i];
+    return ionItems;
+	}
   
   ReorderDrag.prototype._getParentIonItem = function(elem) {
   	if (elem.tagName === "ION-ITEM")

--- a/js/views/listView.js
+++ b/js/views/listView.js
@@ -236,7 +236,7 @@
     var placeholder = this.el.cloneNode(true);
 
     placeholder.classList.add(ITEM_PLACEHOLDER_CLASS);
-
+    this.origElStyleCssTrans = this.el.style[ionic.CSS.TRANSFORM];
     this.el.parentNode.insertBefore(placeholder, this.el);
     this.el.classList.add(ITEM_REORDERING_CLASS);
 
@@ -245,6 +245,7 @@
       startIndex: startIndex,
       placeholder: placeholder,
       scrollHeight: scroll,
+      initialY: null,
       list: placeholder.parentNode
     };
 
@@ -300,19 +301,15 @@
       this._moveElement(e);
 
       this._currentDrag.currentY = scrollY + pageY - offset;
-
+      if (this._currentDrag.initialY === null )
+      	this._currentDrag.initialY = this._currentDrag.currentY; 
       // this._reorderItems();
     }
   });
 
   // When an item is dragged, we need to reorder any items for sorting purposes
-  ReorderDrag.prototype._getReorderIndex = function() {
+  ReorderDrag.prototype._getNgRepeatReorderIndex = function(siblings) {
     var self = this;
-
-    var siblings = Array.prototype.slice.call(self._currentDrag.placeholder.parentNode.children)
-      .filter(function(el) {
-        return el.nodeName === self.el.nodeName && el !== self.el;
-      });
 
     var dragOffsetTop = self._currentDrag.currentY;
     var el;
@@ -334,18 +331,91 @@
     return self._currentDrag.startIndex;
   };
 
+  ReorderDrag.prototype._getColRepeatReorderIndex = function() {
+  	this._currentDrag.startIndex = this._currentDrag.initialY;
+  	this._currentDrag.startIndex = this._currentDrag.startIndex/(this.el.clientHeight+1);
+  	this._currentDrag.startIndex = Math.max(this._currentDrag.startIndex, 0);
+
+    var finalIndex = this._currentDrag.currentY;
+    finalIndex = finalIndex/(this.el.clientHeight+1);
+    finalIndex = Math.max(finalIndex, 0);
+    var diff = Math.round(finalIndex - this._currentDrag.startIndex);
+    var adiff = Math.abs(diff);
+    this._currentDrag.startIndex = Math.floor(this._currentDrag.startIndex);
+    finalIndex = this._currentDrag.startIndex + (adiff >= 1 ? diff : 0);
+    return finalIndex;
+  }
+  
+  ReorderDrag.prototype._getColDropVirtWinIdx = function(e, siblings) {
+    var ret = -1;
+    var stackObj = [], stackDisp =[], x = e.gesture.center.pageX, y = e.gesture.center.pageY, cnt = 1;
+    var elem;
+    while ((elem = this._getParentIonItem(document.elementFromPoint(x, y))) !== null) {
+    	if (elem === this.el) {
+      	stackObj.push(elem);
+      	stackDisp.push(elem.style.display);
+      	elem.style.display = "none";
+      	continue;
+    	}
+    	break;
+    }
+    for (var i=0; i< stackObj.length; i++) 
+    	stackObj[i].style.display = stackDisp[i];
+    if (elem !== null) {
+      for (var i = 0, len = siblings.length; i < len; i++) {
+        var cmp = siblings[i];
+      	if (elem === cmp) {
+      		ret = i;
+      		break;
+      	}
+      }
+    } 
+    return ret;   
+  }
+  
+  ReorderDrag.prototype._getParentIonItem = function(elem) {
+  	if (elem.tagName === "ION-ITEM")
+  		return elem;
+  	var par = elem.parentElement;
+  	if (par)
+  		return this._getParentIonItem(par);
+  	return null;
+  }
+  
+  ReorderDrag.prototype._setRepeatReorderFromToItem = function(src, dst) {
+  	var scopeSrc = angular.element(src).scope();
+  	var scopeDst = angular.element(dst).scope();
+  	var scopeToUse = angular.isDefined(scopeDst.$repeatReorder) ? scopeDst : scopeSrc;
+  	scopeSrc.$repeatReorder.fromItem = scopeSrc[scopeSrc.$repeatReorder.keyExpression];
+  	scopeSrc.$repeatReorder.toItem = scopeToUse[scopeSrc.$repeatReorder.keyExpression];
+  }
+  
   ReorderDrag.prototype.end = function(e, doneCallback) {
     if (!this._currentDrag) {
       doneCallback && doneCallback();
       return;
     }
 
+    var self = this;
+    var siblings = Array.prototype.slice.call(self._currentDrag.placeholder.parentNode.children)
+      .filter(function(el) {
+        return el.nodeName === self.el.nodeName && el !== self.el;
+      });
     var placeholder = this._currentDrag.placeholder;
-    var finalIndex = this._getReorderIndex();
-
+    var useNg = true;
+    if (siblings.length > 0) 
+    	useNg = (siblings[0].offsetTop !== -1); 
+    var finalIndex = useNg ? this._getNgRepeatReorderIndex(siblings) : this._getColRepeatReorderIndex();
+    var toItemIdx = finalIndex; 
+    if (!useNg) { 
+    	toItemIdx = this._getColDropVirtWinIdx(e, siblings);
+	    if (toItemIdx !== -1)
+	    	this._setRepeatReorderFromToItem(this.el, siblings[toItemIdx]);
+    }
+    
     // Reposition the element
     this.el.classList.remove(ITEM_REORDERING_CLASS);
-    this.el.style[ionic.CSS.TRANSFORM] = '';
+    this.el.style[ionic.CSS.TRANSFORM] = this.origElStyleCssTrans;
 
     placeholder.parentNode.insertBefore(this.el, placeholder);
     placeholder.parentNode.removeChild(placeholder);


### PR DESCRIPTION
RE: https://github.com/driftyco/ionic/issues/3959

Problem:
  Note, <ion-reorder-button> works with ng-repeat. However, it is not 
  compatible with collection-repeat. The ion-re-ordering feature is
based on the following assumptions:
  1. style offset top attributes have been set DOM objects in the list
items
  2. that the aggregate of client heights can be summed

Complication:
  Fixing the re-ordering defect is highly problematic because:
  1. The ion-reordering feature is subject to filters which when applied
to the collection can affect one’s reordering callback.
  2. All items may not display with the same fixed client height


Solution:
  1. Establish the contract that the fromIndex & toIndex values sent to
the reordering callback must be values that are applicable to the
context of the current [filtered|orderedBy] view ONLY. In this manner it
is up to the developer to transform the from/to index values prior to
reordering the original data source
  a. Create separate functions for handling both hg-repeat & collection
repeat:
    - ng-repeat: uses: _getNgRepeatReorderIndex
    - collection-repeat: uses: _getColRepeatReorderIndex


  2. The ion-reordering for collection-repeat assumes a constant client
height for all items. However, if this is not the case then this renders
this feature useless and developers are forced to use ng-repeat. In such
instances an alternative approach would be to invoke a re-order callback
with a repeatReorder object. This object is initialised via:
  ReorderDrag.prototype._setRepeatReorderFromToItem = function(src, dst)
{
  	var scopeSrc = angular.element(src).scope();
  	var scopeDst = angular.element(dst).scope();
  	var scopeToUse = angular.isDefined(scopeDst.$repeatReorder) ?
scopeDst : scopeSrc;
  	scopeSrc.$repeatReorder.fromItem =
scopeSrc[scopeSrc.$repeatReorder.keyExpression];
  	scopeSrc.$repeatReorder.toItem =
scopeToUse[scopeSrc.$repeatReorder.keyExpression];
  }


Resulting context:
  1) using index values on ordering:
Eg.
<ion-list show-reorder="true"> 
  <ion-item collection-repeat="item in contacts | filter:data.search">
  …
  <ion-reorder-button class="opt-btn button-small icon ion-ios-drag"
on-reorder="reorderItem(item,$fromIndex,$toIndex)"></ion-reorder-button>

  2) using repeatReorder object on ordering:
<ion-list show-reorder="true"> 
  <ion-item collection-repeat="item in contacts | filter:data.search">
  …
  <ion-reorder-button class="opt-btn button-small icon ion-ios-drag"
on-reorder="reorderItem($repeatReorder)"></ion-reorder-button>


Known issues:
- Sometimes the drag item is lost when doing a move that spans multiple
scrolled pages. Hence, collection-repeat forces a re-load and the drag
action is lost. 
- When moving an item downwards the CSS z-index of the dragged item is
not being honoured and appears hidden behind other items in the list. My
work-around for this is to have items that have a transparent
background.