### PR TITLE
chore(build): add validate task to gulp that will run linting tools a…

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "gulp-remember": "^0.3.0",
     "gulp-rename": "~1.2.0",
     "gulp-sass": "^2.0.4",
+    "gulp-scss-lint": "^0.3.9",
     "gulp-shell": "^0.4.0",
     "gulp-strip-debug": "^1.1.0",
     "gulp-tslint": "^4.3.4",


### PR DESCRIPTION
#### Short description of what this resolves:
Add validate task to gulp that will run linting tools and testing tools

#### Changes proposed in this pull request:
- create gulp validate task
- change typescript typechecking to end on error
- add scss linting task to gulp

**Ionic Version**: 2.x