### PR TITLE
feat(confg): create reference to global app injector 

### DIFF
--- a/ionic/components/app/app.ts
+++ b/ionic/components/app/app.ts
@@ -1,4 +1,4 @@
-import {Injectable, NgZone} from 'angular2/core';
+import {Injectable, Injector, NgZone} from 'angular2/core';
 import {Title} from 'angular2/platform/browser';
 
 import {Config} from '../../config/config';
@@ -18,6 +18,7 @@ export class IonicApp {
   private _title: string = '';
   private _titleSrv: Title = new Title();
   private _isProd: boolean = false;
+  private _appInjector: Injector;
 
   constructor(
     private _config: Config,
@@ -155,4 +156,19 @@ export class IonicApp {
     return this._cmps[id];
   }
 
+  /**
+   * Set the global app injector that contains references to all of the instantiated providers
+   * @param injector
+   */
+  setAppInjector(injector: Injector) {
+    this._appInjector = injector;
+  }
+
+  /**
+   * Get an instance of the global app injector that contains references to all of the instantiated providers
+   * @returns {Injector}
+   */
+  getAppInjector(): Injector {
+    return this._appInjector;
+  }
 }

--- a/ionic/decorators/app.ts
+++ b/ionic/decorators/app.ts
@@ -96,6 +96,7 @@ export function App(args: AppMetadata={}) {
     bootstrap(cls, providers).then(appRef => {
       appRef.injector.get(TapClick);
       let app: IonicApp = appRef.injector.get(IonicApp);
+      app.setAppInjector(appRef.injector);
       app.setProd(args.prodMode);
     });
 


### PR DESCRIPTION
Create a method to access the global app injector which contains references the bootstrapped providers

This feature simply sets a reference to the injector on the IonicApp class, so it can be referenced
by other components. This is sometimes necessary when injecting providers that depend on other
providers. This issue is discussed here
https://github.com/angular/angular/issues/4112#issuecomment-139381970, and Brandon Roberts' solution
of an appInjector() method has been used to solve a variety of dependency injection conflicts.
Unfortunately, it requires access to Angular's bootstrap() method, which Ionic handles in the @App
decorator. This fix will create a reference to the appInjector(), so it can be references from
within Ionic components.

closes #5973