### PR TITLE
Bug fix for repeated infinite scroll calling after a state change with native scrolling

### DIFF
--- a/js/angular/controller/infiniteScrollController.js
+++ b/js/angular/controller/infiniteScrollController.js
@@ -100,13 +100,15 @@ function($scope, $attrs, $element, $timeout) {
     };
     var computedStyle = window.getComputedStyle(self.scrollEl) || {};
     return {
-      left: computedStyle.overflowX === 'scroll' ||
-      computedStyle.overflowX === 'auto' ||
-      self.scrollEl.style['overflow-x'] === 'scroll' ?
+      left: maxValues.left &&
+        (computedStyle.overflowX === 'scroll' ||
+        computedStyle.overflowX === 'auto' ||
+        self.scrollEl.style['overflow-x'] === 'scroll') ?
         calculateMaxValue(maxValues.left) : -1,
-      top: computedStyle.overflowY === 'scroll' ||
-      computedStyle.overflowY === 'auto' ||
-      self.scrollEl.style['overflow-y'] === 'scroll' ?
+      top: maxValues.top &&
+        (computedStyle.overflowY === 'scroll' ||
+        computedStyle.overflowY === 'auto' ||
+        self.scrollEl.style['overflow-y'] === 'scroll' ) ?
         calculateMaxValue(maxValues.top) : -1
     };
   };


### PR DESCRIPTION
This issue #3871 discusses the problem but it was closed without a solution. 

The problem was that the maximum scroll height and the current height were both 0 which made it appear like the scroll was at the bottom.
