### PR TITLE
Avoid continuously painting invisible spinners

### DIFF
--- a/js/angular/controller/refresherController.js
+++ b/js/angular/controller/refresherController.js
@@ -28,6 +28,8 @@ IonicModule
 
     $scope.showIcon = isDefined($attrs.refreshingIcon);
 
+    $scope.isRefreshing = false;
+
     $ionicBind($scope, $attrs, {
       pullingIcon: '@',
       pullingText: '@',
@@ -287,6 +289,7 @@ IonicModule
         // deactivateCallback
         $element.removeClass('active refreshing refreshing-tail');
         if (activated) activated = false;
+        $scope.isRefreshing = false;
       }, 150);
     }
 
@@ -294,6 +297,7 @@ IonicModule
       // startCallback
       $element[0].classList.add('refreshing');
       $scope.$onRefresh();
+      $scope.isRefreshing = true;
     }
 
     function show() {

--- a/js/angular/controller/spinnerController.js
+++ b/js/angular/controller/spinnerController.js
@@ -337,36 +337,38 @@
       var circleEle = ele.querySelector('circle');
 
       function run() {
-        var v = easeInOutCubic(Date.now() - startTime, 650);
-        var scaleX = 1;
-        var translateX = 0;
-        var dasharray = (188 - (58 * v));
-        var dashoffset = (182 - (182 * v));
+        if (ele.parentNode) {
+          var v = easeInOutCubic(Date.now() - startTime, 650);
+          var scaleX = 1;
+          var translateX = 0;
+          var dasharray = (188 - (58 * v));
+          var dashoffset = (182 - (182 * v));
 
-        if (rIndex % 2) {
-          scaleX = -1;
-          translateX = -64;
-          dasharray = (128 - (-58 * v));
-          dashoffset = (182 * v);
+          if (rIndex % 2) {
+            scaleX = -1;
+            translateX = -64;
+            dasharray = (128 - (-58 * v));
+            dashoffset = (182 * v);
+          }
+
+          var rotateLine = [0, -101, -90, -11, -180, 79, -270, -191][rIndex];
+
+          setSvgAttribute(circleEle, 'da', Math.max(Math.min(dasharray, 188), 128));
+          setSvgAttribute(circleEle, 'os', Math.max(Math.min(dashoffset, 182), 0));
+          setSvgAttribute(circleEle, 't', 'scale(' + scaleX + ',1) translate(' + translateX + ',0) rotate(' + rotateLine + ',32,32)');
+
+          rotateCircle += 4.1;
+          if (rotateCircle > 359) rotateCircle = 0;
+          setSvgAttribute(svgEle, 't', 'rotate(' + rotateCircle + ',32,32)');
+
+          if (v >= 1) {
+            rIndex++;
+            if (rIndex > 7) rIndex = 0;
+            startTime = Date.now();
+          }
+
+          ionic.requestAnimationFrame(run);
         }
-
-        var rotateLine = [0, -101, -90, -11, -180, 79, -270, -191][rIndex];
-
-        setSvgAttribute(circleEle, 'da', Math.max(Math.min(dasharray, 188), 128));
-        setSvgAttribute(circleEle, 'os', Math.max(Math.min(dashoffset, 182), 0));
-        setSvgAttribute(circleEle, 't', 'scale(' + scaleX + ',1) translate(' + translateX + ',0) rotate(' + rotateLine + ',32,32)');
-
-        rotateCircle += 4.1;
-        if (rotateCircle > 359) rotateCircle = 0;
-        setSvgAttribute(svgEle, 't', 'rotate(' + rotateCircle + ',32,32)');
-
-        if (v >= 1) {
-          rIndex++;
-          if (rIndex > 7) rIndex = 0;
-          startTime = Date.now();
-        }
-
-        ionic.requestAnimationFrame(run);
       }
 
       return function() {

--- a/js/angular/directive/refresher.js
+++ b/js/angular/directive/refresher.js
@@ -77,7 +77,7 @@ IonicModule
         '</div>' +
         '<div class="text-pulling" ng-bind-html="pullingText"></div>' +
         '<div class="icon-refreshing">' +
-          '<ion-spinner ng-if="showSpinner" icon="{{spinner}}"></ion-spinner>' +
+          '<ion-spinner ng-if="showSpinner && isRefreshing" icon="{{spinner}}"></ion-spinner>' +
           '<i ng-if="showIcon" class="icon {{refreshingIcon}}"></i>' +
         '</div>' +
         '<div class="text-refreshing" ng-bind-html="refreshingText"></div>' +

--- a/test/unit/angular/directive/refresher.unit.js
+++ b/test/unit/angular/directive/refresher.unit.js
@@ -26,6 +26,20 @@ describe('ionRefresher directive', function() {
     return el;
   }
 
+  function startRefreshing(el) {
+    var refresher = el.refresherCtrl.getRefresherDomMethods();
+    refresher.start();
+    el.scope().$apply();
+  }
+  function stopRefreshing(el) {
+    inject(function($timeout) {
+      var refresher = el.refresherCtrl.getRefresherDomMethods();
+      refresher.deactivate();
+      $timeout.flush();
+      el.scope().$apply();
+    });
+  }
+
   it('should error without ionScroll or ionContent', inject(function($compile, $rootScope) {
     expect(function() {
       $compile('<ion-refresher>')($rootScope);
@@ -79,19 +93,32 @@ describe('ionRefresher directive', function() {
     expect(el[0].querySelector('.icon-pulling .super-icon')).toBeTruthy();
   });
 
-  it('should have default spinner', function() {
+  it('should have default spinner', inject(function($rootScope) {
     var el = setup();
+    startRefreshing(el);
     expect(el[0].querySelector('ion-spinner')).toBeTruthy();
-  });
+  }));
   it('should allow a custom spinner', function() {
     var el = setup('spinner="android"');
+    startRefreshing(el);
     expect(el[0].querySelector('.spinner-android')).toBeTruthy();
   });
   it('should allow spinner to be none', function() {
     var el = setup('spinner="none"');
+    startRefreshing(el);
     expect(el[0].querySelector('ion-spinner')).not.toBeTruthy();
     expect(el[0].querySelector('.icon.icon-refreshing')).not.toBeTruthy();
   });
+  it('should have no spinner prior to refreshing', inject(function($rootScope) {
+    var el = setup();
+    expect(el[0].querySelector('ion-spinner')).not.toBeTruthy();
+  }));
+  it('should have no spinner after refreshing', inject(function($rootScope) {
+    var el = setup();
+    startRefreshing(el);
+    stopRefreshing(el);
+    expect(el[0].querySelector('ion-spinner')).not.toBeTruthy();
+  }));
   it('should allow custom refreshingIcon', function() {
     var el = setup('refreshing-icon="monkey-icon"');
     expect(el[0].querySelector('.icon.icon-refreshing.ion-arrow-down-c')).toBeFalsy();


### PR DESCRIPTION
It has been noted in several previous issues that spinners continue to render despite being hidden with CSS (both `visibility: hidden` and `display: none`). This introduces an unnecessary constant cycle of layout, painting, and compositing. In some cases this may compete for resources that would be better allocated to animations and interactions. This can be seen at the [Pull to Refresh:Nightly](http://codepen.io/ionic/pen/mqolp) codepen by recording the timeline for a few seconds in a WebKit browser while (this is the important part) not interacting at all with the app frame.

This is not yet a complete pull request; I wish to determine whether the approach used herein is worth consideration before continuing the implementation for other directives and services that make use of spinners. 

### Workaround

Users have been encouraged by the Ionic team to implement custom CSS spinners to avoid the issues with SVG. However, SVG spinners are generally nicer than CSS spinners and all of the built-in ones use SVG animations.

### This Approach

This pull request uses `ngIf` to ensure that spinners are not just hidden but *not attached to the DOM at all* until they need to be shown. I believe that any added overhead of toggling the spinner with `ngIf` is a worthwhile compromise to avoid constantly repainting the invisible spinners.

Furthermore, the android spinner will short-circuit all of its SVG manipulation logic when the spinner element is detached from the DOM. The `run` function will stop once the element is detached from the DOM.

### Tests

This behavior required modification to a few existing tests. There is now guaranteed to be no `ion-spinner` until the refresh begins. Therefore, tests involving inspection of this element now require a function call and scope digest prior to inspecting the DOM. This has been wrapped up in two convenience functions `startRefreshing` and `stopRefreshing` in the `ionRefresher` tests.

### Concerns

`ngIf` scraps the old SVG element and then creates a new one. Ideally, the android spinner would stop animating when detached from the DOM and then resume animating when attached again. However, the behavior of `ngIf` causes a second SVG element to be created when the spinner is shown again in which case the original will continue requesting animation frames, checking whether it has a parent yet, forever. Perhaps a better solution would be an attribute on `ion-spinner` that allows it to be turned off (removed from the DOM) and back on but without creating a new element and in a way that allows the animation to be resumed without polling at each animation frame.