### PR TITLE
Update to decorators docs (bad link)

### DIFF
--- a/ionic/decorators/app.ts
+++ b/ionic/decorators/app.ts
@@ -26,7 +26,7 @@ const _reflect: any=Reflect;
 * }
 * ```
 *
-* @property {object} [config] - the app's {@link docs/v2/api/config/Config/ Config} object
+* @property {object} [config] - the app's {@link /docs/v2/api/config/Config/ Config} object
 * @property {array}  [providers] - any providers for your app
 * @property {string} [template] - the template to use for the app root
 * @property {string} [templateUrl] - a relative URL pointing to the template to use for the app root


### PR DESCRIPTION
the config link was relative to the page rather than the domain. I think the added '/' should fix that.