### PR TITLE
Fixed a bug caused by requestAnimationFrame did not run on the correct context

### DIFF
--- a/ionic/util/dom.ts
+++ b/ionic/util/dom.ts
@@ -5,7 +5,7 @@ let docEle: any = doc.documentElement;
 
 // requestAnimationFrame is polyfilled for old Android
 // within the web-animations polyfill
-export const raf = win.requestAnimationFrame;
+export const raf = win.requestAnimationFrame.bind(win);
 
 export function rafFrames(framesToWait, callback) {
   framesToWait = Math.ceil(framesToWait);


### PR DESCRIPTION
If requestAnimationFrame does not run within the `window` context, it causes `TypeError: Illegal invocation` every time that Ionic tries to use it. 
The change I made binds the `requestAnimationFrame` to the `window` so it will always runs from the correct context. 

Noticed it while trying to run Ionic 2 with Meteor 1.3-beta - for some reason (which I did not found yet..), `requestAnimationFrame` runs from another context instead of `window`. 