### PR TITLE
Update component.ts template to declare "text" variable before using it

### DIFF
--- a/tooling/generators/component/component.tmpl.ts
+++ b/tooling/generators/component/component.tmpl.ts
@@ -11,6 +11,8 @@ import {Component} from 'angular2/core';
   templateUrl: 'build/<%= directory %>/<%= fileName %>/<%= fileName %>.html'
 })
 export class <%= jsClassName %> {
+  public text: string;
+  
   constructor() {
     this.text = 'Hello World';
   }


### PR DESCRIPTION
#### Short description of what this resolves:

Declare `text` variable before using it in the constructor. Avoid TypeScript compiler warnings and in some cases failing if linter does not allow the use of undeclared variables

#### Changes proposed in this pull request:

- Declare `text` variable as public of type `string`


**Ionic Version**: 2.0