### PR TITLE
ionHeaderBar: Do not scroll the ScrollView if the no-tap-scroll attribute is set

### DIFF
--- a/js/angular/directive/headerFooterBar.js
+++ b/js/angular/directive/headerFooterBar.js
@@ -97,6 +97,7 @@ function tapScrollToTopDirective() {
           while (depth-- && current) {
             if (current.classList.contains('button') ||
                 current.tagName.match(/input|textarea|select/i) ||
+                ((current.getAttribute('no-tap-scroll') != null) && (current.getAttribute('no-tap-scroll') !== "false")) ||
                 current.isContentEditable) {
               return;
             }


### PR DESCRIPTION
In some case one does not want the ScrollView to scroll to the top of the list when tapping the title of the headerbar. Think of scenarios where the `h1` would link to a different view, or trigger a modal being shown.

Instead of checking for all possible attributes that could trigger this (such as `ui-sref, `href`, `ng-click`), a generic `no-tap-scroll` would also afford this. This PR introduces the latter.