### PR TITLE
Bubble up the DOM until we find an activatable element or run out of parents

### DIFF
--- a/ionic/components/tap-click/tap-click.ts
+++ b/ionic/components/tap-click/tap-click.ts
@@ -182,11 +182,12 @@ export class TapClick {
 
 
 function getActivatableTarget(ele) {
-  let targetEle = ele;
-  for (let x = 0; x < 4; x++) {
-    if (!targetEle) break;
-    if (isActivatable(targetEle)) return targetEle;
-    targetEle = targetEle.parentElement;
+  if (isActivatable(ele)) {
+    return ele;
+  }
+  let parentEle = ele.parentElement;
+  if (parentEle) {
+    return getActivatableTarget(parentEle);
   }
   return null;
 }


### PR DESCRIPTION
ion-list doesn't get class 'activated' on mousedown when ion-item contains html elements. This pull request fixes it by bubbling up the DOM until we find an activatable element or run out of parents.

**Fixes**: #6192 