### PR TITLE
Fix `e.detail.keyboardHeight` undefined error in keyboardAttach directive

### DIFF
--- a/js/angular/directive/keyboardAttach.js
+++ b/js/angular/directive/keyboardAttach.js
@@ -46,7 +46,7 @@ IonicModule
       }
 
       //for testing
-      var keyboardHeight = e.keyboardHeight || e.detail.keyboardHeight;
+      var keyboardHeight = e.keyboardHeight || (e.detail && e.detail.keyboardHeight);
       element.css('bottom', keyboardHeight + "px");
       scrollCtrl = element.controller('$ionicScroll');
       if (scrollCtrl) {


### PR DESCRIPTION
My background:

- newest ionic
- newest ionic cordova keyboard plugin installed
- iOS 8 + iPhone 5C
- debugging through Safari Emulator

What happens:

When focusing on the input in `<ion-footer-bar keyboard-attach>`, I get a `TypeError: undefined is not an object (evaluating 'e.detail.keyboardHeight')` error.

This bugfix fixes it.