### PR TITLE
Fix on safari the height of bar-header is more

### DIFF
--- a/scss/_platform.scss
+++ b/scss/_platform.scss
@@ -9,7 +9,7 @@
   // iOS has a status bar which sits on top of the header.
   // Bump down everything to make room for it. However, if
   // if its in Cordova, and set to fullscreen, then disregard the bump.
-  &:not(.fullscreen) {
+  &:not(.fullscreen):not(.platform-browser) {
     .bar-header:not(.bar-subheader) {
       height: $bar-height + $ios-statusbar-height;
 


### PR DESCRIPTION
#### Short description of what this resolves:
On platform browser in safari the header has the same margin-top of platform iOS but here this content doesn't slide below the status bar.

#### Changes proposed in this pull request:

Reduce margin-top in iOS on platform-website


**Ionic Version**: 1.x / 2.x
