### PR TITLE
fix(SideMenu): Prevent draging SideMenu while draging range input

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -392,6 +392,11 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
       startX <= self.edgeThreshold ||
       startX >= self.content.element.offsetWidth - self.edgeThreshold;
 
+    //Prevent draging sidemenu while draging a range input
+    if (e.target.getAttribute('type') == 'range') {
+      return false;
+    }
+
     var backView = $ionicHistory.backView();
     var menuEnabled = enableMenuWithBackViews ? true : !backView;
     if (!menuEnabled) {

--- a/test/unit/angular/directive/sideMenu.unit.js
+++ b/test/unit/angular/directive/sideMenu.unit.js
@@ -117,6 +117,9 @@ describe('Ionic Angular Side Menu', function() {
         tagName: 'DIV',
         dataset: {
           preventScroll: false
+        },
+        getAttribute: function(){
+          return null;
         }
       }
     };
@@ -164,6 +167,11 @@ describe('Ionic Angular Side Menu', function() {
     };
     expect(ctrl.isDraggableTarget(e)).toBe(false);
 
+    e.target.getAttribute = function(val){
+      return (val == 'type' ? 'range' : false);
+    };
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
     e.target.getAttribute = function(){
       return null;
     };
@@ -187,6 +195,9 @@ describe('Ionic Angular Side Menu', function() {
         tagName: 'DIV',
         dataset: {
           preventScroll: false
+        },
+        getAttribute: function(){
+          return null;
         }
       }
     };
@@ -216,6 +227,36 @@ describe('Ionic Angular Side Menu', function() {
     $ionicHistory.currentView({historyId: '003'});
     $ionicHistory.backView({historyId: 'root'});
     expect(ctrl.isDraggableTarget(e)).toBe(true);
+
+    e.target.getAttribute = function(val){
+      return (val == 'type' ? 'range' : false);
+    };
+
+    ctrl.enableMenuWithBackViews(true);
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
+    ctrl.enableMenuWithBackViews(false);
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
+    ctrl.enableMenuWithBackViews(false);
+    $ionicHistory.currentView({historyId: 'root'});
+    $ionicHistory.backView({historyId: 'root'});
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
+    ctrl.enableMenuWithBackViews(false);
+    $ionicHistory.currentView({historyId: 'root'});
+    $ionicHistory.backView(null);
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
+    ctrl.enableMenuWithBackViews(true);
+    $ionicHistory.currentView({historyId: 'root'});
+    $ionicHistory.backView({historyId: 'root'});
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
+
+    ctrl.enableMenuWithBackViews(false);
+    $ionicHistory.currentView({historyId: '003'});
+    $ionicHistory.backView({historyId: 'root'});
+    expect(ctrl.isDraggableTarget(e)).toBe(false);
 
   }));
 


### PR DESCRIPTION
This fix should close issue, with revealing the side menu while sliding a range input. 
In current version of Ionic it is impossible to change range smoothly in sidemenu layout. Even disabling drag-content doesn't solve this problem.
My fix seems to be a solution for this issue.