### PR TITLE
Feature(scrollView): trigger `scrollstart` when starting a scroll

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -396,7 +396,8 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.onScroll = function() {
 
       if (!ionic.scroll.isScrolling) {
-        setTimeout(self.setScrollStart, 50);
+        if (!self.scrollStartTimer) self.triggerScrollStartEvent();
+        self.scrollStartTimer = setTimeout(self.setScrollStart, 50);
       } else {
         clearTimeout(self.scrollTimer);
         self.scrollTimer = setTimeout(self.setScrollStop, 80);
@@ -420,6 +421,15 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.setScrollStop = function() {
       ionic.scroll.isScrolling = false;
       ionic.scroll.lastTop = self.__scrollTop;
+      self.scrollStartTimer = null;
+    };
+
+    self.triggerScrollStartEvent = function() {
+      ionic.trigger('scrollstart', {
+        scrollTop: self.__scrollTop,
+        scrollLeft: self.__scrollLeft,
+        target: self.__container
+      });
     };
 
     self.triggerScrollEvent = ionic.throttle(function() {

--- a/test/html/scrollview-events.html
+++ b/test/html/scrollview-events.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html ng-app="ionicApp">
+  <head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>Ionic ScrollView Start/End Events</title>
+
+    <link href="../../dist/css/ionic.min.css" rel="stylesheet">
+    <script src="../../dist/js/ionic.bundle.min.js"></script>
+  </head>
+
+  <body ng-controller="MyCtrl">
+
+    <ion-header-bar class="bar-positive">
+      <h1 class="title">Ionic ScrollView Start/End Events</h1>
+    </ion-header-bar>
+
+    <ion-content>
+      <ion-list>
+        <ion-item ng-repeat="item in items">
+          <h2>Item {{ item.id }}</h2>
+          <p>{{item.id}}</p>
+        </ion-item>
+
+      </ion-list>
+
+    </ion-content>
+
+    <script>
+angular.module('ionicApp', ['ionic'])
+
+.controller('MyCtrl', function($scope, $timeout, $ionicScrollDelegate) {
+
+  $scope.items = [];
+  for (var i=0; i<50; i++) {
+    $scope.items.push({id:i});
+  }
+
+  $timeout(function() {
+    var scrollView = $ionicScrollDelegate.getScrollView();
+    if (!scrollView) return;
+
+    ionic.on('scrollstart', function(e) {
+      console.log('scrollstart');
+    }, scrollView.__container);
+
+    ionic.on('scroll', function(e) {
+      console.log('scroll');
+    }, scrollView.__container);
+
+    ionic.on('scrollend', function(e) {
+      console.log('scrollend');
+    }, scrollView.__container);
+
+  });
+
+});
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
`scrollView` currently triggers `scroll` ([L425](https://github.com/driftyco/ionic/blob/1.1/js/views/scrollView.js#L425)) and `scrollend` ([L434](https://github.com/driftyco/ionic/blob/1.1/js/views/scrollView.js#L434) + see #4026). This patch also adds a `scrollstart` trigger.