### PR TITLE
fix(Nav): fixes swipeBackEnabled as attribute

### DIFF
--- a/demos/events/main.html
+++ b/demos/events/main.html
@@ -24,4 +24,4 @@
 </ion-menu>
 
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/demos/id/main.html
+++ b/demos/id/main.html
@@ -31,4 +31,4 @@
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/demos/menu/main.html
+++ b/demos/menu/main.html
@@ -31,4 +31,4 @@
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/basic/main.html
+++ b/ionic/components/menu/test/basic/main.html
@@ -138,6 +138,6 @@
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
 
 <div [hidden]="isChangeDetecting()"></div>

--- a/ionic/components/menu/test/disable-swipe/main.html
+++ b/ionic/components/menu/test/disable-swipe/main.html
@@ -33,4 +33,4 @@
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/enable-disable/main.html
+++ b/ionic/components/menu/test/enable-disable/main.html
@@ -76,4 +76,4 @@
 </ion-menu>
 
 
-<ion-nav id="nav" [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/multiple/main.html
+++ b/ionic/components/menu/test/multiple/main.html
@@ -33,4 +33,4 @@
 </ion-menu>
 
 
-<ion-nav [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/overlay/main.html
+++ b/ionic/components/menu/test/overlay/main.html
@@ -37,4 +37,4 @@
 </ion-menu>
 
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/push/main.html
+++ b/ionic/components/menu/test/push/main.html
@@ -37,4 +37,4 @@
 </ion-menu>
 
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/menu/test/reveal/main.html
+++ b/ionic/components/menu/test/reveal/main.html
@@ -36,4 +36,4 @@
 
 </ion-menu>
 
-<ion-nav id="nav" [root]="rootView" #content swipe-back-enabled="false"></ion-nav>
+<ion-nav id="nav" [root]="rootView" #content swipeBackEnabled="false"></ion-nav>

--- a/ionic/components/nav/nav-controller.ts
+++ b/ionic/components/nav/nav-controller.ts
@@ -108,9 +108,9 @@ export class NavController extends Ion {
   private _init = false;
   private _trans: Transition;
   private _sbGesture: SwipeBackGesture;
-  private _sbEnabled: boolean;
   private _sbThreshold: number;
 
+  protected _sbEnabled: boolean;
   protected _ids: number = -1;
   protected _trnsDelay: any;
   protected _trnsTime: number = 0;
@@ -1288,7 +1288,7 @@ export class NavController extends Ion {
     let shouldResetZIndex = this._views.some(v => v.zIndex < 0);
     if (shouldResetZIndex) {
       this._views.forEach(view => {
-        view.setZIndex( view.zIndex + INIT_ZINDEX + 1, this._renderer );
+        view.setZIndex(view.zIndex + INIT_ZINDEX + 1, this._renderer);
       });
     }
   }
@@ -1401,7 +1401,7 @@ export class NavController extends Ion {
       // start the transition, fire callback when done...
       this._transition(enteringView, leavingView, opts, (hasCompleted: boolean) => {
         // swipe back has finished!!
-	      console.debug('swipeBack, hasCompleted', hasCompleted);
+        console.debug('swipeBack, hasCompleted', hasCompleted);
       });
     }
   }
@@ -1463,18 +1463,6 @@ export class NavController extends Ion {
         this._sbGesture.unlisten();
       }
     }
-  }
-
-  /**
-   * @input {boolean} Whether it's possible to swipe-to-go-back on this nav controller or not.
-   */
-  @Input()
-  get swipeBackEnabled(): boolean {
-    return this._sbEnabled;
-  }
-
-  set swipeBackEnabled(val: boolean) {
-    this._sbEnabled = isTrueProperty(val);
   }
 
   /**
@@ -1572,7 +1560,7 @@ export class NavController extends Ion {
    * @returns {viewController}
    */
   getPrevious(view: ViewController): ViewController {
-    return this.getByIndex( this.indexOf(view) - 1 );
+    return this.getByIndex(this.indexOf(view) - 1);
   }
 
   /**

--- a/ionic/components/nav/nav.ts
+++ b/ionic/components/nav/nav.ts
@@ -3,6 +3,7 @@ import {Component, ElementRef, Input, Optional, NgZone, Compiler, AppViewManager
 import {IonicApp} from '../app/app';
 import {Config} from '../../config/config';
 import {Keyboard} from '../../util/keyboard';
+import {isTrueProperty} from '../../util/util';
 import {NavController} from './nav-controller';
 import {ViewController} from './view-controller';
 
@@ -42,10 +43,10 @@ import {ViewController} from './view-controller';
  * Nav will automatically add a back button to it if there is a page
  * before the one you are navigating to in the navigation stack.
  *
- * Additionally, specifying the `swipe-back-enabled` property will allow you to
+ * Additionally, specifying the `swipeBackEnabled` property will allow you to
  * swipe to go back:
  * ```html
- * <ion-nav swipe-back-enabled="false" [root]="rootPage"></ion-nav>
+ * <ion-nav swipeBackEnabled="false" [root]="rootPage"></ion-nav>
  * ```
  *
  * Here is a diagram of how Nav animates smoothly between pages:
@@ -144,6 +145,18 @@ export class Nav extends NavController {
     if (this._hasInit) {
       this.setRoot(page);
     }
+  }
+
+  /**
+   * @input {boolean} Whether it's possible to swipe-to-go-back on this nav controller or not.
+   */
+  @Input()
+  get swipeBackEnabled(): boolean {
+    return this._sbEnabled;
+  }
+
+  set swipeBackEnabled(val: boolean) {
+    this._sbEnabled = isTrueProperty(val);
   }
 
   /**

--- a/ionic/components/nav/test/nested/index.ts
+++ b/ionic/components/nav/test/nested/index.ts
@@ -44,7 +44,7 @@ export class Login {
      </ion-content>
     </ion-menu>
 
-    <ion-nav id="account-nav" [root]="rootPage" #content swipe-back-enabled="false"></ion-nav>
+    <ion-nav id="account-nav" [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>
   `
 })
 export class Account {
@@ -135,7 +135,7 @@ export class Profile {
 
 
 @App({
-  template: `<ion-nav id="root-nav" [root]="rootPage" swipe-back-enabled="false"></ion-nav>`
+  template: `<ion-nav id="root-nav" [root]="rootPage" swipeBackEnabled="false"></ion-nav>`
 })
 class E2EApp {
   constructor() {


### PR DESCRIPTION
#### Short description of what this resolves:
`@Input()` has to be used in the angular component itself, not subclasses.

This PR also updates the documentation and demos.

**Ionic Version**: 2.x

**Fixes**: #5653

