### PR TITLE
fix(checkbox): add 'type="button"' to <button> tag

### DIFF
--- a/ionic/components/checkbox/checkbox.ts
+++ b/ionic/components/checkbox/checkbox.ts
@@ -54,6 +54,7 @@ const CHECKBOX_VALUE_ACCESSOR = new Provider(
       '<div class="checkbox-inner"></div>' +
     '</div>' +
     '<button role="checkbox" ' +
+            'type="button" ' +
             '[id]="id" ' +
             '[attr.aria-checked]="_checked" ' +
             '[attr.aria-labelledby]="_labelId" ' +


### PR DESCRIPTION
#### Short description of what this resolves:

Enables forms with ion-checkboxes to be submitted as normal forms (i.e. with the enter key)

**Ionic Version**: 2.x

Add attribute 'type="button"' to <button> tag. The missing attribute caused forms with

ion-checkboxes to not be submitted as a normal form