### PR TITLE
added removePullToRefresh

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -1425,6 +1425,24 @@ ionic.views.Scroll = ionic.views.View.inherit({
     self.__refreshTailTime = 100;
     self.__minSpinTime = 600;
   },
+  
+  
+  /**
+   * Remove pull-to-refresh.
+   */
+  removePullToRefresh: function() {
+    var self = this;
+    
+    self.__refreshHeight = null;
+    self.__refreshActivate = null;
+    self.__refreshDeactivate = null;
+    self.__refreshStart = null;
+    self.__refreshShow = null;
+    self.__refreshHide = null;
+    self.__refreshTail = null;
+    self.__refreshTailTime = null;
+    self.__minSpinTime = null;
+  },
 
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
until now we were not able to remove the ionRefresher.

#### Changes proposed in this pull request:

- added this method removePullToRefresh() to remove the pullToRefresh

**Ionic Version**: 1.x

**Fixes**: #

we could remove the ionicRefresher with this method $ionicScrollDelegate.getScrollView().removePullToRefresh() and add ng-if in this control.