### PR TITLE
Improve keyboardAttach

### DIFF
--- a/js/angular/directive/keyboardAttach.js
+++ b/js/angular/directive/keyboardAttach.js
@@ -52,8 +52,11 @@ IonicModule
       // Get keyboardHeight from the event (or from the detail when testing)
       keyboardHeight = e.keyboardHeight || e.detail.keyboardHeight;
 
+      // Get Scroll Controller
+      scrollCtrl = element.controller('$ionicScroll');
+
       // Scroll Controller present? Shift the whole ionView up
-      if (scrollCtrl = element.controller('$ionicScroll')) {
+      if (scrollCtrl) {
 
         // get the ionView
         scrollView = scrollCtrl.getScrollView();


### PR DESCRIPTION
Hi,

I've cleaned up the current `keyboardAttach` implementation. Main difference is that it adjusts the scroll position of the scrollview so that the content of the scrollview does not shift/jump when the keyboard is shown/hidden.

Regards,
Bramus.