### PR TITLE
feat(app): Better support for npm and modules manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ $ ionic start myproject
   * The `release` folder of this repository
   * Ionic CDN: [Latest Release](http://code.ionicframework.com/)
   * Using bower: `bower install ionic`
+  * Using npm: `npm install ionic-sdk`
+  
 - Download the **bleeding edge just-from-master release** from:
   * Ionic CDN: [Nightly Build](http://code.ionicframework.com/#nightly)
   * Using bower: `bower install driftyco/ionic-bower#master`

--- a/index.js
+++ b/index.js
@@ -1,0 +1,14 @@
+// Should already be required, here for clarity
+require('angular');
+
+// Load dependent libs
+require('angular-animate');
+require('angular-sanitize');
+require('angular-ui-router');
+
+// Now load ionic
+require('./release/js/ionic');
+require('./release/js/ionic-angular');
+
+// Export namespace
+module.exports = 'ionic';

--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "repository": {
     "url": "git://github.com/driftyco/ionic.git"
   },
+  "main": "index.js",
+  "dependencies": {
+    "angular": "^1.3.0 || >1.4.0-beta.0",
+    "angular-animate": "^1.3.0 || >1.4.0-beta.0",
+    "angular-sanitize": "^1.3.0 || >1.4.0-beta.0",
+    "angular-ui-router": "^0.2.0"
+  },
   "devDependencies": {
     "canonical-path": "0.0.2",
     "chalk": "^0.4.0",


### PR DESCRIPTION
The purpose of this PR is to give ionic an easier integration with modules manager like `webpack` and `browserify`.

I use the same process as what was done for `angular-material`

Installation: `npm install ionic-sdk`
Usage (using webpack or browserify):
```js
var angular = require('angular');
require('ionic-sdk');
var app = angular.module('my-app', ['ionic']);
```

The nice thing is that it will now pull out the dependencies (angular-ui-router, angular-sanitze, etc...) automatically

