### PR TITLE
Prevent click events from firing twice on Windows Phone

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -236,6 +236,9 @@ ionic.tap = {
   },
 
   requiresNativeClick: function(ele) {
+    if (ionic.Platform.isWindowsPhone && (ele.tagName == 'A' || ele.tagName == 'BUTTON' || ele.hasAttribute('ng-click') || (ele.tagName == 'INPUT' && (ele.type == 'button' || ele.type == 'submit')))) {
+      return true; //Windows Phone edge case, prevent ng-click (and similar) events from firing twice on this platform
+    }
     if (!ele || ele.disabled || (/^(file|range)$/i).test(ele.type) || (/^(object|video)$/i).test(ele.tagName) || ionic.tap.isLabelContainingFileInput(ele)) {
       return true;
     }

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -236,7 +236,7 @@ ionic.tap = {
   },
 
   requiresNativeClick: function(ele) {
-    if (ionic.Platform.isWindowsPhone && (ele.tagName == 'A' || ele.tagName == 'BUTTON' || ele.hasAttribute('ng-click') || (ele.tagName == 'INPUT' && (ele.type == 'button' || ele.type == 'submit')))) {
+    if (ionic.Platform.isWindowsPhone() && (ele.tagName == 'A' || ele.tagName == 'BUTTON' || ele.hasAttribute('ng-click') || (ele.tagName == 'INPUT' && (ele.type == 'button' || ele.type == 'submit')))) {
       return true; //Windows Phone edge case, prevent ng-click (and similar) events from firing twice on this platform
     }
     if (!ele || ele.disabled || (/^(file|range)$/i).test(ele.type) || (/^(object|video)$/i).test(ele.tagName) || ionic.tap.isLabelContainingFileInput(ele)) {


### PR DESCRIPTION
On Windows Phone 8.1 and 10, Ionic (1.1.1) invokes click events twice in certain situations (caused by the tap handler). This patch filters out these events on the affected element types.

Note: I recognise that Windows Phone is not currently officially supported. However, this is literally the only issue I've encountered when targeting Windows Phone - which is pretty good going for an unsupported platform.