### PR TITLE
fix(viewLifecycle): move event emit after transition cleanup

### DIFF
--- a/js/angular/controller/navViewController.js
+++ b/js/angular/controller/navViewController.js
@@ -161,6 +161,7 @@ function($scope, $element, $attrs, $compile, $controller, $ionicNavBarDelegate, 
 
 
   self.transitionEnd = function() {
+    console.log('TRANSITION END CHILD VIEW');
     var viewElements = $element.children();
     var x, l, viewElement;
 

--- a/js/angular/controller/navViewController.js
+++ b/js/angular/controller/navViewController.js
@@ -161,7 +161,6 @@ function($scope, $element, $attrs, $compile, $controller, $ionicNavBarDelegate, 
 
 
   self.transitionEnd = function() {
-    console.log('TRANSITION END CHILD VIEW');
     var viewElements = $element.children();
     var x, l, viewElement;
 

--- a/js/angular/service/viewSwitcher.js
+++ b/js/angular/service/viewSwitcher.js
@@ -257,7 +257,6 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
             $timeout.cancel(enteringEle.data(DATA_FALLBACK_TIMER));
             leavingEle && $timeout.cancel(leavingEle.data(DATA_FALLBACK_TIMER));
 
-
             // resolve that this one transition (there could be many w/ nested views)
             deferred && deferred.resolve(navViewCtrl);
 
@@ -265,6 +264,10 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
             // transition promises should be added to the services array of promises
             if (transitionId === transitionCounter) {
               $q.all(transitionPromises).then(ionicViewSwitcher.transitionEnd);
+
+              // emit that the views have finished transitioning
+              // each parent nav-view will update which views are active and cached
+              switcher.emit('after', enteringData, leavingData);
               switcher.cleanup(enteringData);
             }
 
@@ -273,9 +276,6 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
               instance.triggerTransitionEnd();
             });
 
-            // emit that the views have finished transitioning
-            // each parent nav-view will update which views are active and cached
-            switcher.emit('after', enteringData, leavingData);
 
             // remove any references that could cause memory issues
             nextTransition = nextDirection = enteringView = leavingView = enteringEle = leavingEle = null;

--- a/js/angular/service/viewSwitcher.js
+++ b/js/angular/service/viewSwitcher.js
@@ -273,10 +273,11 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
               instance.triggerTransitionEnd();
             });
 
-            // remove any references that could cause memory issues
             // emit that the views have finished transitioning
             // each parent nav-view will update which views are active and cached
             switcher.emit('after', enteringData, leavingData);
+
+            // remove any references that could cause memory issues
             nextTransition = nextDirection = enteringView = leavingView = enteringEle = leavingEle = null;
           }
 

--- a/js/angular/service/viewSwitcher.js
+++ b/js/angular/service/viewSwitcher.js
@@ -257,9 +257,6 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
             $timeout.cancel(enteringEle.data(DATA_FALLBACK_TIMER));
             leavingEle && $timeout.cancel(leavingEle.data(DATA_FALLBACK_TIMER));
 
-            // emit that the views have finished transitioning
-            // each parent nav-view will update which views are active and cached
-            switcher.emit('after', enteringData, leavingData);
 
             // resolve that this one transition (there could be many w/ nested views)
             deferred && deferred.resolve(navViewCtrl);
@@ -277,6 +274,9 @@ function($timeout, $document, $q, $ionicClickBlock, $ionicConfig, $ionicNavBarDe
             });
 
             // remove any references that could cause memory issues
+            // emit that the views have finished transitioning
+            // each parent nav-view will update which views are active and cached
+            switcher.emit('after', enteringData, leavingData);
             nextTransition = nextDirection = enteringView = leavingView = enteringEle = leavingEle = null;
           }
 

--- a/test/html/nav.html
+++ b/test/html/nav.html
@@ -26,6 +26,7 @@
           <button class="button button-icon ion-android-search"></button>
         </ion-nav-buttons>
         <ion-content padding="true">
+          <h2>Random {{random}}</h2>
           <ion-list>
             <div class="item item-divider">
               Things
@@ -46,6 +47,7 @@
     <script id="page2.html" type="text/ng-template">
       <ion-view title="Page 2">
         <ion-content padding="true">
+          <h2>Random: {{random}}</h2>
           <a ng-click="goBack()" class="button button-positive">Back</a>
           <a href="#/page3" class="button button-positive">Page 3</a>
         </ion-content>
@@ -62,7 +64,9 @@
     <script>
       angular.module('nav', ['ionic'])
 
-      .config(function($stateProvider, $urlRouterProvider) {
+      .config(function($stateProvider, $urlRouterProvider, $ionicConfigProvider) {
+
+        //$ionicConfigProvider.views.maxCache(0);
 
         $stateProvider
           .state('page1', {
@@ -84,7 +88,8 @@
          $urlRouterProvider.otherwise("/page1");
        })
 
-       .controller('Page1Ctrl', function($scope) {
+       .controller('Page1Ctrl', function($scope, $ionicHistory) {
+         $scope.random = Math.random() * 100;
          $scope.items = [];
          for(var i = 0; i < 4; i++) {
           $scope.items.push({});
@@ -96,7 +101,13 @@
          }
        })
 
-       .controller('Page2Ctrl', function($scope, $ionicNavBarDelegate) {
+       .controller('Page2Ctrl', function($timeout, $scope, $ionicNavBarDelegate, $ionicHistory) {
+         $scope.$on('$ionicView.enter', function() {
+           //$timeout(function() {
+             $ionicHistory.clearCache();
+           //})
+         });
+
         $scope.goBack = function() {
           $ionicNavBarDelegate.back();
         };
@@ -107,7 +118,7 @@
           $ionicNavBarDelegate.back();
         };
        })
-      
+
     </script>
   </body>
 </html>


### PR DESCRIPTION
Right now view lifecycle events can fire before the transition is fully cleaned up, meaning our past view can be in a `leaving` state instead of `cached` when the new view's `$ionicView.enter` is triggered.

This fixes #2939 where this code would not correctly clear the last view because it is marked `leaving` rather than `cached` in the navViewController.clearCache function:

```
controller('MyCtrl', function() {
  $scope.$on('$ionicView.enter' function() {
    $ionicHistory.clearCached();
  });
});
```

The fix was to move the event emit to the bottom of transitionCompleted in `viewSwitcher.js`