### PR TITLE
+ Swipe to go back fix

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -766,6 +766,10 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
     if (ele && ele.attr('can-swipe-back') === 'false') {
       return false;
     }
+    var eleChild = ele.find('ion-view');
+    if (eleChild && eleChild.attr('can-swipe-back') === 'false') {
+      return false;
+    }
     return true;
   }
 


### PR DESCRIPTION
Swipe to go back attribute not being read because sometimes the view is
inside a second pane.

I have seen it countless times on the forums and in my own projects. I have noticed that the can-swipe-back="false" attribute doesn't actually stop the swiping action leading multiple people to have to not use the feature including myself for a while. I found that the element (ele) is actually a parent of the ion-view that *should* be targeted. This extra code I added should find the actual ion-view if it didn't pass the previous two tests, and then check the attribute. 