### PR TITLE
Bug V2: ion-toggle, toggleEle return NULL

### DIFF
--- a/ionic/components/toggle/toggle.ts
+++ b/ionic/components/toggle/toggle.ts
@@ -124,7 +124,7 @@ export class Toggle {
       }
     }
 
-    let toggleEle = _elementRef.nativeElement.querySelector('.toggle-media');
+    let toggleEle = _elementRef.nativeElement;
 
     this.addMoveListener = function() {
       toggleEle.addEventListener('touchmove', pointerMove);


### PR DESCRIPTION
toggleEle is NULL when calling **querySelector** on **nativeElement**

removeMoveListener throw exception **toggleEle can not be null**

Changing
```Typescript
let toggleEle = _elementRef.nativeElement.querySelector('.toggle-media');
```
to
```Typescript
let toggleEle = _elementRef.nativeElement;
```
fix the issue.