### PR TITLE
Removed redundant this.nav declaration

### DIFF
--- a/tooling/generators/page/page.tmpl.ts
+++ b/tooling/generators/page/page.tmpl.ts
@@ -10,7 +10,5 @@ import {Page, NavController} from 'ionic-angular';
   templateUrl: 'build/<%= directory %>/<%= fileName %>/<%= fileName %>.html',
 })
 export class <%= jsClassName %> {
-  constructor(public nav: NavController) {
-    this.nav = nav;
-  }
+  constructor(public nav: NavController) {}
 }


### PR DESCRIPTION
#### Short description of what this resolves:

`nav` variable declaration redundancy

#### Changes proposed in this pull request:

`this.nav = nav` is already present due to the `public nav: NavController` declaration, having it in the constructor as well is redundant

**Ionic Version**: 2.0

**Fixes**: #