### PR TITLE
Fix link to Refresher docs

### DIFF
--- a/ionic/components/content/content.ts
+++ b/ionic/components/content/content.ts
@@ -15,7 +15,7 @@ import {ScrollView} from '../../util/scroll-view';
  * some useful methods to control the scrollable area.
  *
  * The content area can also implement pull-to-refresh with the
- * [Refresher](../../scroll/Refresher) component.
+ * [Refresher](../../refresher/Refresher) component.
  *
  * @usage
  * ```html


### PR DESCRIPTION
Fixed the link to the Refresher component from the Content component.

**Ionic Version**: 2.x


