### PR TITLE
(docs): close ion-input tag correctly

### DIFF
--- a/js/angular/directive/input.js
+++ b/js/angular/directive/input.js
@@ -12,7 +12,7 @@
 * <ion-list>
 *   <ion-input>
 *     <input type="text" placeholder="First Name">
-*   <ion-input>
+*   </ion-input>
 *
 *   <ion-input>
 *     <ion-label>Username</ion-label>


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes typo in `ion-input` closing tag.