### PR TITLE
fix(toolbar): fixes title aligment when cordova iOS style is applied

### DIFF
--- a/ionic/components/toolbar/toolbar.ios.scss
+++ b/ionic/components/toolbar/toolbar.ios.scss
@@ -17,7 +17,7 @@ $toolbar-order-ios: (
 );
 
 $toolbar-ios-padding:                       4px !default;
-$toolbar-ios-height:                        4.4rem !default;
+$toolbar-ios-height:                        44px !default;
 $toolbar-ios-button-font-size:              1.7rem !default;
 $toolbar-ios-title-font-size:               1.7rem !default;
 $navbar-ios-height:                         $toolbar-ios-height !default;

--- a/ionic/platform/cordova.ios.scss
+++ b/ionic/platform/cordova.ios.scss
@@ -3,7 +3,7 @@
 // iOS Cordova
 // --------------------------------------------------
 
-$cordova-ios-toolbar-padding:    2rem   !default;
+$cordova-ios-toolbar-padding:    20px   !default;
 
 
 &.platform-cordova.platform-ios {
@@ -15,7 +15,7 @@ $cordova-ios-toolbar-padding:    2rem   !default;
 
   ion-navbar ion-title,
   ion-navbar ion-segment, {
-    padding-top: $cordova-ios-toolbar-padding;
+    padding-top: $cordova-ios-toolbar-padding - $toolbar-ios-padding;
   }
 
   ion-navbar,


### PR DESCRIPTION
Before:
<img width="373" alt="screen shot 2016-02-10 at 18 06 52" src="https://cloud.githubusercontent.com/assets/127379/12956284/8f07a0b2-d027-11e5-8b20-0e285fd0c23e.png">

After:
<img width="392" alt="screen shot 2016-02-10 at 18 47 54" src="https://cloud.githubusercontent.com/assets/127379/12956286/95d6e74a-d027-11e5-8add-73524a0e3e3e.png">
<img width="378" alt="screen shot 2016-02-10 at 18 44 49" src="https://cloud.githubusercontent.com/assets/127379/12956305/a8b7f4c6-d027-11e5-9507-4591fdc92e2d.png">



closes #5208