### PR TITLE
Use other options for the next view when you go back to the current state

### DIFF
--- a/js/angular/directive/menuClose.js
+++ b/js/angular/directive/menuClose.js
@@ -23,11 +23,12 @@
  * ```
  */
 IonicModule
-.directive('menuClose', ['$ionicHistory', function($ionicHistory) {
+.directive('menuClose', ['$ionicHistory', '$timeout', function($ionicHistory, $timeout) {
   return {
     restrict: 'AC',
     link: function($scope, $element) {
       $element.bind('click', function() {
+        var currentState = $ionicHistory.currentStateName();
         var sideMenuCtrl = $element.inheritedData('$ionSideMenusController');
         if (sideMenuCtrl) {
           $ionicHistory.nextViewOptions({
@@ -36,6 +37,15 @@ IonicModule
             expire: 300
           });
           sideMenuCtrl.close();
+          $timeout(function(){
+            if (currentState === $ionicHistory.currentStateName()) {
+              $ionicHistory.nextViewOptions({
+                historyRoot: false,
+                disableAnimate: false,
+                expire: 300
+              });
+            }
+          }, 10);
         }
       });
     }


### PR DESCRIPTION
If I click on a menu element to return in the current view the next view will not work as expected anymore. I made this quick and dirty fix to release the prototype of my app asap, I think that there's a better way but I hadn't so much time to investigate further. 