### PR TITLE
Adapts the bower.json file to use its new ui-router package name

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -51,6 +51,6 @@
     "angular": "1.4.3",
     "angular-animate": "1.4.3",
     "angular-sanitize": "1.4.3",
-    "angular-ui-router": "0.2.13"
+    "ui-router": "0.2.13"
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
It is currently impossible to install ionic using bower because the angular-ui-router package has been renamed to just ui-router

#### Changes proposed in this pull request:
Instead of having angular-ui-router in the list of deps, I'm using ui-router.
-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

