### PR TITLE
adds selectable-text as a class. when added to an element containing …

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -361,7 +361,7 @@ function tapMouseDown(e) {
     //console.log('mousedown', 'stop event');
     e.stopPropagation();
 
-    if (!ionic.Platform.isEdge() && (!ionic.tap.isTextInput(e.target) || tapLastTouchTarget !== e.target) &&
+    if (!ionic.Platform.isEdge() && (e.hasClass('selectable-text') || !ionic.tap.isTextInput(e.target) || tapLastTouchTarget !== e.target) &&
       !isSelectOrOption(e.target.tagName) && !ionic.tap.isVideo(e.target)) {
       // If you preventDefault on a text input then you cannot move its text caret/cursor.
       // Allow through only the text input default. However, without preventDefault on an

--- a/scss/_util.scss
+++ b/scss/_util.scss
@@ -60,6 +60,10 @@
   -ms-content-zooming: none;
 }
 
+.selectable-text {
+  @include user-select(text!important);
+}
+
 // Fill the screen to block clicks (a better pointer-events: none) for the body
 // to avoid full-page reflows and paints which can cause flickers
 .click-block {


### PR DESCRIPTION
#### Short description of what this resolves:

There isn't an option outside of text inputs to allow text selection. This gives the developer the option to define selectable areas.

#### Changes proposed in this pull request:

- Allow text selection

**Ionic Version**: 1.x / 2.x

**Fixes**: #

…text, that text becomes selectable.