### PR TITLE
fix(scroll): prevent 'cannot read from undefined' exception

### DIFF
--- a/js/angular/controller/scrollController.js
+++ b/js/angular/controller/scrollController.js
@@ -54,7 +54,7 @@ function($scope,
 
   if (!isDefined(scrollViewOptions.bouncing)) {
     ionic.Platform.ready(function() {
-      if (scrollView.options) {
+      if (scrollView && scrollView.options) {
         scrollView.options.bouncing = true;
         if (ionic.Platform.isAndroid()) {
           // No bouncing by default on Android


### PR DESCRIPTION
Sometimes, I don't know why yet, `scrollView` is undefined and this line rises an Error. This commit fix this problem, but don't fix what makes the `scrollView` undefined.