### PR TITLE
fix(radio-button): check for _group and _form before calling 'remove'

### DIFF
--- a/ionic/components/radio/radio-button.ts
+++ b/ionic/components/radio/radio-button.ts
@@ -151,7 +151,11 @@ export class RadioButton {
    * @private
    */
   ngOnDestroy() {
-    this._form.deregister(this);
-    this._group.remove(this);
+    if (this._form) {
+      this._form.deregister(this);
+    }
+    if (this._group) {
+      this._group.remove(this);
+    }
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
When exiting view with radio buttons the following error shows up in the console

```
Uncaught TypeError: Cannot read property 'remove' of null
```

<img width="483" alt="screen shot 2016-03-03 at 5 46 50 pm" src="https://cloud.githubusercontent.com/assets/3433118/13515640/f77d2c6a-e167-11e5-91d5-50ca82e9d10f.png">

#### Changes proposed in this pull request:

- check for `this._form` and `this._group` before destroying

**Ionic Version**: 2.x

