### PR TITLE
Hide Firefox's focus outline on range inputs

### DIFF
--- a/scss/_range.scss
+++ b/scss/_range.scss
@@ -20,6 +20,11 @@
   background-size: 99% $range-track-height;
   background-repeat: no-repeat;
   -webkit-appearance: none;
+  
+  &::-moz-focus-outer {
+    /* hide the focus outline in Firefox */
+    border: 0;  
+  }
 
   &::-webkit-slider-thumb {
     position: relative;


### PR DESCRIPTION
Firefox ignores "outline: none;" on ranges, so a dotted rectangle is shown around focused range sliders.
This change hides that rectangle to bring the appearance in line with other browsers.