### PR TITLE
Clarify the purpose of the color attribute

### DIFF
--- a/ionic/components/button/button.ts
+++ b/ionic/components/button/button.ts
@@ -27,7 +27,7 @@ import {isTrueProperty} from '../../util/util';
   * @property [fab-center] - Position a fab button towards the center.
   * @property [fab-top] - Position a fab button towards the top.
   * @property [fab-bottom] - Position a fab button towards the bottom.
-  * @property [color] - Dynamically set which color attribute this button should use.
+  * @property [color] - Dynamically set which predefined color this button should use (e.g. default, secondary, danger, etc).
   *
   * @demo /docs/v2/demos/button/
   * @see {@link /docs/v2/components#buttons Button Component Docs}
@@ -142,7 +142,7 @@ export class Button {
   }
 
   /**
-   * @input {string} Dynamically set which color attribute this button should use.
+   * @input {string} Dynamically set which predefined color this button should use (e.g. default, secondary, danger, etc).
    */
   @Input()
   set color(val: string) {


### PR DESCRIPTION
#### Short description of what this resolves:
Clarifies that the `color` attribute is meant to be used only with predefined colors.

#### Changes proposed in this pull request:

- Update the docs for the button's color attribute.

**Ionic Version**: 2.x

**Fixes**: #

It's not clear that the `color` attribute is meant to be used only with the predefined colors _(i.e. the ones from the `$colors` list in `app.variables.scss`)_. The users expect that the attribute can also be used with color values like `red` or `#FF0000` which is not supported. More details are available in [this forum post](https://forum.ionicframework.com/t/changing-button-color-or-icon-dynamically/37675/19).