### PR TITLE
Update gulp-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gulp-jscs": "^1.3.0",
     "gulp-minify-css": "^0.3.0",
     "gulp-rename": "^1.1.0",
-    "gulp-sass": "^0.7.1",
+    "gulp-sass": "^2.0.4",
     "gulp-strip-debug": "^0.3.0",
     "gulp-template": "^0.1.1",
     "gulp-uglify": "^0.2.1",


### PR DESCRIPTION
Ionic is currently using an ancient and unsupported version of gulp-sass.
This is currently causing a significant support load on the gulp-sass and node-sass team.

This also brings iojs and node 4 support when the other broken deps are eventually updated.