### PR TITLE
Make button border style configurable

### DIFF
--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -93,8 +93,8 @@ $button-bar-button-height:        32px !default;
 $button-bar-button-padding:       8px !default;
 $button-bar-button-icon-size:     20px !default;
 
-$button-default-border:       transparent;
-$button-default-active-border:null;
+$button-default-border:           transparent !default;
+$button-default-active-border:    null !default;
 
 $button-light-bg:                 $light !default;
 $button-light-text:               #444 !default;


### PR DESCRIPTION
#### Short description of what this resolves:
Makes it possible to configure button style variables `$button-default-border` and `$button-default-active-border` from a user sass file. 
Just like all other ionic sass variables.

#### Changes proposed in this pull request:
added `!default` flag to `$button-default-border` and `$button-default-active-border`

**Ionic Version**: 1.3.1

**Related to**: #5576