### PR TITLE
fix on-hold for Some devices

### DIFF
--- a/js/utils/gestures.js
+++ b/js/utils/gestures.js
@@ -1014,7 +1014,7 @@
     index: 10,
     defaults: {
       hold_timeout: 500,
-      hold_threshold: 1
+      hold_threshold: 9
     },
     timer: null,
     handler: function holdGesture(ev, inst) {


### PR DESCRIPTION
Fix on-hold callback that are not fired on Galaxy S6 and some other android 5.1 devices

See   https://github.com/driftyco/ionic/issues/4672

Maybe related to https://forum.ionicframework.com/t/issues-with-on-hold-event-on-android/14051/17

and https://forum.ionicframework.com/t/ionic-view-android-gesture-issues/21807