### PR TITLE
Typo in docs

### DIFF
--- a/ionic/util/events.ts
+++ b/ionic/util/events.ts
@@ -8,7 +8,7 @@
  * ```ts
  * import {Events} from 'ionic-angular';
  * 
- * constructor(public events: Event) {}
+ * constructor(public events: Events) {}
  * 
  * // first page (publish an event when a user is created)
  * function createUser(user) {


### PR DESCRIPTION
#### Short description of what this resolves:

Typo in docs
#### Changes proposed in this pull request:

- Add an 's'

**Ionic Version**: 1.x / 2.x

**Fixes**: #

The class name should be 'Events' instead of 'Event'