### PR TITLE
fix(action-sheet): action sheet button shortens when activated in Safari

### DIFF
--- a/ionic/components/action-sheet/action-sheet.ios.scss
+++ b/ionic/components/action-sheet/action-sheet.ios.scss
@@ -67,7 +67,7 @@ ion-action-sheet {
 
 .action-sheet-button {
   padding: $action-sheet-ios-button-padding;
-
+  margin: 0;
   min-height: $action-sheet-ios-button-min-height;
 
   border-bottom: $action-sheet-ios-button-border-width $action-sheet-ios-button-border-style $action-sheet-ios-border-color;


### PR DESCRIPTION
In safari the action-sheet buttons have a non-0 margin (not sure why). This PR normalizes how the buttons are rendered in safari and chrome.

It SHOULD NOT affect how the action-sheet looks in Chrome.

**Ionic Version**: 2.x

**Fixes**: #5828

