### PR TITLE
use integer version for SqlStorage

### DIFF
--- a/ionic/platform/storage/sql.ts
+++ b/ionic/platform/storage/sql.ts
@@ -63,7 +63,7 @@ export class SqlStorage extends StorageEngine {
     } else {
       console.warn('Storage: SQLite plugin not installed, falling back to WebSQL. Make sure to install cordova-sqlite-storage in production!');
 
-      this._db = win.openDatabase(dbOptions.name, '1.0', 'database', 5 * 1024 * 1024);
+      this._db = win.openDatabase(dbOptions.name, 1, 'database', 5 * 1024 * 1024);
     }
     this._tryInit();
   }


### PR DESCRIPTION
#### Short description of what this resolves:
Bad versioning type when creating SqlStorage in IndexedDB

#### Changes proposed in this pull request:

- use an integer instead of a string for database version

**Ionic Version**: 2.x

**Fixes**: [#5518](https://github.com/driftyco/ionic/issues/5518)

