### PR TITLE
Update slides.ts

### DIFF
--- a/ionic/components/slides/slides.ts
+++ b/ionic/components/slides/slides.ts
@@ -44,7 +44,7 @@ import {Scroll} from '../scroll/scroll';
  * | direction             | `string`  | 'horizontal'   | Swipe direction: 'horizontal' or 'vertical'.                                               |
  * | initialSlide          | `number`  | 0              | Index number of initial slide                                                              |
  * | loop                  | `boolean` | false          | Whether to continuously loop from the last slide to the first slide.                       |
- * | pager                 | `boolean` | false          | Show the pagination bullets.                                                               |
+ * | pagination            | `boolean` | true           | Show the pagination bullets.                                                               |
  * | speed                 | `number`  | 300            | Duration of transition between slides (in ms).                                             |
  *
  * See [Usage](#usage) below for more information on configuring slides.


### PR DESCRIPTION
#### Short description of what this resolves:

In the documentation is shows pager as property for options but that is no longer the case from my understanding it is pagination and is set to true as a default.

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

From what I found out is that pager no longer is the property but pagination is and it is set to true by default in the options.