### PR TITLE
ionic 2: fix(Storage): getJson() implementation

### DIFF
--- a/ionic/platform/storage/storage.ts
+++ b/ionic/platform/storage/storage.ts
@@ -20,12 +20,14 @@ export class Storage {
     return this._strategy.get(key);
   }
   getJson(key) {
-    try {
-      return JSON.parse(this._strategy.get(key));
-    } catch(e) {
-      console.warn('Storage getJson(): unable to parse value for key', key,' as JSON')
-      return null;
-    }
+    return this.get(key).then(value => {
+      try {
+        return JSON.parse(value);
+      } catch (e) {
+        console.warn('Storage getJson(): unable to parse value for key', key, ' as JSON');
+        throw e; // rethrowing exception so it can be handled with .catch()
+      }
+    });
   }
   set(key, value) {
     return this._strategy.set(key, value);


### PR DESCRIPTION
The current implementation pases a promise to JSON.parse() which is fundamentally wrong.
Also, JSON.parse() is caught without rethrowing the exception which makes very difficult to handle failure cases.

My fix allows this:
```ts
storage.getJson("key").then(json => {
  // handle success case, json is a valid js object.
}).catch(error => {
  // this is called if JSON or db access fails!
});
```

Note, please checkout https://github.com/driftyco/ionic/pull/4995
as well.