### PR TITLE
feat(select): using action sheet as an ion-select interface

### DIFF
--- a/ionic/components/action-sheet/action-sheet.ios.scss
+++ b/ionic/components/action-sheet/action-sheet.ios.scss
@@ -82,6 +82,11 @@ ion-action-sheet {
   }
 }
 
+.action-sheet-selected {
+  font-weight: bold;
+  background: white;
+}
+
 .action-sheet-destructive {
   color: $action-sheet-ios-button-destructive-text-color;
 }

--- a/ionic/components/action-sheet/action-sheet.md.scss
+++ b/ionic/components/action-sheet/action-sheet.md.scss
@@ -64,3 +64,7 @@ $action-sheet-md-icon-margin:                           0 28px 0 0 !default;
     margin-bottom: $action-sheet-md-group-margin-bottom;
   }
 }
+
+.action-sheet-selected {
+  font-weight: bold;
+}

--- a/ionic/components/action-sheet/action-sheet.ts
+++ b/ionic/components/action-sheet/action-sheet.ts
@@ -240,6 +240,8 @@ class ActionSheetCmp {
       } else {
         if (button.role === 'destructive') {
           button.cssClass = (button.cssClass + ' ' || '') + 'action-sheet-destructive';
+        } else if (button.role === 'selected') {
+          button.cssClass = (button.cssClass + ' ' || '') + 'action-sheet-selected';
         }
         buttons.push(button);
       }

--- a/ionic/components/action-sheet/action-sheet.wp.scss
+++ b/ionic/components/action-sheet/action-sheet.wp.scss
@@ -69,6 +69,10 @@ $action-sheet-wp-icon-margin:                     0 16px 0 0 !default;
   }
 }
 
+.action-sheet-selected {
+  font-weight: bold;
+}
+
 .action-sheet-cancel {
   background: $action-sheet-wp-button-background;
 }

--- a/ionic/components/select/test/single-value/index.ts
+++ b/ionic/components/select/test/single-value/index.ts
@@ -16,6 +16,7 @@ class E2EPage {
   month: string;
   year: string;
   years: Array<number>;
+  notification: string;
 
   constructor() {
     this.gaming = '';
@@ -23,6 +24,7 @@ class E2EPage {
     this.music = null;
     this.month = '12';
     this.year = '1994';
+    this.notification = "enable";
 
     this.years = [1989, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 1998, 1999];
 

--- a/ionic/components/select/test/single-value/main.html
+++ b/ionic/components/select/test/single-value/main.html
@@ -26,7 +26,7 @@
 
   <ion-item>
     <ion-label>Operating System</ion-label>
-    <ion-select [(ngModel)]="os" submitText="Okay" cancelText="Nah">
+    <ion-select [(ngModel)]="os" interface="alert" submitText="Okay" cancelText="Nah">
       <ion-option value="dos">DOS</ion-option>
       <ion-option value="lunix">Linux</ion-option>
       <ion-option value="mac7">Mac OS 7</ion-option>
@@ -34,6 +34,16 @@
       <ion-option value="win3.1">Windows 3.1</ion-option>
       <ion-option value="win95">Windows 95</ion-option>
       <ion-option value="win98">Windows 98</ion-option>
+    </ion-select>
+  </ion-item>
+
+  <ion-item>
+    <ion-label>Notifications</ion-label>
+    <ion-select [(ngModel)]="notification" interface="action-sheet" cancelText="Cancel!">
+      <ion-option value="enable">Enable</ion-option>
+      <ion-option value="mute">Mute</ion-option>
+      <ion-option value="mute_week">Mute for a week</ion-option>
+      <ion-option value="mute_year">Mute for a year</ion-option>
     </ion-select>
   </ion-item>
 
@@ -74,11 +84,16 @@
   <button (click)="resetGender()">Reset Gender</button>
 
   <p aria-hidden="true" padding>
-    <code>gender: {{gender}}</code><br>
-    <code>gaming: {{gaming}}</code><br>
-    <code>os: {{os}}</code><br>
-    <code>music: {{music}}</code><br>
-    <code>date: {{month}}/{{year}}</code><br>
+    <code>gender: {{gender}}</code>
+    <br>
+    <code>gaming: {{gaming}}</code>
+    <br>
+    <code>os: {{os}}</code>
+    <br>
+    <code>music: {{music}}</code>
+    <br>
+    <code>date: {{month}}/{{year}}</code>
+    <br>
   </p>
 
 </ion-content>


### PR DESCRIPTION
#### Short description of what this resolves:
![mar 09 2016 22 39](https://cloud.githubusercontent.com/assets/127379/13653442/1cf52698-e652-11e5-9a86-b5baa28ac1b9.gif)


#### Changes proposed in this pull request:
- Adds a new "selected" role to `action-sheet`
- Adds an "interface" attribute to `ion-select`
- Allows using a action-sheet as interface for a ion-select

**Ionic Version**: 2.x


