### PR TITLE
exposeAsideWhen directive bug fix

### DIFF
--- a/js/angular/directive/exposeAsideWhen.js
+++ b/js/angular/directive/exposeAsideWhen.js
@@ -23,7 +23,6 @@
  * the most common use-case. However, for added flexibility, any valid media query could be added
  * as the value, such as `(min-width:600px)` or even multiple queries such as
  * `(min-width:750px) and (max-width:1200px)`.
-
  * @usage
  * ```html
  * <ion-side-menus>
@@ -39,11 +38,20 @@
  * For a complete side menu example, see the
  * {@link ionic.directive:ionSideMenus} documentation.
  */
+
 IonicModule.directive('exposeAsideWhen', ['$window', function($window) {
   return {
     restrict: 'A',
     require: '^ionSideMenus',
     link: function($scope, $element, $attr, sideMenuCtrl) {
+
+      // Setup a match media query listener that triggers a ui change only when a change
+      // in media matching status occurs
+      var mq = $attr.exposeAsideWhen == 'large' ? '(min-width:768px)' : $attr.exposeAsideWhen;
+      var mql = $window.matchMedia(mq);
+      mql.addListener(function() {
+        onResize();
+      });
 
       function checkAsideExpose() {
         var mq = $attr.exposeAsideWhen == 'large' ? '(min-width:768px)' : $attr.exposeAsideWhen;
@@ -61,14 +69,6 @@ IonicModule.directive('exposeAsideWhen', ['$window', function($window) {
       }, 300, false);
 
       $scope.$evalAsync(checkAsideExpose);
-
-      ionic.on('resize', onResize, $window);
-
-      $scope.$on('$destroy', function() {
-        ionic.off('resize', onResize, $window);
-      });
-
     }
   };
 }]);
-


### PR DESCRIPTION
Fixes issue #3600 by ensuring that the side menu changes position only when $window.matchMedia changes from valid to invalid and vice versa, rather than listening to every resize event to trigger a change.

Since Ionic broadcasts a resize event on every popover and modal show action, this ensures that opening a popover located in the side-menu does not close the side menu, which is an issue that has been mentioned in the following ionic forum posts:

1) http://forum.ionicframework.com/t/menu-left-closes-when-popover-show/21476

2) http://forum.ionicframework.com/t/bug-side-menu-with-expose-aside-when-will-close-by-itself-when-a-modal-or-popover-comes-up/14532

3) http://forum.ionicframework.com/t/popover-in-side-menu-how-to-stop-side-menu-close/12277
