### PR TITLE
Added two more choices of column size: 40% and 60%

### DIFF
--- a/scss/_grid.scss
+++ b/scss/_grid.scss
@@ -118,9 +118,17 @@
   @include flex(0, 0, 33.3333%);
   max-width: 33.3333%;
 }
+.col-40 {
+  @include flex(0, 0, 40%);
+  max-width: 40%;
+}
 .col-50 {
   @include flex(0, 0, 50%);
   max-width: 50%;
+}
+.col-60 {
+  @include flex(0, 0, 60%);
+  max-width: 60%;
 }
 .col-66, .col-67 {
   @include flex(0, 0, 66.6666%);


### PR DESCRIPTION
I was missing two column sizes in my projects, so maybe it could also be useful for everyone.

I added `col-60` and `col-40` for two reasons:

- `col-60` and `col-40` can be combined together
- `col-60` can be used with `col-offset-20` to center an element