### PR TITLE
fix(footer bar): fix a typo in footer bar styles using balanced class

### DIFF
--- a/scss/_bar.scss
+++ b/scss/_bar.scss
@@ -99,7 +99,7 @@
   &.bar-balanced {
     @include bar-style($bar-balanced-bg, $bar-balanced-border, $bar-balanced-text);
     &.bar-footer{
-      background-image: linear-gradient(180deg, $bar-balanced-border, $bar-positive-border 50%, transparent 50%);
+      background-image: linear-gradient(180deg, $bar-balanced-border, $bar-balanced-border 50%, transparent 50%);
     }
   }
   &.bar-energized {


### PR DESCRIPTION
#### Short description of what this resolves:

Just fix the `background-image` color gradient of the `bar-footer` when used with `bar-balanced` class.

#### Changes proposed in this pull request:

No changes, just a typo fix.

**Ionic Version**: 1.3

**Fixes**: #6422 

