### PR TITLE
Add static get parameters() at provider's template generator.

### DIFF
--- a/tooling/generators/provider/provider.tmpl.js
+++ b/tooling/generators/provider/provider.tmpl.js
@@ -1,4 +1,4 @@
-import {Injectable, Inject} from 'angular2/core';
+import {Injectable} from 'angular2/core';
 import {Http} from 'angular2/http';
 
 /*
@@ -9,7 +9,11 @@ import {Http} from 'angular2/http';
 */
 @Injectable()
 export class <%= jsClassName %> {
-  constructor(@Inject(Http) http) {
+  static get parameters() {
+    return [[Http]];
+  }
+  
+  constructor(http) {
     this.http = http;
     this.data = null;
   }


### PR DESCRIPTION
#### Short description of what this resolves:
At the provider template generator, to use the new get parameters() syntax for passing to constructor parameters types. 

#### Changes proposed in this pull request:
- Provider template generator.

**Ionic Version**: 2.0beta

**Fixes**: #
When using 'ionic generate provider', a class with '@Inject' at the constructor was created, but compiler is waiting for the static get parameter() style of typing constructor parameters.

