### PR TITLE
ionic 2: fix(Searchbar):stopInput() argument name typo

### DIFF
--- a/ionic/components/searchbar/searchbar.ts
+++ b/ionic/components/searchbar/searchbar.ts
@@ -20,7 +20,7 @@ export class SearchbarInput {
    * @private
    * Don't send the input's input event
    */
-  private stopInput(ev) {
+  private stopInput(event) {
     event.preventDefault();
     event.stopPropagation();
   }


### PR DESCRIPTION
argument name did not match the variable name inside the function, it's changed from 'ev' to match the name 'event' of the variable used inside the function.