### PR TITLE
fixes regression in my last refactor(Storage) PR.

### DIFF
--- a/ionic/platform/storage/sql.ts
+++ b/ionic/platform/storage/sql.ts
@@ -120,7 +120,7 @@ export class SqlStorage extends StorageEngine {
   get(key: string): Promise<any> {
     return this.query('select key, value from kv where key = ? limit 1', [key]).then(data => {
       if (data.res.rows.length > 0) {
-        return data.res.rows.item(0);
+        return data.res.rows.item(0).value;
       }
     });
   }


### PR DESCRIPTION
#### Short description of what this resolves:

StorageSql engine's get() method must not return the item but the value of the item.
@adamdbradley sorry about that :(

**Ionic Version**: 2.x