### PR TITLE
Added mousewheel support for touch devices

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -885,6 +885,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
       document.addEventListener("touchmove", self.touchMove, false);
       document.addEventListener("touchend", self.touchEnd, false);
       document.addEventListener("touchcancel", self.touchEnd, false);
+      document.addEventListener("wheel", self.mouseWheel, false);
 
     } else if (window.navigator.pointerEnabled) {
       // Pointer Events


### PR DESCRIPTION
Related issue: https://github.com/driftyco/ionic/issues/4208
I finally had some time to take a look at this and it was literally a 1 line fix. =D

Mousewheel scrolling works perfectly on touch devices now on Chrome, and I haven't found any adverse effects yet in my testing.

I'm still seeing really slow scrolling on Firefox though, but that's probably another issue entirely.