### PR TITLE
feat(ion-item-sliding): style icons on top of text in an option button

### DIFF
--- a/ionic/components/button/button.scss
+++ b/ionic/components/button/button.scss
@@ -29,7 +29,7 @@ $button-round-border-radius:      64px !default;
   @include appearance(none);
 }
 
-span.button-inner {
+.button-inner {
     width: 100%;
     height: 100%;
     display: flex;

--- a/ionic/components/item/item-sliding.scss
+++ b/ionic/components/item/item-sliding.scss
@@ -32,8 +32,22 @@ ion-item-options .button {
   height: 100%;
 }
 
-ion-item-sliding.active-slide {
+ion-item-sliding:not([horizontal]) {
+  .button.button-icon-left {
+    font-size: 14px;
 
+    .button-inner {
+      flex-direction: column;
+    }
+    ion-icon {
+      padding-left: 0 !important;
+      padding-right: 0 !important;
+      padding-bottom: 0.3em;
+    }
+  }
+}
+
+ion-item-sliding.active-slide {
 
   .item,
   .item.activated {

--- a/ionic/components/item/item-sliding.scss
+++ b/ionic/components/item/item-sliding.scss
@@ -32,7 +32,7 @@ ion-item-options .button {
   height: 100%;
 }
 
-ion-item-options:not([icon-left]) > .button-icon-left  {
+ion-item-options:not([icon-left]) .button-icon-left {
   font-size: 14px;
 
   .button-inner {

--- a/ionic/components/item/item-sliding.scss
+++ b/ionic/components/item/item-sliding.scss
@@ -32,18 +32,16 @@ ion-item-options .button {
   height: 100%;
 }
 
-ion-item-sliding:not([horizontal]) {
-  .button.button-icon-left {
-    font-size: 14px;
+ion-item-options:not([icon-left]) > .button-icon-left  {
+  font-size: 14px;
 
-    .button-inner {
-      flex-direction: column;
-    }
-    ion-icon {
-      padding-left: 0 !important;
-      padding-right: 0 !important;
-      padding-bottom: 0.3em;
-    }
+  .button-inner {
+    flex-direction: column;
+  }
+  ion-icon {
+    padding-left: 0 !important;
+    padding-right: 0 !important;
+    padding-bottom: 0.3em;
   }
 }
 

--- a/ionic/components/item/test/sliding/main.html
+++ b/ionic/components/item/test/sliding/main.html
@@ -31,7 +31,9 @@
       </ion-item>
       <ion-item-options>
         <button primary (click)="archive(item)">Archive</button>
-        <button danger (click)="del(item)"><ion-icon name="trash"></ion-icon></button>
+        <button danger (click)="del(item)">
+          <ion-icon name="trash"></ion-icon>
+        </button>
       </ion-item-options>
     </ion-item-sliding>
 
@@ -48,13 +50,15 @@
       </ion-item-options>
     </ion-item-sliding>
 
-    <ion-item-sliding #item>
+    <ion-item-sliding #item horizontal>
       <ion-item>
         <ion-icon name="mail" item-left></ion-icon>
         One Line w/ Icon, div only text
       </ion-item>
       <ion-item-options>
-        <button primary (click)="archive(item)">Archive</button>
+        <button primary (click)="archive(item)">
+          <ion-icon name="archive"></ion-icon>Archive
+        </button>
       </ion-item-options>
     </ion-item-sliding>
 
@@ -66,7 +70,16 @@
         One Line w/ Avatar, div only text
       </ion-item>
       <ion-item-options>
-        <button primary (click)="archive(item)">Archive</button>
+        <button primary>
+          <ion-icon name="more"></ion-icon>More
+        </button>
+        <button secondary (click)="archive(item)">
+          <ion-icon name="archive"></ion-icon>Archive
+        </button>
+        <button danger (click)="del(item)">
+          <ion-icon name="trash"></ion-icon>Delete
+        </button>
+
       </ion-item-options>
     </ion-item-sliding>
 

--- a/ionic/components/item/test/sliding/main.html
+++ b/ionic/components/item/test/sliding/main.html
@@ -50,12 +50,12 @@
       </ion-item-options>
     </ion-item-sliding>
 
-    <ion-item-sliding #item horizontal>
+    <ion-item-sliding #item>
       <ion-item>
         <ion-icon name="mail" item-left></ion-icon>
         One Line w/ Icon, div only text
       </ion-item>
-      <ion-item-options>
+      <ion-item-options icon-left>
         <button primary (click)="archive(item)">
           <ion-icon name="archive"></ion-icon>Archive
         </button>


### PR DESCRIPTION
closes #5352 

This is the magic css:

```css
ion-item-sliding:not([horizontal]) {
  .button.button-icon-left {
    font-size: 14px;
    
    .button-inner {
      flex-direction: column;
    }
    ion-icon {
      padding-left: 0 !important;
      padding-right: 0 !important;
      padding-bottom: 0.3em;
    }
  }
}
```

It is very complete and "intelligent":
- If ion-item-sliding has a "horizontal" attribute, we displaying the options horizontally (like it is done currently)
- If button does not have an icon, it doesn't apply the vertical alignment.
- If button only has only an icon, it doesn't apply the vertical alignment.  


![feb 08 2016 00 29](https://cloud.githubusercontent.com/assets/127379/12876149/13f9d710-cdfb-11e5-9d2f-928fee95b74d.gif)
