### PR TITLE
Update modal.js

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -20,6 +20,8 @@
  * - This example assumes your modal is in your main index file or another template file. If it is in its own
  * template file, remove the script tags and call it by file name.
  *
+ * - Since version 1.7.7 you should not warap the template in a script tag. Reference: http://stackoverflow.com/questions/32552896/ionic-modal-not-showing#answer-33292269
+ * 
  * @usage
  * ```html
  * <script id="my-modal.html" type="text/ng-template">

--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -20,8 +20,9 @@
  * - This example assumes your modal is in your main index file or another template file. If it is in its own
  * template file, remove the script tags and call it by file name.
  *
- * - Since version 1.7.7 you should not warap the template in a script tag. Reference: http://stackoverflow.com/questions/32552896/ionic-modal-not-showing#answer-33292269
- * 
+ * - Since version 1.7.7 you should not warap the template in a script tag. Reference: 
+ * http://stackoverflow.com/questions/32552896/ionic-modal-not-showing#answer-33292269
+ *
  * @usage
  * ```html
  * <script id="my-modal.html" type="text/ng-template">


### PR DESCRIPTION
#### Short description of what this resolves:
Modal not visible, if modal HTML template is wrapped in a script tag.  

#### Changes proposed in this pull request:


Change the usage example by removing the script tag around the template HTML or at least - add a note, which states it needs to be removed since version 1.7.7

-
-
-

**Ionic Version**: 1.x / 2.x
1.7.7 +

**Fixes**: #

The usage example shows the HTML template wrapped into a script tag. It seems since version 1.7.7 this is not valid any more. If the modal HTML template is wrapped into a script tag, only the backdrop will be shown, but not the modal itself. I've spent few hours and found the correct answer here: http://stackoverflow.com/questions/32552896/ionic-modal-not-showing#answer-33292269