### PR TITLE
fix (ionSlideBox): only disable ngAnimate for slidebox and its children

### DIFF
--- a/js/angular/directive/slideBox.js
+++ b/js/angular/directive/slideBox.js
@@ -159,7 +159,7 @@ function($animate, $timeout, $compile, $ionicSlideBoxDelegate, $ionicHistory, $i
 
     link: function($scope, $element, $attr) {
       // Disable ngAnimate for slidebox and its children
-      $animate.enabled(false, $element);
+      $animate.enabled($element, false);
 
       // if showPager is undefined, show the pager
       if (!isDefined($attr.showPager)) {


### PR DESCRIPTION
according to the angular api document, `$element` should be the first argument