### PR TITLE
Setup empty arrays before evaluating ionic.CSS

### DIFF
--- a/js/utils/poly.js
+++ b/js/utils/poly.js
@@ -3,6 +3,8 @@
 
   // Ionic CSS polyfills
   ionic.CSS = {};
+  ionic.CSS.TRANSITION = [];
+  ionic.CSS.TRANSFORM = [];
 
   (function() {
 


### PR DESCRIPTION
I know IE9 support isn't a priority, but initializing empty arrays for `ionic.CSS.TRANSITION will keep IE9 from choking when it gets here and finds an undefined variable:

```
var isWebkit = ionic.CSS.TRANSITION.indexOf('webkit') > -1;
```

Adding TRANSFORM too, for the same reason, although it wasn't causing any issues.