### PR TITLE
fix(util): ignore empty query param in getQueryString

### DIFF
--- a/ionic/util/test/util.spec.ts
+++ b/ionic/util/test/util.spec.ts
@@ -3,6 +3,32 @@ import * as util from 'ionic-angular/util';
 export function run() {
   describe('extend', function() {
 
+    describe('getQuerystring', function() {
+      it('should have no entries for empty url', () => {
+        expect(util.getQuerystring('')).toEqual({});
+      });
+
+      it('should have no entries for url with no "?" character', () => {
+        expect(util.getQuerystring('http://localhost:1234/#key1=1&key2=2')).toEqual({});
+      });
+
+      it('should contain key/value entries for all the parameters after "?" character', () => {
+        expect(util.getQuerystring('http://localhost:1234/#key0=0&key0x=0x?key1=1&key2=2')).toEqual({
+          key1: '1',
+          key2: '2'
+        });
+      });
+
+      it('should ignore empty ?& and &&', () => {
+        expect(util.getQuerystring('http://localhost:1234/#?&&')).toEqual({});
+
+        expect(util.getQuerystring('http://localhost:1234/#?&&key1=1&key2=2&&')).toEqual({
+          key1: '1',
+          key2: '2'
+        });
+      });
+    });
+
     describe('isTrueProperty', function() {
 
       it('should be true from boolean true', () => {

--- a/ionic/util/util.ts
+++ b/ionic/util/util.ts
@@ -163,7 +163,7 @@ export function getQuerystring(url: string): any {
     const startIndex = url.indexOf('?');
     if (startIndex !== -1) {
       const queries = url.slice(startIndex + 1).split('&');
-      queries.forEach((param) => {
+      queries.filter((param) => { return param.indexOf('=') > 0; }).forEach((param) => {
         var split = param.split('=');
         queryParams[split[0].toLowerCase()] = split[1].split('#')[0];
       });


### PR DESCRIPTION
#### Short description of what this resolves:
ignores empty query param in getQueryString

#### Changes proposed in this pull request:

- filter out query params with no `=` character

**Ionic Version**: 2.x

**Fixes**: #5562

