### PR TITLE
Fix CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -213,15 +213,15 @@ Was:
 Now:
 
 ```html
-<ion-input>
+<ion-item>
   <ion-label fixed>Username</ion-label>
   <ion-input></ion-input>
-</ion-input>
+</ion-item>
 
-<ion-input>
+<ion-item>
   <ion-label floating>Email</ion-label>
   <ion-input type="email"></ion-input>
-</ion-input>
+</ion-item>
 ```
 ### misc
 


### PR DESCRIPTION
"Inputs are now placed inside of `ion-item`"