### PR TITLE
Disable $compileProvider debug info for performance boost.

### DIFF
--- a/js/angular/service/ionicConfig.js
+++ b/js/angular/service/ionicConfig.js
@@ -653,4 +653,5 @@ IonicModule
 .config(['$compileProvider', function($compileProvider) {
   $compileProvider.aHrefSanitizationWhitelist(/^\s*(https?|tel|ftp|mailto|file|ghttps?|ms-appx|x-wmapp0):/);
   $compileProvider.imgSrcSanitizationWhitelist(/^\s*(https?|ftp|file|content|blob|ms-appx|x-wmapp0):|data:image\//);
+  $compileProvider.debugInfoEnabled(false);
 }]);


### PR DESCRIPTION
According to https://docs.angularjs.org/api/ng/provider/$compileProvider disabling debug info on $compileProvider gives a significant performance boost. What about making it a default setting?