### PR TITLE
fix(tap): on iOS9, isElementTapDisabled fails to detect data-tap-disabled attribute after few clicks (fix #4506)

### DIFF
--- a/js/utils/dom.js
+++ b/js/utils/dom.js
@@ -245,7 +245,27 @@
       }
       return null;
     },
-
+    /**
+     * @ngdoc method
+     * @name ionic.DomUtil#getParentOrSelfWithAttribute
+     * @param {DOMElement} element
+     * @param {string} attrName (camelCased)
+     * @param {string} value
+     * @returns {DOMElement} The closest parent or self matching the
+     * attrName with specified value, or null.
+     */
+    getParentOrSelfWithAttribute: function(e, attrName, value, depth) {
+      // Convert camelCase to dash: attrName --> attr-name (http://bit.ly/1RkhjEA)
+      var attrToDash = attrName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase();
+      depth = depth || 10;
+      while (e && e.nodeType !== 9 && depth--) {
+        if (e.dataset ? e.dataset[attrName] : e.getAttribute('data-' + attrToDash) == value) {
+          return e;
+        }
+        e = e.parentNode;
+      }
+      return null;
+    },
     /**
      * @ngdoc method
      * @name ionic.DomUtil#rectContains

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -251,16 +251,11 @@ ionic.tap = {
   },
 
   isElementTapDisabled: function(ele) {
+    var withDataTapDisabled;
     if (ele && ele.nodeType === 1) {
-      var element = ele;
-      while (element) {
-        if ((element.dataset ? element.dataset.tapDisabled : element.getAttribute('data-tap-disabled')) == 'true') {
-          return true;
-        }
-        element = element.parentElement;
-      }
+      withDataTapDisabled = ionic.DomUtil.getParentOrSelfWithAttribute(ele, 'tapDisabled', 'true');
     }
-    return false;
+    return !!withDataTapDisabled;
   },
 
   setTolerance: function(releaseTolerance, releaseButtonTolerance) {


### PR DESCRIPTION
Hi,
I have tried several workarounds to try to fix the (strange) #4506 bug.
The proposed PR seems to solve it (at least in my case).
Please, can you review it and confirm that it works on your own ?
Thanks in advance and let me know if you need more info and/or changes are required.