### PR TITLE
Icon fonts need to be Meteor assets

### DIFF
--- a/package.js
+++ b/package.js
@@ -24,11 +24,14 @@ Package.onUse(function(api) {
 
   api.addFiles([
     'release/css/ionic.css',
-    'release/fonts/ionicons.eot',
-    'release/fonts/ionicons.svg',
-    'release/fonts/ionicons.ttf',
-    'release/fonts/ionicons.woff',
     'release/js/ionic.js',
     'release/js/ionic-angular.js'
   ], where);
+
+  api.addAssets([
+    'release/fonts/ionicons.eot',
+    'release/fonts/ionicons.svg',
+    'release/fonts/ionicons.ttf',
+    'release/fonts/ionicons.woff'
+  ], where)
 });


### PR DESCRIPTION
This problem is described in #4766 

After this is fixed, it should be possible to publish the package to Atmosphere, the Meteor package repository.