### PR TITLE
fix(modal): Don't show click-block-div unnecessarily on remove()

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -251,10 +251,24 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
      * @returns {promise} A promise which is resolved when the modal is finished animating out.
      */
     remove: function() {
-      var self = this;
+      var self = this,
+          deferred, promise;
       self.scope.$parent && self.scope.$parent.$broadcast(self.viewType + '.removed', self);
 
-      return self.hide().then(function() {
+      // Only hide modal, when it is actually shown!
+      // The hide function shows a click-block-div for a split second, because on iOS,
+      // clicks will sometimes bleed through/ghost click on underlying elements.
+      // However, this will make the app unresponsive for short amount of time.
+      // We don't want that, if the modal window is already hidden.
+      if (self._isShown) {
+        promise = self.hide();
+      } else {
+        deferred = $$q.defer();
+        deferred.resolve();
+        promise = deferred.promise;
+      }
+
+      return promise.then(function() {
         self.scope.$destroy();
         self.$el.remove();
       });


### PR DESCRIPTION
#### Short description of what this resolves:
Don't show click-block-div unnecessarily on remove().
See [this comment and the following ones](https://github.com/driftyco/ionic/issues/4383#issuecomment-209810320)

#### Changes proposed in this pull request:
It's just a small and reasonable change to `js/angular/service/modal.js`. 

**Ionic Version**: 1.x

**Fixes**: #4383

