### PR TITLE
fix(slides): Update slides(swiper) pagination for multiple use

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -77,7 +77,7 @@ function($animate, $timeout) {
       var options = $scope.options || {};
 
       var newOptions = angular.extend({
-        pagination: '.swiper-pagination',
+        pagination: $element.children().children()[1],
         paginationClickable: true,
         lazyLoading: true,
         preloadImages: false


### PR DESCRIPTION
According to the Swiper documentation, the pagination parameter can receive a string with a selector or directly the html element.
Passing directly the html element ensures that the pagination works with multiple sliders. Resolves #4837.