### PR TITLE
Fix initial copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2015-present Drifty Co.
+Copyright 2013-present Drifty Co.
 http://drifty.com/
 
 MIT License


### PR DESCRIPTION
According to http://www.copyright.gov/circs/circ01.pdf (See screenshot of relevant section below) , listing the first year of publication in the copyright is necessary

![selection_008](https://cloud.githubusercontent.com/assets/829526/12409934/7021c3a6-be95-11e5-8d1a-18f6948571e0.png)

This pull request reverts it back to 2013 (As it was in the commit when the MIT license was introduced cc38f014c366128 )