### PR TITLE
Fix ion-spinner (android) stopping when another instance is removed

### DIFF
--- a/js/angular/controller/spinnerController.js
+++ b/js/angular/controller/spinnerController.js
@@ -330,7 +330,8 @@
   var animations = {
 
     android: function(ele) {
-      var self = this;
+      // Note that this is called as a function, not a constructor.
+      var self = {};
 
       this.stop = false;
 


### PR DESCRIPTION
When there are multiple instances of `<ion-spinner icon="android"></ion-spinner>`, and one of them is removed from the DOM, all others stop animating.

The issue is that the animation function uses `this` in a function that is not called as a constructor, which is therefore shared over all instances of the animation. This results in all of them stopping when `anim.stop = true` is called.

This change creates a new object as the state for each instance of the animation, instead of sharing the state.

Existing issues:
https://github.com/driftyco/ionic/issues/5156
https://github.com/driftyco/ionic/issues/4819
https://github.com/driftyco/ionic/pull/4827 (does not seem to solve the underlying issue)

Codepen demonstrating the issue: http://codepen.io/dennishn/pen/OMNybR (from #4819)

Affects at least Ionic 1.2.x.
