### PR TITLE
add ngOnDestroy to ion-icon and remove added css class

### DIFF
--- a/ionic/components/icon/icon.ts
+++ b/ionic/components/icon/icon.ts
@@ -54,7 +54,7 @@ export class Icon {
   private _md: string = '';
   private _css: string = '';
   mode: string;
-  
+
   constructor(
     config: Config,
     private _elementRef: ElementRef,
@@ -70,11 +70,20 @@ export class Icon {
     }
   }
 
+  /**
+   * @private
+   */
+  ngOnDestroy() {
+    if (this._css) {
+      this._renderer.setElementClass(this._elementRef, this._css, false);
+    }
+  }
+
   @Input()
   get name() {
     return this._name;
   }
- 
+
   set name(val) {
     if (!(/^md-|^ios-|^logo-/.test(val))) {
       // this does not have one of the defaults
@@ -85,7 +94,7 @@ export class Icon {
     this.update();
   }
 
-  @Input() 
+  @Input()
   get ios(): string {
     return this._ios;
   }


### PR DESCRIPTION
the symptom was described in issue https://github.com/driftyco/ionic/issues/4955

#### Bug Explained:
- when user view item detail page the first time, ion-icon is created and dom element is updated with first icon name
- when user view item detail page second time with a different icon name, the same dom element (with first icon name) is now added with the new icon name. The updated dom is still there because the page is cached.

The page cache behavior is described in nav-controller.ts:

    * By default, pages are cached and left in the DOM if they are navigated away
    * from but still in the navigation stack (the exiting page on a `push()` for
    * example).  They are destroyed when removed from the navigation stack (on
    * [pop()](#pop) or [setRoot()](#setRoot)).

#### Solution Implemented in this PR:

add a ngOnDestroy function in ion-item directive which reset the css classes added to dom element when the directive is destroyed (aka user leaving the page)