### PR TITLE
Remove Ionicons Sass aliases

### DIFF
--- a/ionic/fonts/ionicons.scss
+++ b/ionic/fonts/ionicons.scss
@@ -6,8 +6,8 @@
 
 $ionicons-font-path: $font-path !default;
 
-@import "ionicons-icons";
-@import "ionicons-variables";
+@import "~ionicons/dist/scss/ionicons-icons";
+@import "~ionicons/dist/scss/ionicons-variables";
 
 
 @font-face {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes errors due to missing sass aliases:

```
Module build failed:
@import "ionicons-variables";
^
      File to import not found or unreadable: ionicons-variables
```

This:

```
@import "ionicons-icons";
@import "ionicons-variables";
```

cannot work without aliases defined in `ionic.config.js` or webpack or any tool you want to use to compile your Sass.

#### Changes proposed in this pull request:

- Change import from alias to direct path

**Ionic Version**: 2.x

**Fixes**: #5155