### PR TITLE
add a method to show and hide a tab bar programmatically

### DIFF
--- a/js/angular/controller/tabsController.js
+++ b/js/angular/controller/tabsController.js
@@ -114,4 +114,9 @@ function($scope, $element, $ionicHistory) {
     return false;
   };
 
+  self.showTabBar = function(shouldShow) {
+    if (shouldShow) $element.removeClass('tabs-item-hide');
+    else $element.addClass('tabs-item-hide');
+  };
+
 }]);

--- a/js/angular/service/tabsDelegate.js
+++ b/js/angular/service/tabsDelegate.js
@@ -48,7 +48,7 @@ IonicModule
    * @name $ionicTabsDelegate#selectedIndex
    * @returns `number` The index of the selected tab, or -1.
    */
-  'selectedIndex'
+  'selectedIndex',
   /**
    * @ngdoc method
    * @name $ionicTabsDelegate#$getByHandle
@@ -59,5 +59,6 @@ IonicModule
    *
    * Example: `$ionicTabsDelegate.$getByHandle('my-handle').select(0);`
    */
+   'showTabBar'
 ]));
 


### PR DESCRIPTION
I implemented a function mentioned at #395.

usage:
```js
$ionicTabsDelegate.showTabBar(true); // show tab bar
$ionicTabsDelegate.showTabBar(false); // hide tab bar
```

Though I haven't written any comment or document for this function yet, I'm ready to do it if this function is in demand and my code is acceptable.