### PR TITLE
docs(sqlStorage): string error in query example

### DIFF
--- a/ionic/platform/storage/sql.ts
+++ b/ionic/platform/storage/sql.ts
@@ -23,7 +23,7 @@ const win :any = window;
  * });
  *
  * // Sql storage also exposes the full engine underneath
- * storage.query('insert into projects(name, data) values('Cool Project', 'blah')');
+ * storage.query('insert into projects(name, data) values("Cool Project", "blah")');
  * storage.query('select * from projects').then((resp) => {})
  * ```
  *


### PR DESCRIPTION
#### Short description of what this resolves:

The v2 docs for SqlStorage, the sample isn't correct, this PR fix the string on the query example.

**Ionic Version**: 2.x

