### PR TITLE
feat(radio-button) fix thrown error on dismiss solves #6466

### DIFF
--- a/ionic/components/radio/radio-button.ts
+++ b/ionic/components/radio/radio-button.ts
@@ -155,6 +155,8 @@ export class RadioButton {
    */
   ngOnDestroy() {
     this._form.deregister(this);
-    this._group.remove(this);
+    if (this._group) {
+      this._group.remove(this);
+    }
   }
 }

--- a/ionic/components/radio/test/radio.spec.ts
+++ b/ionic/components/radio/test/radio.spec.ts
@@ -86,30 +86,48 @@ export function run() {
       });
 
     });
+  });
 
-    let rg: RadioGroup;
-    let form: Form;
+  describe('RadioButton', () => {
 
-    function createRadioButton() {
-      return new RadioButton(form, null, rg);
-    }
+    describe('ngOnDestroy', () => {
+      it('should work without a group', () => {
+        let rb1 = createRadioButton(false);
+        expect(() => rb1.ngOnDestroy()).not.toThrowError();
+      });
 
-    function mockRenderer(): any {
-      return {
-        setElementAttribute: function(){}
-      }
-    }
+      it('should remove button from group if part of a radio group', () => {
+        let rb1 = createRadioButton();
+        spyOn(rg, 'remove');
+        rb1.ngOnDestroy();
+        expect(rg.remove).toHaveBeenCalledWith(rb1);
+      });
 
-    function mockElementRef(): any {
-      return {
-        nativeElement: document.createElement('div')
-      }
-    }
-
-    beforeEach(() => {
-      rg = new RadioGroup(mockRenderer(), mockElementRef());
-      form = new Form();
     });
 
+  });
+
+  let rg: RadioGroup;
+  let form: Form;
+
+  function createRadioButton(shouldIncludeGroup = true) {
+    return new RadioButton(form, null, shouldIncludeGroup? rg : null);
+  }
+
+  function mockRenderer(): any {
+    return {
+      setElementAttribute: function(){}
+    }
+  }
+
+  function mockElementRef(): any {
+    return {
+      nativeElement: document.createElement('div')
+    }
+  }
+
+  beforeEach(() => {
+    rg = new RadioGroup(mockRenderer(), mockElementRef());
+    form = new Form();
   });
 }


### PR DESCRIPTION
#### Short description of what this resolves:
- Radio Buttons throws errors on dismissal when it's not part of a radio group.

#### Changes proposed in this pull request:
- check if the button is part of a group before trying to remove.

**Ionic Version**: 2.0.0-beta.6

**Fixes**: https://github.com/driftyco/ionic/issues/6466

