### PR TITLE
Typo on docs (v2)

### DIFF
--- a/ionic/util/keyboard.ts
+++ b/ionic/util/keyboard.ts
@@ -62,7 +62,7 @@ export class Keyboard {
  *  }
  *  closeCallback(){
  *     // call what ever functionality you want on keyboard close
- *     console.log('Closing time");
+ *     console.log('Closing time');
  *  }
  * }
  *


### PR DESCRIPTION
#### Short description of what this resolves:
 Just a typo :)

**Ionic Version**: 2

**Fixes**: none

Typo that break color highlight on the website