### PR TITLE
fix(searchbar): Hide cancle button for android

### DIFF
--- a/ionic/components/searchbar/searchbar.ts
+++ b/ionic/components/searchbar/searchbar.ts
@@ -39,7 +39,7 @@ export class SearchbarInput {
  *
  * @usage
  * ```html
- * <ion-searchbar [(ngModel)]="defaultSearch" (input)="triggerInput($event)" (cancel)="onCancelSearchbar($event)" (clear)="onClearSearchbar($event)"></ion-searchbar>
+ * <ion-searchbar [(ngModel)]="defaultSearch" (input)="triggerInput($event)" (cancel)="onCancelSearchbar($event)" (clear)="onClearSearchbar($event)" [hideCancelButton]="false"></ion-searchbar>
  * ```
  *
  * @demo /docs/v2/demos/searchbar/
@@ -49,7 +49,7 @@ export class SearchbarInput {
   selector: 'ion-searchbar',
   template:
     '<div class="searchbar-input-container">' +
-      '<button (click)="cancelSearchbar()" (mousedown)="cancelSearchbar()" clear dark class="searchbar-md-cancel">' +
+      '<button (click)="cancelSearchbar()" (mousedown)="cancelSearchbar()" [hidden]="hideCancelButton" clear dark class="searchbar-md-cancel">' +
         '<ion-icon name="arrow-back"></ion-icon>' +
       '</button>' +
       '<div class="searchbar-search-icon"></div>' +


### PR DESCRIPTION
#### Short description of what this resolves:
Search bar won't hide the cancel button for android.

#### Changes proposed in this pull request:
- Hide search-bar cancel button for android also
- Added `hideCancelButton` to example. 

**Ionic Version**: 2.x

**Fixes**: # Use `hideCancelButton` for Android as well 

Hide cancel button for android as well...
The example should help ng1 guys... I tried snake-case way too long.