### PR TITLE
segment.wp: display active style outside toolbar

### DIFF
--- a/ionic/components/segment/segment.wp.scss
+++ b/ionic/components/segment/segment.wp.scss
@@ -40,8 +40,7 @@ ion-segment {
   background-color: $segment-button-wp-background-color;
   opacity: $segment-button-wp-opacity;
   
-  .activated,
-  .segment-activated {
+  &.segment-activated {
     opacity: $segment-button-wp-opacity-activated;
   }
 

--- a/ionic/components/segment/segment.wp.scss
+++ b/ionic/components/segment/segment.wp.scss
@@ -39,6 +39,11 @@ ion-segment {
   color: $segment-button-wp-text-color-activated;
   background-color: $segment-button-wp-background-color;
   opacity: $segment-button-wp-opacity;
+  
+  .activated,
+  .segment-activated {
+    opacity: $segment-button-wp-opacity-activated;
+  }
 
   ion-icon {
     font-size: $segment-button-wp-icon-size;
@@ -51,12 +56,6 @@ ion-segment {
   ion-segment {
     margin: 0 auto;
   }
-
-  .segment-button.activated,
-  .segment-button.segment-activated {
-    opacity: $segment-button-wp-opacity-activated;
-  }
-
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Inconsistent styling in Windows Phone when an ion-segment is used outside of a toolbar

#### Changes proposed in this pull request:

- Let active-segment styles outside of a toolbar work on Windows Phone.  Matches behavior of iOS and Android

**Ionic Version**: 2.x

**Fixes**: #5994

In the iOS and Android styles the segment-activated class lives directly under segment-button.  However in the Windows Phone version these styles live only under toolbar, causing the styles to not be applied properly if the ion-segment is used outside of a toolbar.