### PR TITLE
Let tapIgnoreEvent check data-tap-disabled.

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -469,6 +469,10 @@ function tapEnableTouchEvents() {
 function tapIgnoreEvent(e) {
   if (e.isTapHandled) return true;
   e.isTapHandled = true;
+  
+  if(ionic.tap.isElementTapDisabled(e.target)){
+      return true;
+  }
 
   if (ionic.scroll.isScrolling && ionic.tap.containsOrIsTextInput(e.target)) {
     e.preventDefault();


### PR DESCRIPTION
This fix enables the data-tap-disabled tag to completely bypass the ionic tap handling for designated elements. 
This is a bug fix for 

https://github.com/driftyco/ionic/issues/2132
http://forum.ionicframework.com/t/ionic-tap-event-conflicting-with-d3-event/7369
http://stackoverflow.com/questions/30113156/d3-zoom-in-ionic

and more.

Without this fix, the tap event handling of ionic conflicts with d3 and many other js libs.