### PR TITLE
Folder name is different in doc from the original folder name in js/angular-ui/

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ If you'd rather do everything by hand, you can grab all the files for Ionic belo
 
 Once you have a release, use `js/ionic.js`, `js/ionic-angular.js`, and `css/ionic.css`.
 
-For most cases, you'll need AngularJS as well.  This is bundled in `js/angular/` and `js/angular-ui-router/`.
+For most cases, you'll need AngularJS as well.  This is bundled in `js/angular/` and `js/angular-ui/`.
 
 ## Platform Support
 


### PR DESCRIPTION
Folder name is different in doc from the original folder name in 

change **js/angular-ui-router/**  to  **js/angular-ui/**

Thanks