### PR TITLE
feat(generators): add Sass import reminder to page generator

### DIFF
--- a/tooling/generators/page/index.js
+++ b/tooling/generators/page/index.js
@@ -1,4 +1,5 @@
 var path = require('path'),
+    fs = require('fs'),
     Generator = require('../../generator');
 
 module.exports = PageGenerator;
@@ -10,5 +11,26 @@ function PageGenerator(options) {
 }
 
 PageGenerator.prototype = Object.create(Generator.prototype);
+
+Generator.prototype.renderTemplates = function renderTemplates() {
+  var templates = this.loadTemplates();
+  var scssPath = null;
+
+  templates.forEach(function(template) {
+    var renderedTemplate = this.renderTemplate(template);
+    var renderedTemplateDest = path.join(this.appDirectory, 'app', this.directory, this.fileName, this.fileName + template.extension);
+    if (template.extension === '.scss') {
+      scssName = this.fileName + template.extension;
+      scssPath = renderedTemplateDest;
+    }
+    console.log('√ Create'.blue, path.relative(this.appDirectory, renderedTemplateDest));
+    fs.writeFileSync(renderedTemplateDest, renderedTemplate);
+  }, this);
+
+  console.log(('\nDon\'t forget to add an import for ' + scssName + ' ' + 'in ' +
+               path.join('app', 'themes', 'app.core.scss') + ':\n\n  @import ' +
+               path.relative(path.join(this.appDirectory, 'app', 'themes'), scssPath) +
+               '\n').green);
+}
 
 


### PR DESCRIPTION
Addresses https://github.com/driftyco/ionic/issues/5467
 https://github.com/driftyco/ionic-cli/issues/773.

Adds the message: 
```
conference$ ionic g page test
√ Create app/pages/test/test.html
√ Create app/pages/test/test.js
√ Create app/pages/test/test.scss

Don't forget to add an import for test.scss in app/themes/app.core.scss:

  @import ../pages/test/test.scss

```

Yes, we're assuming that app/themes/app.core.scss is where their styles are located, but I think it's fair to assume conventions when using generators.

@leonsas @adamdbradley look ok?