### PR TITLE
Fix ionSlidePage destroy

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -129,6 +129,10 @@ function($animate, $timeout, $compile) {
     template: '<div class="swiper-slide" ng-transclude></div>',
     link: function($scope, $element, $attr, ionSlidesCtrl) {
       ionSlidesCtrl.rapidUpdate();
+
+      $scope.$on('$destroy', function() {
+        ionSlidesCtrl.rapidUpdate();
+      });
     }
   };
 }]);

--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -73,9 +73,16 @@ function($animate, $timeout, $compile) {
             _this.__slider.createLoop();
           }
 
+          var slidesLength = _this.__slider.slides.length;
+
           // Don't allow pager to show with > 10 slides
-          if (_this.__slider.slides.length > 10) {
+          if (slidesLength > 10) {
             $scope.showPager = false;
+          }
+
+          // When slide index is greater than total then slide to last index
+          if (_this.__slider.activeIndex > slidesLength - 1) {
+            _this.__slider.slideTo(slidesLength - 1)
           }
         });
       };

--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -82,7 +82,7 @@ function($animate, $timeout, $compile) {
 
           // When slide index is greater than total then slide to last index
           if (_this.__slider.activeIndex > slidesLength - 1) {
-            _this.__slider.slideTo(slidesLength - 1)
+            _this.__slider.slideTo(slidesLength - 1);
           }
         });
       };


### PR DESCRIPTION
When a `<ion-slide-page>` directive is destroyed, the slider is not updated.
This PR fix the issue related in #5120 adding a destroy event in the directive.