### PR TITLE
Prevent the toggle from submitting the form

### DIFF
--- a/ionic/components/toggle/toggle.ts
+++ b/ionic/components/toggle/toggle.ts
@@ -56,7 +56,7 @@ const TOGGLE_VALUE_ACCESSOR = new Provider(
     '<div class="toggle-icon" [class.toggle-checked]="_checked" [class.toggle-activated]="_activated">' +
       '<div class="toggle-inner"></div>' +
     '</div>' +
-    '<button role="checkbox" ' +
+    '<button type="button" role="checkbox" ' +
             'type="button" ' +
             '[id]="id" ' +
             '[attr.aria-checked]="_checked" ' +


### PR DESCRIPTION
#### Short description of what this resolves:
Prevent the toggle from submitting the form which happens when a `<ion-toggle>` is placed inside a `<form>` because the type of its underlying `<button>` element defaults to `type="submit"`.

#### Changes proposed in this pull request:

- Adds `type="button"` to the button element to prevent it from submitting the containing form

**Ionic Version**: 2.x

**Fixes**: #6120

