### PR TITLE
v2: wrap swiper init code in set timeout

### DIFF
--- a/ionic/components/slides/slides.ts
+++ b/ionic/components/slides/slides.ts
@@ -186,9 +186,10 @@ export class Slides extends Ion {
       return this.options.onLazyImageReady && this.options.onLazyImageReady(swiper, slide, img);
     };
 
-    var swiper = new Swiper(this.getNativeElement().children[0], options);
-
-    this.slider = swiper;
+    setTimeout(() => {
+      var swiper = new Swiper(this.getNativeElement().children[0], options);
+      this.slider = swiper;
+    });
 
     /*
     * TODO: Finish this
@@ -597,9 +598,9 @@ export class Slides extends Ion {
 })
 export class Slide {
   private ele: HTMLElement;
-  
+
   @Input() zoom;
-  
+
   constructor(
     elementRef: ElementRef,
     @Host() slides: Slides


### PR DESCRIPTION
moving the pull request from ionic2 to ionic:2.0
original pull request in ionic2 repo: https://github.com/driftyco/ionic2/pull/786

delay the Swiper initialization with setTimeout, in order to let Swiper find the DOM created with ion-slide ngFor
