### PR TITLE
docs(content): fix ion-content scroll event listener example

### DIFF
--- a/ionic/components/content/content.ts
+++ b/ionic/components/content/content.ts
@@ -98,7 +98,7 @@ export class Content extends Ion {
    *   ngAfterViewInit() {
    *     // Here 'my-content' is the ID of my ion-content
    *     this.content = this.app.getComponent('my-content');
-   *     this.content.addScrollEventListener(this.myScroll);
+   *     this.content.addScrollListener(this.myScroll);
    *   }
    *     myScroll() {
    *      console.info('They see me scrolling...');


### PR DESCRIPTION
#### Short description of what this resolves:
A function was renamed in 91df5f97eef9ed1d261e6642c2d9ab7e8cc4063c and made this example outdated

**Ionic Version**: 2.x
