### PR TITLE
fix(ion-infinite-scroll): Fix error leaving page

### DIFF
--- a/ionic/components/content/content.ts
+++ b/ionic/components/content/content.ts
@@ -162,6 +162,7 @@ export class Content extends Ion {
     this.scrollElement.addEventListener(type, handler);
 
     return () => {
+      if (!this.scrollElement) { return; }
       this.scrollElement.removeEventListener(type, handler);
     }
   }


### PR DESCRIPTION
#### Short description of what this resolves:
This PR fixes the js error TypeError: Cannot read property 'removeEventListener'
- Having ion-refresher / ion-infinite-scroll on a page
- Navigate to another page
- Come back

**Ionic Version**: 2.0

**Fixes**: #5760 