### PR TITLE
closeItems() typo

### DIFF
--- a/ionic/components/list/list.ts
+++ b/ionic/components/list/list.ts
@@ -93,7 +93,7 @@ export class List extends Ion {
    * export class MyClass {
    *    @ViewChild(List) list: List;
    *    constructor(){}
-   *    closeItmes(){
+   *    closeItems(){
    *      this.list.closeSlidingItems();
    *    }
    * }


### PR DESCRIPTION
#### Short description of what this resolves:
Typo fix

#### Changes proposed in this pull request:
Changed closeItems() name

**Ionic Version**: 2.x

