### PR TITLE
Add Subfooter with tabs support

### DIFF
--- a/scss/_scaffolding.scss
+++ b/scss/_scaffolding.scss
@@ -236,6 +236,10 @@ ion-infinite-scroll {
   }
 }
 
+.bar-subfooter.has-tabs {
+  bottom: $tabs-height + $bar-footer-height;
+}
+
 .has-footer.has-tabs {
   bottom: $tabs-height + $bar-footer-height;
 }


### PR DESCRIPTION
Hello,

I'm currently trying to add a subfooter with a tabs but the actual CSS doesn't implement this feature.

I can see that the .has-footer.has-tabs doing the same thing but the directive is actually not generating those classes.