### PR TITLE
HtmlUnit compability

### DIFF
--- a/js/utils/poly.js
+++ b/js/utils/poly.js
@@ -2,7 +2,10 @@
   'use strict';
 
   // Ionic CSS polyfills
-  ionic.CSS = {};
+  ionic.CSS = {
+    'TRANSFORM': [],
+    'TRANSITION': []
+  };
 
   (function() {
 


### PR DESCRIPTION
I use HtmlUnit to prerender ionic SPA. All works fine except this polyfill. If i render page through HtmlUnit then exception occurs:
```
 TypeError: Cannot call method "indexOf" of undefined (line 33)
```