### PR TITLE
fix(bar): set correct title bar height

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -366,6 +366,11 @@
   &.item-input-inset {
     position: absolute;
   }
+
+  .title {
+    height: $bar-footer-height - 1;
+    line-height: $bar-footer-height;
+  }
 }
 
 // Don't render padding if the bar is just for tabs
@@ -378,12 +383,22 @@
   display: block;
 
   height: $bar-subheader-height;
+
+  .title {
+    height: $bar-subheader-height - 1;
+    line-height: $bar-subheader-height;
+  }
 }
 .bar-subfooter {
   bottom: $bar-footer-height;
   display: block;
 
   height: $bar-subfooter-height;
+
+  .title {
+    height: $bar-subfooter-height - 1;
+    line-height: $bar-subfooter-height;
+  }
 }
 
 .nav-bar-block {


### PR DESCRIPTION
When you customize the SASS variables: `$bar-footer-height`, `$bar-subheader-height`, `$bar-subfooter-height`. If you set a title inside subheader, footer, and subfooter bar:

```html
      <ion-header-bar class="bar-stable">
        <h1 class="title">Header</h1>
      </ion-header-bar>

      <ion-header-bar class="bar-subheader bar-energized">
        <h1 class="title">SubHeader</h1>
      </ion-header-bar>

      <ion-footer-bar class="bar-stable">
        <h1 class="title">Footer</h1>
      </ion-footer-bar>

      <ion-footer-bar class="bar-energized bar-subfooter">
        <h1 class="title">SubFooter</h1>
      </ion-footer-bar>
```
The title have a wrong height!

ScreenShot to illustrate the problem:
![capture](https://cloud.githubusercontent.com/assets/659811/12334443/54e99774-bafa-11e5-949f-0321f821d98c.PNG)