### PR TITLE
feat(ionTabs): added ability to hide/show with $ionicTabsDelegate

### DIFF
--- a/js/angular/controller/tabsController.js
+++ b/js/angular/controller/tabsController.js
@@ -8,6 +8,7 @@ function($scope, $element, $ionicHistory) {
   var selectedTab = null;
   var previousSelectedTab = null;
   var selectedTabIndex;
+  var isVisible = true;
   self.tabs = [];
 
   self.selectedIndex = function() {
@@ -23,6 +24,13 @@ function($scope, $element, $ionicHistory) {
   self.add = function(tab) {
     $ionicHistory.registerHistory(tab);
     self.tabs.push(tab);
+  };
+
+  self.show = function (shouldShow) {
+    if (arguments.length) {
+      isVisible = !!shouldShow;
+    }
+    return isVisible;
   };
 
   self.remove = function(tab) {

--- a/js/angular/directive/tabs.js
+++ b/js/angular/directive/tabs.js
@@ -82,6 +82,14 @@ function($ionicTabsDelegate, $ionicConfig) {
           $scope.$emit('$ionicTabs.top', $scope.$hasTabsTop);
         });
 
+        $scope.$watch(function() { return tabsCtrl.show(); }, function(value, oldValue) {
+          if (value) {
+            $element.removeClass("tabs-item-hide");
+          } else {
+            $element.addClass("tabs-item-hide");
+          }
+        });
+
         function emitLifecycleEvent(ev, data) {
           ev.stopPropagation();
           var previousSelectedTab = tabsCtrl.previousSelectedTab();

--- a/js/angular/service/tabsDelegate.js
+++ b/js/angular/service/tabsDelegate.js
@@ -48,7 +48,15 @@ IonicModule
    * @name $ionicTabsDelegate#selectedIndex
    * @returns `number` The index of the selected tab, or -1.
    */
-  'selectedIndex'
+  'selectedIndex',
+  /**
+   * @ngdoc method
+   * @name $ionicTabsDelegate#show
+   * @description Set/get whether the {@link ionic.directive:ionTabs} is shown.
+   * @param {boolean=} show Whether to show the {@link ionic.directive:ionTabs}.
+   * @returns {boolean} Whether the {@link ionic.directive:ionTabs} is shown.
+   */
+  'show'
   /**
    * @ngdoc method
    * @name $ionicTabsDelegate#$getByHandle


### PR DESCRIPTION
You can now call $ionicTabsDelegate.show(true/false) to show/hide the ion-tabs bar, or just $ionicTabsDelegate.show() to get the current status. This solves the same problem as #4133 but with a bit more separation of concerns, and correct docs.