### PR TITLE
Center Wide Popover on larger Viewports

### DIFF
--- a/scss/_popover.scss
+++ b/scss/_popover.scss
@@ -163,5 +163,6 @@
 @media (min-width: $popover-large-break-point) {
   .popover {
     width: $popover-large-width;
+    margin-left: -$popover-large-width / 2;
   }
 }


### PR DESCRIPTION
The margin was not updated when the width was changed resulting in the popover being offset to the right.