### PR TITLE
Updated the API-docs for platform.versions().

### DIFF
--- a/ionic/platform/platform.ts
+++ b/ionic/platform/platform.ts
@@ -152,9 +152,7 @@ export class Platform {
    * }
    * ```
    *
-   * @param {string} [platformName] optional platformName
-   * @returns {object} An object with various platform info
-   *
+   * @returns {object} An object containing all of the platforms and their versions.
    */
   versions(): {[name: string]: PlatformVersion} {
     // get all the platforms that have a valid parsed version


### PR DESCRIPTION
#### Short description of what this resolves:
Updates the outdated API-docs for `platform.versions()`.

#### Changes proposed in this pull request:

- Removed the `platformName` parameter from the API-docs for `platform.versions()`.
- Updated the information about the return value of `platform.versions()`.

**Ionic Version**: 2.x

**Fixes**: #

