### PR TITLE
Access popup scope in the tap event handlers

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -296,7 +296,7 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
       subTitle: options.subTitle,
       cssClass: options.cssClass,
       $buttonTapped: function(button, event) {
-        var result = (button.onTap || noop)(event);
+        var result = (button.onTap || noop).apply(self, [event]);
         event = event.originalEvent || event; //jquery events
 
         if (!event.defaultPrevented) {


### PR DESCRIPTION
I think that it might be nice to have access to the popup scope in the `onTap` method. I needed to do that because my popup contained a `Do not show again` check box that was bound to the popup's scope and I could not access its value at all, because popup calls `$new()` on its scope option, if one is passed. You can basically see my code below:
```
$ionicPopup.show({
        scope: $scope,
        title: 'Text',
        template: '\
<div class="item item-text-wrap">\
   <!-- A very annoying message -->\
    <span>Annoying message.</span>\
</div>\
<!-- Make sure user has a chance to turn it off -->\
<ion-checkbox ng-model="doNotShow">Do Not Show Again</ion-checkbox>',
        buttons: [{
          text: 'Cancel'
        },
        {
          text: 'Continue',
          onTap: function(e) {
                // `this` is now the popup object
                // and we can have access to its scope nicely
          	if(this.scope.doNotShow) {
          		rememberNotToShow();
          	}	
          	return true;
          }
        }]
      });
``` 