### PR TITLE
Return Polyfill RAF When Native is Undefined

### DIFF
--- a/ionic/util/dom.ts
+++ b/ionic/util/dom.ts
@@ -25,7 +25,9 @@
 })();
 
 // use native raf rather than the zone wrapped one
-export const nativeRaf = (window[window['Zone']['__symbol__']('requestAnimationFrame')] || window[window['Zone']['__symbol__']('webkitRequestAnimationFrame')])['bind'](window);
+let originalRaf = (window[window['Zone']['__symbol__']('requestAnimationFrame')] || window[window['Zone']['__symbol__']('webkitRequestAnimationFrame')]);
+// if the originalRaf from the Zone symbol is not available, we need to provide the polyfilled version
+export const nativeRaf = originalRaf !== undefined ? originalRaf['bind'](window) : window.requestAnimationFrame.bind(window);
 
 // zone wrapped raf
 export const raf = window.requestAnimationFrame.bind(window);


### PR DESCRIPTION
#### Short description of what this resolves:
This will resolve issue  where unit tests bomb when ['bind'] is called on an undefined, non-polyfilled ```requestAnimationFrame``` function.

#### Changes proposed in this pull request:

- Return the polyfill version of RAF when the native version is not found

**Ionic Version**:  2.x

**Fixes**: #6417 6417

When in a headless environment RAF may not be defined so we need to return the polyfilled version rather than letting the undefined function be called.