### PR TITLE
Watch not working, Needed a small change.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -69,7 +69,7 @@ var IS_WATCH = false;
 gulp.task('watch', ['build'], function() {
   IS_WATCH = true;
   gulp.watch('js/**/*.js', ['bundle']);
-  gulp.watch('scss/**/*.scss', ['sass']);
+  gulp.watch('www/**/*.scss', ['sass']);
 });
 
 gulp.task('changelog', function() {


### PR DESCRIPTION
It worked when 

var paths = {
  sass: ['./scss/**/*.scss']
};

changed to

var paths = {
  sass: ['./www/**/*.scss']
};

Anybody else have the same issue?