### PR TITLE
enable expression for tab hidden

### DIFF
--- a/js/angular/directive/tabNav.js
+++ b/js/angular/directive/tabNav.js
@@ -43,8 +43,7 @@ IonicModule
       }
 
       $scope.isHidden = function() {
-        if ($attrs.hidden === 'true' || $attrs.hidden === true) return true;
-        return false;
+        return $attrs.hidden === 'true' || $attrs.hidden === true || $scope.$eval($attrs.hidden) === true;
       };
 
       $scope.getIconOn = function() {


### PR DESCRIPTION
This will enable expression in the hidden attribute, however due to the isolate scope on tab, the expression can not read parent scope property directly. Like for me I will use 
```
<ion-tab hidden="$parent.$parent.tabHidden">...</ion-tab>
```