### PR TITLE
fix(button): buttons don't get activated when ion-label contains some elements

### DIFF
--- a/ionic/components/app/normalize.scss
+++ b/ionic/components/app/normalize.scss
@@ -151,6 +151,11 @@ textarea {
   touch-action: manipulation;
 }
 
+button ion-label,
+a ion-label {
+    pointer-events: none;
+}
+
 button {
   border: 0;
   font-family: inherit;

--- a/ionic/components/item/test/buttons/main.html
+++ b/ionic/components/item/test/buttons/main.html
@@ -88,8 +88,18 @@
     <button outline item-right (click)="testClick($event)">View</button>
   </ion-item>
 
-  <button ion-item *ngFor="#data of [0,1,2,3,4]; #i = index" [class.activated]="i == 1">
+  <button ion-item *ngFor="#data of [0,1,2,3,4]; #i = index" [class.activated]="i == 1" (click)="testClick($event)">
+    <ion-avatar item-left>
+        <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAAAAACH5BAAAAAAALAAAAAABAAEAAAICTAEAOw==">
+    </ion-avatar>
     <h3>ng-for {{i}}</h3>
+    <ion-badge item-right>260k</ion-badge>
   </button>
 
 </ion-content>
+
+<style>
+  img {
+    height: 100px;
+  }
+</style>


### PR DESCRIPTION
#### Short description of what this resolves:

If a button contains `<p>`, `<h1>` or any exotic element, the button is not properly activated if the user taps under such elements. This feels very unresponsive and laggy.

I am not sure making `<ion-label>` pointer-events: none is the correct solution, but this bug is real and it should be fixed somehow.


**Ionic Version**: 2.x


