### PR TITLE
Fixes for Provider Generator

### DIFF
--- a/tooling/generators/provider/provider.tmpl.js
+++ b/tooling/generators/provider/provider.tmpl.js
@@ -1,5 +1,6 @@
 import {Injectable} from 'angular2/core';
 import {Http} from 'angular2/http';
+import 'rxjs/add/operator/map';
 
 /*
   Generated class for the <%= jsClassName %> provider.

--- a/tooling/generators/provider/provider.tmpl.js
+++ b/tooling/generators/provider/provider.tmpl.js
@@ -1,4 +1,4 @@
-import {Injectable, Inject} from 'angular2/core';
+import {Injectable} from 'angular2/core';
 import {Http} from 'angular2/http';
 
 /*
@@ -9,7 +9,11 @@ import {Http} from 'angular2/http';
 */
 @Injectable()
 export class <%= jsClassName %> {
-  constructor(@Inject(Http) http) {
+  static get parameters(){
+    return [[Http]]
+  }  
+
+  constructor(http) {
     this.http = http;
     this.data = null;
   }


### PR DESCRIPTION
Fixes injection of Http service and error due to not importing map operation from rxjs.

Closes driftyco/ionic-cli#863
