### PR TITLE
Feature(scrollView): trigger touchstart/touchmove/touchend events

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -452,7 +452,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
         target: self.__container
       }, false);
 
-    }
+    };
 
     self.triggerTouchMoveEvent = ionic.throttle(function() {
       ionic.trigger('scrollview.touchmove', {

--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -439,6 +439,41 @@ ionic.views.Scroll = ionic.views.View.inherit({
       });
     };
 
+    self.triggerTouchStartEvent = function() {
+
+      // Store current scroll position to calculate delta later on
+      self.__scrollTopAtTouchStart = self.__scrollTop;
+      self.__scrollLeftAtTouchStart = self.__scrollLeft;
+
+      // Trigger it!
+      ionic.trigger('scrollview.touchstart', {
+        scrollTop: self.__scrollTop,
+        scrollLeft: self.__scrollLeft,
+        target: self.__container
+      }, false);
+
+    }
+
+    self.triggerTouchMoveEvent = ionic.throttle(function() {
+      ionic.trigger('scrollview.touchmove', {
+        scrollTop: self.__scrollTop,
+        deltaY: self.__scrollTopAtTouchStart - self.__scrollTop,
+        scrollLeft: self.__scrollLeft,
+        deltaX: self.__scrollLeftAtTouchStart - self.__scrollLeft,
+        target: self.__container
+      }, false);
+    }, self.options.scrollEventInterval);
+
+    self.triggerTouchEndEvent = function() {
+      ionic.trigger('scrollview.touchend', {
+        scrollTop: self.__scrollTop,
+        deltaY: self.__scrollTopAtTouchStart - self.__scrollTop,
+        scrollLeft: self.__scrollLeft,
+        deltaX: self.__scrollLeftAtTouchStart - self.__scrollLeft,
+        target: self.__container
+      }, false);
+    };
+
     self.__scrollLeft = self.options.startX;
     self.__scrollTop = self.options.startY;
 
@@ -1771,6 +1806,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
     // Clearing data structure
     self.__positions = [];
 
+    // Trigger touchstart
+    self.triggerTouchStartEvent();
+
   },
 
 
@@ -1972,6 +2010,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.__lastTouchMove = timeStamp;
     self.__lastScale = scale;
 
+    // Trigger touchmove
+    self.triggerTouchMoveEvent();
+
   },
 
 
@@ -2099,6 +2140,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
     // Fully cleanup list
     self.__positions.length = 0;
+
+    // Trigger touchend
+    self.triggerTouchEndEvent();
 
   },
 

--- a/test/html/scrollview-touchevents.html
+++ b/test/html/scrollview-touchevents.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html ng-app="ionicApp">
+  <head>
+
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no">
+    <title>Ionic ScrollView Start/End Events</title>
+
+    <link href="../../dist/css/ionic.css" rel="stylesheet">
+    <script src="../../dist/js/ionic.bundle.js"></script>
+  </head>
+
+  <body ng-controller="MyCtrl">
+
+    <ion-header-bar class="bar-positive">
+      <h1 class="title">Ionic ScrollView Start/End Events</h1>
+    </ion-header-bar>
+
+    <ion-content delegate-handle="list">
+      <ion-list>
+        <ion-item ng-repeat="item in items">
+          <h2>Item {{ item.id }}</h2>
+          <p>{{item.id}}</p>
+        </ion-item>
+
+      </ion-list>
+
+    </ion-content>
+
+    <script>
+angular.module('ionicApp', ['ionic'])
+
+.controller('MyCtrl', function($scope, $timeout, $ionicScrollDelegate) {
+
+  $scope.items = [];
+  for (var i=0; i<50; i++) {
+    $scope.items.push({id:i});
+  }
+
+  $timeout(function() {
+    var scrollView = $ionicScrollDelegate.$getByHandle().getScrollView();
+    if (!scrollView) return;
+
+    ionic.on('scrollview.touchstart', function(e) {
+      console.log('touchstart');
+    }, scrollView.__container);
+
+    ionic.on('scrollview.touchmove', function(e) {
+      console.log('touchmove');
+    }, scrollView.__container);
+
+    ionic.on('scrollview.touchend', function(e) {
+      console.log('touchend');
+    }, scrollView.__container);
+
+  });
+
+});
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This patch will trigger `touchstart`/`touchmove`/`touchend` events on the scrollView. This in addition to the `scroll(start|end)` events being triggered.

Note that the events are prefixed with `scrollview.`. This is because MobileSafari already _(magically?)_ fires `touchstart`/`touchmove`/`touchend` events. When using non-prefixed eventnames, MobileSafari will throw an `RangeError: Maximum call stack size exceeded.` exception as events will keep on getting fired.