### PR TITLE
lacks return-type annotation, implicitly has an 'any' return type

### DIFF
--- a/ionic/components/slides/swiper-widget.d.ts
+++ b/ionic/components/slides/swiper-widget.d.ts
@@ -4,9 +4,9 @@ export declare class Swiper {
   activeIndex: number;
   isEnd: boolean;
   isBeginning: boolean;
-  
-  update();
-  slideNext();
-  slidePrev();
-  
+
+  update():any;
+  slideNext():any;
+  slidePrev():any;
+
 }


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

Fix for tsc with 'noImplicitAny' option