### PR TITLE
Update view.js

### DIFF
--- a/js/angular/directive/view.js
+++ b/js/angular/directive/view.js
@@ -64,19 +64,19 @@
  *  </tr>
  *  <tr>
  *   <td><code>$ionicView.beforeEnter</code></td>
- *   <td>The view is about to enter and become the active view.</td>
+ *   <td>The view is about to enter and become the active view. This event will fire, whether it is cached or destroyed.</td>
  *  </tr>
  *  <tr>
  *   <td><code>$ionicView.beforeLeave</code></td>
- *   <td>The view is about to leave and no longer be the active view.</td>
+ *   <td>The view is about to leave and no longer be the active view. This event will fire, whether it is cached or destroyed.</td>
  *  </tr>
  *  <tr>
  *   <td><code>$ionicView.afterEnter</code></td>
- *   <td>The view has fully entered and is now the active view.</td>
+ *   <td>The view has fully entered and is now the active view. This event will fire, whether it is cached or destroyed.</td>
  *  </tr>
  *  <tr>
  *   <td><code>$ionicView.afterLeave</code></td>
- *   <td>The view has finished leaving and is no longer the active view.</td>
+ *   <td>The view has finished leaving and is no longer the active view. This event will fire, whether it is cached or destroyed.</td>
  *  </tr>
  *  <tr>
  *   <td><code>$ionicView.unloaded</code></td>


### PR DESCRIPTION
Since the docs specify that `$ionicView.enter` and `$ionicView.leave` will fire whether it is cached or destroyed, I thought that the same wasn't true for `$ionicView.beforeEnter`, `$ionicView.beforeLeave`, `$ionicView.afterEnter`, and `$ionicView.afterLeave`. After testing out `$ionicView.beforeEnter`, I found that all of those events are fired whether it is cached or destroyed.

I think this update makes the behavior more clear.