### PR TITLE
set hammer options for Pan

### DIFF
--- a/ionic/gestures/gesture.ts
+++ b/ionic/gestures/gesture.ts
@@ -46,7 +46,8 @@ export class Gesture {
   }
 
   listen() {
-    this._hammer = Hammer(this.element, this._options);
+    this._hammer = new Hammer(this.element, {recognizers: []});
+    this._hammer.add(new Hammer.Pan(this._options));
   }
 
   unlisten() {


### PR DESCRIPTION
Pan treshold is currently set to the default value (10) not to the value in this._options
this is how they do in hammerjs [unit test](https://github.com/hammerjs/hammer.js/blob/master/tests/unit/gestures/test_pan.js#L23)