### PR TITLE
Allow to change popup properties after it was initialized

### DIFF
--- a/js/angular/service/popup.js
+++ b/js/angular/service/popup.js
@@ -1,15 +1,15 @@
 
 var POPUP_TPL =
-  '<div class="popup-container" ng-class="cssClass">' +
+  '<div class="popup-container" ng-class="options.cssClass">' +
     '<div class="popup">' +
       '<div class="popup-head">' +
-        '<h3 class="popup-title" ng-bind-html="title"></h3>' +
-        '<h5 class="popup-sub-title" ng-bind-html="subTitle" ng-if="subTitle"></h5>' +
+        '<h3 class="popup-title" ng-bind-html="options.title"></h3>' +
+        '<h5 class="popup-sub-title" ng-bind-html="options.subTitle" ng-if="options.subTitle"></h5>' +
       '</div>' +
       '<div class="popup-body">' +
       '</div>' +
-      '<div class="popup-buttons" ng-show="buttons.length">' +
-        '<button ng-repeat="button in buttons" ng-click="$buttonTapped(button, $event)" class="button" ng-class="button.type || \'button-default\'" ng-bind-html="button.text"></button>' +
+      '<div class="popup-buttons" ng-show="options.buttons.length">' +
+        '<button ng-repeat="button in options.buttons" ng-click="$buttonTapped(button, $event)" class="button" ng-class="button.type || \'button-default\'" ng-bind-html="button.text"></button>' +
       '</div>' +
     '</div>' +
   '</div>';
@@ -283,34 +283,27 @@ function($ionicTemplateLoader, $ionicBackdrop, $q, $timeout, $rootScope, $ionicB
   return $ionicPopup;
 
   function createPopup(options) {
-    options = extend({
-      scope: null,
-      title: '',
-      buttons: []
-    }, options || {});
+
+    options = options || {};
+    options.scope = options.scope || $rootScope;
 
     var self = {};
-    self.scope = (options.scope || $rootScope).$new();
+    self.scope = options.scope.$new();
     self.element = jqLite(POPUP_TPL);
     self.responseDeferred = $q.defer();
 
     $ionicBody.get().appendChild(self.element[0]);
     $compile(self.element)(self.scope);
 
-    extend(self.scope, {
-      title: options.title,
-      buttons: options.buttons,
-      subTitle: options.subTitle,
-      cssClass: options.cssClass,
-      $buttonTapped: function(button, event) {
-        var result = (button.onTap || noop).apply(self, [event]);
-        event = event.originalEvent || event; //jquery events
+    self.scope.options = options;
+    self.scope.$buttonTapped = function(button, event) {
+      var result = (button.onTap || noop).apply(self, [event]);
+      event = event.originalEvent || event; //jquery events
 
-        if (!event.defaultPrevented) {
-          self.responseDeferred.resolve(result);
-        }
+      if (!event.defaultPrevented) {
+        self.responseDeferred.resolve(result);
       }
-    });
+    };
 
     $q.when(
       options.templateUrl ?

--- a/test/unit/angular/service/popup.unit.js
+++ b/test/unit/angular/service/popup.unit.js
@@ -168,6 +168,53 @@ describe('$ionicPopup service', function() {
       });
     });
 
+    describe('change', function() {
+      it('should change title after dialog was initialized', inject(function($rootScope) {
+        var popupOptions = {
+              title: 'initial title'
+            },
+            popup = TestUtil.unwrapPromise($ionicPopup._createPopup(popupOptions));
+            expect(popup.element[0].querySelector('.popup-title').innerHTML).toEqual(popupOptions.title);
+            popupOptions.title = 'new title';
+            $rootScope.$apply();
+            expect(popup.element[0].querySelector('.popup-title').innerHTML).toEqual(popupOptions.title);
+      }));
+      it('should change sub title after dialog was initialized', inject(function($rootScope) {
+        var popupOptions = {
+              subTitle: 'initial sub title'
+            },
+            popup = TestUtil.unwrapPromise($ionicPopup._createPopup(popupOptions));
+        expect(popup.element[0].querySelector('.popup-sub-title').innerHTML).toEqual(popupOptions.subTitle);
+        popupOptions.subTitle = 'new sub title';
+        $rootScope.$apply();
+        expect(popup.element[0].querySelector('.popup-sub-title').innerHTML).toEqual(popupOptions.subTitle);
+      }));
+      it('should change CSS class after dialog was initialized', inject(function($rootScope) {
+        var popupOptions = {
+              cssClass: 'initclass'
+            },
+            popup = TestUtil.unwrapPromise($ionicPopup._createPopup(popupOptions));
+        expect(popup.element.hasClass('initclass')).toBe(true);
+        popupOptions.cssClass = 'newclass';
+        $rootScope.$apply();
+        expect(popup.element.hasClass('newclass')).toBe(true);
+      }));
+      it('should replace buttons after dialog was initialized', inject(function($rootScope) {
+        var popupOptions = {
+              buttons: [
+                { text: 'Cancel' },
+                { text: 'Ok' }
+              ]
+            },
+            popup = TestUtil.unwrapPromise($ionicPopup._createPopup(popupOptions));
+        expect(popup.element[0].querySelectorAll('.popup-buttons .button').length).toEqual(2);
+        popupOptions.buttons = [{text: 'Close'}];
+        $rootScope.$apply();
+        expect(popup.element[0].querySelectorAll('.popup-buttons .button').length).toEqual(1);
+        expect(popup.element[0].querySelector('.popup-buttons .button').innerText).toEqual('Close');
+      }));
+    });
+
   });
 
   describe('$ionicPopup.showPopup()', function() {


### PR DESCRIPTION
Currently, it's not possible to change popup properties after it was initialized. Extend showPopup allowing to change title, subtitle, buttons, cssClass after popup was displayed using original "options" object. Example:
````
var popupOptions = {
  title: 'Initial Title'
};
$ionicPopup.show(popupOptions);
popupOptions.title = 'New Title';
````
Change doesn't affect built in 'alert', 'prompt' and 'config' functions.