### PR TITLE
added method to reset _highestY

### DIFF
--- a/ionic/components/infinite-scroll/infinite-scroll.ts
+++ b/ionic/components/infinite-scroll/infinite-scroll.ts
@@ -220,6 +220,10 @@ export class InfiniteScroll {
     this._setListeners(shouldEnable);
   }
 
+  resetHighestY() {
+    this._highestY = 0;
+  }
+
   private _setListeners(shouldListen: boolean) {
     if (this._init) {
       if (shouldListen) {


### PR DESCRIPTION
#### Short description of what this resolves:

after the data of an already scrolled `ion-list` is reset, the value `_highestY` in [infinite-scroll.ts#L171](https://github.com/driftyco/ionic/blob/2.0/ionic/components/infinite-scroll/infinite-scroll.ts#L171) prevents infinite scrolling.

#### Changes proposed in this pull request:

- added method to reset _highestY on demand (e.g. after receiving new data)

**Ionic Version**: 2.x

**Fixes**: #5677

