### PR TITLE
fix(): add default link color

### DIFF
--- a/scss/_type.scss
+++ b/scss/_type.scss
@@ -103,13 +103,13 @@ blockquote {
   margin: 0 0 $line-height-computed;
   padding: ($line-height-computed / 2) $line-height-computed;
   border-left: 5px solid gray;
-  
+
   p {
     font-weight: 300;
     font-size: ($font-size-base * 1.25);
     line-height: 1.25;
   }
-  
+
   p:last-child {
     margin-bottom: 0;
   }
@@ -148,6 +148,13 @@ address {
 
 // Links
 // -------------------------
+a {
+  color: $link-color;
+
+  &:hover {
+    color: $link-hover-color;
+  }
+}
 
 a.subdued {
   padding-right: 10px;


### PR DESCRIPTION
The variables **$link-color** and **$link-hover-color** are not used in the Ionic style.

When you write a link directly in a ion-content it takes the ugly default blue color of the browser.
I suggest to used this variables to make links more friendlier :art:.