### PR TITLE
docs(ionicons): move to top level

### DIFF
--- a/ionic/components/icon/icon.ts
+++ b/ionic/components/icon/icon.ts
@@ -8,7 +8,7 @@ import {Config} from '../../config/config';
  * @description
  * Icons can be used on their own, or inside of a number of Ionic components.
  * For a full list of available icons, check out the
- * [Ionicons resource docs](../../../../resources/ionicons).
+ * [Ionicons docs](../../../../ionicons).
  *
  * One feature of Ionicons in Ionic is when icon names are set, the actual icon
  * which is rendered can change slightly depending on the mode the app is


### PR DESCRIPTION
#### Short description of what this resolves:
Updates the link to the Ionicons _(according to commit: https://github.com/driftyco/ionic-site/commit/e75930d9324f4ab97d6e335ebca1ae009e60610d)_.

#### Changes proposed in this pull request:

- Update of the Ionicons link in the `ion-icon` docs.

**Ionic Version**: 2.x

**Fixes**: #
