### PR TITLE
Update toolbar.ios.scss

### DIFF
--- a/ionic/components/toolbar/toolbar.ios.scss
+++ b/ionic/components/toolbar/toolbar.ios.scss
@@ -115,7 +115,6 @@ ion-title {
 // --------------------------------------------------
 
 ion-buttons {
-  flex: 1;
   order: map-get($toolbar-order-ios, buttons-start);
 
   transform: translateZ(0);


### PR DESCRIPTION
#### Short description of what this resolves:

Fix ion-buttons style for iOS previously occupied half the width.

#### Changes proposed in this pull request:

- Remove unnecessary flex attribute from scss

**Ionic Version**: 2.x
