### PR TITLE
Fix menuClose snippet

### DIFF
--- a/js/angular/directive/menuClose.js
+++ b/js/angular/directive/menuClose.js
@@ -32,6 +32,7 @@
  *  disableAnimate: true,
  *  expire: 300
  * });
+ * ```
  */
 IonicModule
 .directive('menuClose', ['$ionicHistory', '$timeout', function($ionicHistory, $timeout) {


### PR DESCRIPTION
Just a small formatting error. The code block was left unclosed.