### PR TITLE
Revert "update main section of bower.json with bundle"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
   "main": [
     "release/css/ionic.css",
     "release/fonts/*",
-    "release/js/ionic.bundle.js"
+    "release/js/ionic.js",
+    "release/js/ionic-angular.js"
   ],
   "keywords": [
     "mobile",


### PR DESCRIPTION
This reverts commit bfd9f083b35542a09e655a64b33d5cd130a2ba2a.

This commit bfd9f08 altered bower.json so there is only one main
 .js file, while leaving angular as a dependency.
This means that angular is now loaded into the project twice making it
complain and breaking dependency resolution.