### PR TITLE
fix(Navigation): Using with Angular 2 Router, handler doesn't exists

### DIFF
--- a/ionic/components/nav/nav-router.ts
+++ b/ionic/components/nav/nav-router.ts
@@ -97,7 +97,9 @@ export class NavRouter extends RouterOutlet {
     rules.forEach((rule) => {
 
       pathRecognizer = rule.matchers.find((matcherPathRecognizer) => {
-        return (matcherPathRecognizer.handler.componentType === componentType);
+        if (matcherPathRecognizer.handler) {
+          return (matcherPathRecognizer.handler.componentType === componentType);
+        }
       });
 
     });


### PR DESCRIPTION
Can't seem to make nav work with Angular 2 Router. I am creating a cross-platform app and getting the following error. It seems handler becomes null when you are working with Angular 2 Router. Checking whether handler exists or not, seems to fix the problem.

```
EXCEPTION: TypeError: Cannot read property 'componentType' of undefined
```

and the function that does give the error: 

```
    value: function getPathRecognizerByComponent(componentType) {
    // given a componentType, figure out the best PathRecognizer to use
    var rules = this['_parentRouter'].registry._rules;
    var pathRecognizer = null;
    rules.forEach(function (rule) {
        pathRecognizer = rule.matchers.find(function (matcherPathRecognizer) {
            **return matcherPathRecognizer.handler**.componentType === componentType;
        });
    });
    return pathRecognizer;
}
```

It is fine when I comment out @RouteConfig. 

closes #5540 