### PR TITLE
fix(nullRef): nullify reference to the destroyed slider

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -114,6 +114,7 @@ function($animate, $timeout, $compile) {
 
         $scope.$on('$destroy', function() {
           slider.destroy();
+          _this.__slider = null;
         });
       });
 


### PR DESCRIPTION
Hi ionic team.

I've got an issue today with `ionSlides`, using it in a `ui-view`. When leaving the view containing the slider, by loading another one into the `ui-view`, the `update` method of `ionSlides` was triggered and executed `_this.__slider.update()` in spite of the "falsy-check" just before. Indeed, the instance of the slider is kept even after the slider is destroyed (because of $scope `$destroy` event).

A simple PR to nullify the reference after the slider is destroyed.

In order for this piece of code to work properly:

      this.update = function() {
        $timeout(function() {
          if (!_this.__slider) {
            return;
          }
          
          // not called if the reference is properly nullified
          _this.__slider.update();
          [...]