### PR TITLE
Corrected documented signature for remove() method

### DIFF
--- a/ionic/platform/storage/sql.ts
+++ b/ionic/platform/storage/sql.ts
@@ -186,7 +186,6 @@ export class SqlStorage extends StorageEngine {
   /**
   * Remove the value in the database for the given key.
   * @param {string} key the key
-  * @param {string} value The value (as a string)
   * @return {Promise} that resolves or rejects with an object of the form { tx: Transaction, res: Result (or err)}
   */
   remove(key: string): Promise<any> {


### PR DESCRIPTION
Documentation claimed the remove() method took two parameters: key and value, whereas in reality it only takes one: the key to be removed, as one would expect.