### PR TITLE
Updated ion-input doc typo

### DIFF
--- a/ionic/components/input/input.ts
+++ b/ionic/components/input/input.ts
@@ -55,8 +55,8 @@ import {Platform} from '../../platform/platform';
  *    <ion-input type="tel"></ion-input>
  *  </ion-item>
  *
- *  <ion-item clearInput>
- *    <ion-input placeholder="Username"></ion-input>
+ *  <ion-item>
+ *    <ion-input placeholder="Username" clearInput></ion-input>
  *  </ion-item>
  * ```
  *


### PR DESCRIPTION
#### Short description of what this resolves:
clearInput doc example had a typo, this fixes that typo

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

clearInput property was on ion-item element instead of ion-input element in example