### PR TITLE
Use transition-duration instead of animation-duration

### DIFF
--- a/scss/_refresher.scss
+++ b/scss/_refresher.scss
@@ -38,7 +38,7 @@
   }
   .icon-pulling {
     @include animation-name(refresh-spin-back);
-    @include animation-duration(200ms);
+    @include transition-duration(200ms);
     @include animation-timing-function(linear);
     @include animation-fill-mode(none);
     -webkit-transform: translate3d(0,0,0) rotate(0deg);


### PR DESCRIPTION
This lag only occurs on ios device.

Demo:

- Lag animation-duration
    - http://coub.com/view/8019w
    - https://dl.dropboxusercontent.com/u/714800/ionic-demo/without-fix.zip
- Fix transition-duration
    - http://coub.com/view/801c7
    - https://dl.dropboxusercontent.com/u/714800/ionic-demo/with-fix.zip