### PR TITLE
remove the error throwing in storage engine constructor

### DIFF
--- a/ionic/platform/storage/local-storage.ts
+++ b/ionic/platform/storage/local-storage.ts
@@ -30,7 +30,7 @@ import {StorageEngine} from './storage';
  * @see {@link /docs/v2/platform/storage/ Storage Platform Docs}
  */
 export class LocalStorage extends StorageEngine {
-  constructor() {
+  constructor(options={}) {
     super();
   }
 

--- a/ionic/platform/storage/storage.ts
+++ b/ionic/platform/storage/storage.ts
@@ -56,7 +56,6 @@ export interface IStorageEngine {
 */
 export class StorageEngine {
   constructor(options={}) {
-    throw Error("constructor(options={}) not implemented for this storage engine");
   }
   get(key, value) {
     throw Error("get() not implemented for this storage engine");


### PR DESCRIPTION
fixing the error found by @phavre because of the StorageEngine constructor changes:
https://github.com/driftyco/ionic/commit/07953672f53c793828f29d81101b46d6b88dfafa#commitcomment-15599683