### PR TITLE
Add initialZoom to view

### DIFF
--- a/js/angular/directive/scroll.js
+++ b/js/angular/directive/scroll.js
@@ -36,6 +36,7 @@
  * @param {boolean=} zooming Whether to support pinch-to-zoom
  * @param {integer=} min-zoom The smallest zoom amount allowed (default is 0.5)
  * @param {integer=} max-zoom The largest zoom amount allowed (default is 3)
+ * @param {integer=} initial-zoom The initial zoom (default is 1)
  * @param {boolean=} has-bouncing Whether to allow scrolling to bounce past the edges
  * of the content.  Defaults to true on iOS, false on Android.
  */
@@ -71,7 +72,8 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
           scrollbarY: '@',
           zooming: '@',
           minZoom: '@',
-          maxZoom: '@'
+          maxZoom: '@',
+          initialZoom: '@'
         });
         $scope.direction = $scope.direction || 'y';
 
@@ -106,6 +108,7 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
           zooming: $scope.$eval($scope.zooming) === true,
           maxZoom: $scope.$eval($scope.maxZoom) || 3,
           minZoom: $scope.$eval($scope.minZoom) || 0.5,
+          initialZoom: $scope.$eval($scope.initialZoom) || 1,
           preventDefault: true,
           nativeScrolling: nativeScrolling
         };

--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -352,6 +352,9 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
       /** Maximum zoom level */
       maxZoom: 3,
+      
+      /** Initial zoom level */
+      initialZoom: 1,
 
       /** Multiply or decrease scrolling speed **/
       speedMultiplier: 1,
@@ -441,6 +444,8 @@ ionic.views.Scroll = ionic.views.View.inherit({
 
     self.__scrollLeft = self.options.startX;
     self.__scrollTop = self.options.startY;
+
+    self.__zoomLevel = self.options.initialZoom;
 
     // Get the render update function, initialize event handlers,
     // and calculate the size of the scroll container
@@ -1741,7 +1746,7 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.__initialTouches = touches;
 
     // Store current zoom level
-    self.__zoomLevelStart = self.__zoomLevel;
+    self.__zoomLevelStart = self.options.initialZoom;
 
     // Store initial touch positions
     self.__lastTouchLeft = currentTouchLeft;


### PR DESCRIPTION
Add option to declare the initial zooming level of the scroll element.
This way, we can start at a lower level  and preserve image quality on scaling.
