### PR TITLE
Side menu with back views fix. New attribute enable-menu-swipe-with-b…

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -402,7 +402,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     var backView = $ionicHistory.backView();
 
     if (backView && (enableMenuWithBackViews || enableMenuSwipeWithBackViews) && self.content.element.offsetWidth > 45) {
-      dragIsWithinBounds = startX > 45 && startX < self.content.element.offsetWidth - 45;
+      dragIsWithinBounds = startX > 45 && self.content.element.offsetWidth - 45 > startX;
     } else {
       dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
         startX <= self.edgeThreshold ||

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -14,6 +14,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
   var rightShowing, leftShowing, isDragging;
   var startX, lastX, offsetX, isAsideExposed;
   var enableMenuWithBackViews = true;
+  var enableMenuSwipeWithBackViews = true;
 
   self.$scope = $scope;
 
@@ -294,6 +295,13 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     return enableMenuWithBackViews;
   };
 
+  self.enableMenuSwipeWithBackViews = function(val) {
+    if (arguments.length) {
+      enableMenuSwipeWithBackViews = !!val;
+    }
+    return enableMenuSwipeWithBackViews;
+  };
+
   self.isAsideExposed = function() {
     return !!isAsideExposed;
   };
@@ -389,12 +397,19 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     var startX = e.gesture.startEvent && e.gesture.startEvent.center &&
       e.gesture.startEvent.center.pageX;
 
-    var dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
-      startX <= self.edgeThreshold ||
-      startX >= self.content.element.offsetWidth - self.edgeThreshold;
+    var dragIsWithinBounds = false;
 
     var backView = $ionicHistory.backView();
-    var menuEnabled = enableMenuWithBackViews ? true : !backView;
+
+    if (backView && (enableMenuWithBackViews || enableMenuSwipeWithBackViews)) {
+      dragIsWithinBounds = startX > 45 && startX < self.content.element.offsetWidth - 45;
+    } else {
+      dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
+        startX <= self.edgeThreshold ||
+        startX >= self.content.element.offsetWidth - self.edgeThreshold
+    }
+
+    var menuEnabled = enableMenuWithBackViews || enableMenuSwipeWithBackViews ? true : !backView;
     if (!menuEnabled) {
       var currentView = $ionicHistory.currentView() || {};
       return (dragIsWithinBounds && (backView.historyId !== currentView.historyId));

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -401,8 +401,8 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
 
     var backView = $ionicHistory.backView();
 
-    if (backView && (enableMenuWithBackViews || enableMenuSwipeWithBackViews)) {
-      dragIsWithinBounds = startX > 45 && startX < self.content.element.offsetWidth - 45;
+    if (backView && (enableMenuWithBackViews || enableMenuSwipeWithBackViews) && self.content.element.offsetWidth > 45) {
+      dragIsWithinBounds = 45 < startX && startX < self.content.element.offsetWidth - 45;
     } else {
       dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
         startX <= self.edgeThreshold ||
@@ -418,7 +418,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     return ($scope.dragContent || self.isOpen()) &&
       dragIsWithinBounds &&
       !e.gesture.srcEvent.defaultPrevented &&
-      menuEnabled &&
+      //menuEnabled &&
       !e.target.tagName.match(/input|textarea|select|object|embed/i) &&
       !e.target.isContentEditable &&
       !(e.target.dataset ? e.target.dataset.preventScroll : e.target.getAttribute('data-prevent-scroll') == 'true');

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -402,7 +402,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     var backView = $ionicHistory.backView();
 
     if (backView && (enableMenuWithBackViews || enableMenuSwipeWithBackViews) && self.content.element.offsetWidth > 45) {
-      dragIsWithinBounds = 45 < startX && startX < self.content.element.offsetWidth - 45;
+      dragIsWithinBounds = startX > 45 && startX < self.content.element.offsetWidth - 45;
     } else {
       dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
         startX <= self.edgeThreshold ||

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -406,7 +406,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     } else {
       dragIsWithinBounds = !shouldOnlyAllowEdgeDrag ||
         startX <= self.edgeThreshold ||
-        startX >= self.content.element.offsetWidth - self.edgeThreshold
+        startX >= self.content.element.offsetWidth - self.edgeThreshold;
     }
 
     var menuEnabled = enableMenuWithBackViews || enableMenuSwipeWithBackViews ? true : !backView;

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -14,7 +14,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
   var rightShowing, leftShowing, isDragging;
   var startX, lastX, offsetX, isAsideExposed;
   var enableMenuWithBackViews = true;
-  var enableMenuSwipeWithBackViews = true;
+  var enableMenuSwipeWithBackViews = false;
 
   self.$scope = $scope;
 

--- a/js/angular/directive/sideMenus.js
+++ b/js/angular/directive/sideMenus.js
@@ -71,6 +71,9 @@ IonicModule
  * and the user cannot swipe to open the menu. When going back to the root page of the side menu (the
  * page without a back button visible), then any menuToggle buttons will show again, and menus will be
  * enabled again.
+ * @param {bool=} enable-menu-swipe-with-back-views Determines whether the side menu is enabled when the
+ * back button is showing. When set to `false`, the user cannot swipe to open the menu. When going back
+ * to the root page of the side menu (the page without a back button visible), menus will be enabled again.
  * @param {string=} delegate-handle The handle used to identify this side menu
  * with {@link ionic.service:$ionicSideMenuDelegate}.
  *
@@ -86,6 +89,7 @@ IonicModule
       function prelink($scope, $element, $attrs, ctrl) {
 
         ctrl.enableMenuWithBackViews($scope.$eval($attrs.enableMenuWithBackViews));
+        ctrl.enableMenuSwipeWithBackViews($scope.$eval($attrs.enableMenuSwipeWithBackViews));
 
         $scope.$on('$ionicExposeAside', function(evt, isAsideExposed) {
           if (!$scope.$exposeAside) $scope.$exposeAside = {};

--- a/test/unit/angular/directive/sideMenu.unit.js
+++ b/test/unit/angular/directive/sideMenu.unit.js
@@ -181,6 +181,11 @@ describe('Ionic Angular Side Menu', function() {
       gesture: {
         srcEvent: {
           defaultPrevented: false
+        },
+        startEvent: {
+          center: {
+            pageX: 50
+          }
         }
       },
       target: {


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes bug when user swipes from edge with "enable-menu-with-back-views" enabled.
Now if  "enable-menu-with-back-views" is enabled and has some back views, side menu will be opened only if it starts dragging from edge with 45px offset (in the middle of content).

Added new attribute "enable-menu-swipe-with-back-views" to "ion-side-menus" directive which enables just swipe to open menu and button is still hidden with back views.

**Ionic Version**: 1.x
