### PR TITLE
Fix async popup issues

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -346,7 +346,7 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
     };
 
     self.remove = function() {
-      if (self.removed || !$ionicModal.stack.isHighest(self)) return;
+      if (self.removed) return;
 
       self.hide(function() {
         self.element.remove();
@@ -369,8 +369,8 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
     var showDelay = 0;
 
     if (popupStack.length > 0) {
-      popupStack[popupStack.length - 1].hide();
       showDelay = config.stackPushDelay;
+      $timeout(popupStack[popupStack.length - 1].hide, showDelay, false);
     } else {
       //Add popup-open & backdrop if this is first popup
       $ionicBody.addClass('popup-open');


### PR DESCRIPTION
This commit removes $ionicModal.stack.isHighest check before removing a popup. This recently added check does not seem to have any purpose and it actually breaks programmatically closing popups, if they are not at the top of the stack.

This commit also introduces a delay to hiding the top popup on the stack before showing the new one. Without timeout, if multiple popups are fired within config.showPushDelay, their hide() methods are called before their show() methods due to timeout applied to showing them. So all of them end up being "shown" at the same time.  Purpose of "config.showPushDelay" is not clear from the code, and removing it altogether can also fix the issue but I didn't want to mess with it.

This along with the recently merged PR (https://github.com/driftyco/ionic/pull/4118) should close multiple issues: 
https://github.com/driftyco/ionic/issues/4061
https://github.com/driftyco/ionic/issues/4304
https://github.com/driftyco/ionic/issues/4339
https://github.com/driftyco/ionic/issues/4486
https://github.com/driftyco/ionic/issues/4299


