### PR TITLE
fix(tap) use element.getAttribute rather then trying element.dataset first

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -262,7 +262,7 @@ ionic.tap = {
     if (ele && ele.nodeType === 1) {
       var element = ele;
       while (element) {
-        if ((element.dataset ? element.dataset.tapDisabled : element.getAttribute && element.getAttribute('data-tap-disabled')) == 'true') {
+        if (element.getAttribute && element.getAttribute('data-tap-disabled') == 'true') {
           return true;
         }
         element = element.parentElement;


### PR DESCRIPTION
Unexplainably I have found element.dataset.tapDisabled to be unreliable. This
has been tested on iOS. element.getAttribute is also faster then
element.dataset so might as well just use it all the time.

Here is an example of what I was seeing. I can get this to happen by navigating around the app in the iOS simulator or on an iOS device. Note that this does not happen on the first load. Only after navigating around. The issue shows itself in a LeafletJS map where clicks are not passed to the map.

```
  isElementTapDisabled: function(ele) {
    if (ele && ele.nodeType === 1) {
      var element = ele;
      while (element) {
        console.log('isElementTapDisabled looking at', element);
        console.log('element has dataset', element.dataset);
        console.log('element has dataset' + JSON.stringify(element.dataset, null, 4));
        console.log('data-tap-disabled', element.getAttribute('data-tap-disabled'));
        // See the strange results of the line below in the screenshot:
        console.log('element.dataset.tapDisabled', element.dataset.tapDisabled);
        if (element.getAttribute('data-tap-disabled') == 'true') {
          console.log('data-tap-disabled == true');
        }
        if ((element.dataset ? element.dataset.tapDisabled : element.getAttribute('data-tap-disabled')) == 'true') {
          // element.dataset.tapDisabled is returning undefined so never get here.
          return true;
        }
        element = element.parentElement;
      }
    }
    return false;
  },
```

![screenshot 2015-09-28 11 51 59](https://cloud.githubusercontent.com/assets/999934/10147499/2ae92532-65e3-11e5-920e-d69b2d5b1190.png)