### PR TITLE
add an option to create alert which cannot be dismissed by clicking backdrop

### DIFF
--- a/ionic/components/alert/alert.ts
+++ b/ionic/components/alert/alert.ts
@@ -114,7 +114,7 @@ import {ViewController} from '../nav/view-controller';
  * }
  * ```
  *
- * @demo /docs/v2/demos/alert/ 
+ * @demo /docs/v2/demos/alert/
  */
 export class Alert extends ViewController {
 
@@ -132,7 +132,8 @@ export class Alert extends ViewController {
       checked?: boolean,
       id?: string
     }>,
-    buttons?: Array<any>
+    buttons?: Array<any>,
+    disableClickBackdropToDismiss?: boolean
   } = {}) {
     opts.inputs = opts.inputs || [];
     opts.buttons = opts.buttons || [];
@@ -225,7 +226,8 @@ export class Alert extends ViewController {
       checked?: boolean,
       id?: string
     }>,
-    buttons?: Array<any>
+    buttons?: Array<any>,
+    disableClickBackdropToDismiss?: boolean
   } = {}) {
     return new Alert(opts);
   }
@@ -430,12 +432,14 @@ class AlertCmp {
   }
 
   bdClick() {
-    let cancelBtn = this.d.buttons.find(b => b.role === 'cancel');
-    if (cancelBtn) {
-      this.btnClick(cancelBtn, 1);
+    if (!this.d.disableClickBackdropToDismiss) {
+      let cancelBtn = this.d.buttons.find(b => b.role === 'cancel');
+      if (cancelBtn) {
+        this.btnClick(cancelBtn, 1);
 
-    } else {
-      this.dismiss('backdrop');
+      } else {
+        this.dismiss('backdrop');
+      }
     }
   }
 

--- a/ionic/components/alert/test/basic/index.ts
+++ b/ionic/components/alert/test/basic/index.ts
@@ -237,6 +237,23 @@ class E2EPage {
     }, 100);
   }
 
+  doDisabledBackdropAlert() {
+    let alert = Alert.create({
+      disableClickBackdropToDismiss: true
+    });
+    alert.setTitle('Disabled Backdrop Click'),
+    alert.setSubTitle('Subtitle'),
+    alert.setMessage('This is an alert message.'),
+    alert.addButton({
+      text: 'Cancel',
+      role: 'cancel',
+      handler: () => {
+        console.log('Confirm Cancel');
+      }
+    });
+
+    this.nav.present(alert);
+  }
 }
 
 

--- a/ionic/components/alert/test/basic/main.html
+++ b/ionic/components/alert/test/basic/main.html
@@ -12,6 +12,7 @@
   <button block class="e2eOpenRadio" (click)="doRadio()">Radio</button>
   <button block class="e2eOpenCheckbox" (click)="doCheckbox()">Checkbox</button>
   <button block class="e2eFastClose" (click)="doFastClose()">Fast Close</button>
+  <button block class="e2eDisabledBackdrop" (click)="doDisabledBackdropAlert()">Disabled Backdrop Click</button>
 
   <pre>
     Confirm Opened: {{testConfirmOpen}}


### PR DESCRIPTION
the option name is disableClickBackdropToDismiss

this is the sample usage:

    let alert = Alert.create({
      disableClickBackdropToDismiss: true
    });
    alert.setTitle('Disabled Backdrop Click'),
    alert.setSubTitle('Subtitle'),
    alert.setMessage('This is an alert message.'),
    alert.addButton({
      text: 'Cancel',
      role: 'cancel',
      handler: () => {
        console.log('Confirm Cancel');
      }
    });

    this.nav.present(alert);