### PR TITLE
Correctly remove slides

### DIFF
--- a/js/angular/directive/slides.js
+++ b/js/angular/directive/slides.js
@@ -95,6 +95,10 @@ function($animate, $timeout, $compile) {
         return _this.__slider;
       };
 
+      this.removeSlide = function(slideIdx) {
+        _this.__slider.removeSlide(slideIdx);
+      };
+
       var options = $scope.options || {};
 
       var newOptions = angular.extend({
@@ -139,7 +143,7 @@ function($animate, $timeout, $compile) {
       ionSlidesCtrl.rapidUpdate();
 
       $scope.$on('$destroy', function() {
-        ionSlidesCtrl.rapidUpdate();
+        ionSlidesCtrl.removeSlide($element.data('swiper-slide-index'));
       });
     }
   };


### PR DESCRIPTION
When a slide is removed by angular, typically using ngIf, it needs to be properly removed from swiper. This is particularly true when the loop option is set to true: the slide being removed  might have a duplicate that need to be removed also. The current implementation does not do that.