### PR TITLE
fix(button): button goes transparent on hover on desktop (non-touch d…

### DIFF
--- a/ionic/components/button/button.md.scss
+++ b/ionic/components/button/button.md.scss
@@ -58,7 +58,7 @@ $button-md-small-icon-font-size:           1.4em !default;
               color $button-md-transition-duration $button-md-animation-curve;
 
   &:hover:not(.disable-hover) {
-    background-color: $button-md-clear-hover-background-color;
+    background-color: $button-md-color;
   }
 
   &.activated {
@@ -198,7 +198,7 @@ $button-md-small-icon-font-size:           1.4em !default;
   }
 
   &:hover:not(.disable-hover) {
-    color: $button-md-color;
+    background-color: $button-md-clear-hover-background-color;
   }
 
   ion-button-effect {


### PR DESCRIPTION
…evices)

This is what the hover state for a button looked like:
<img width="306" alt="screen shot 2016-02-10 at 3 56 56 pm" src="https://cloud.githubusercontent.com/assets/3433118/12966078/0d90b134-d010-11e5-9e77-f7d615773a8d.png">

You can see the button under when you navigate to another view and hover over the button because of the transparency:
<img width="308" alt="screen shot 2016-02-10 at 3 57 09 pm" src="https://cloud.githubusercontent.com/assets/3433118/12966077/0d89ec46-d010-11e5-821a-f96277a24437.png">


Plus it seemed weird having `$button-md-clear-hover-background-color` as the `background-color` for `.button` and not `.button-clear`