### PR TITLE
fix(picker): number of dom children != number of options

### DIFF
--- a/ionic/components/picker/picker.ts
+++ b/ionic/components/picker/picker.ts
@@ -306,7 +306,7 @@ class PickerColumnCmp {
 
     } else if (this.y % this.optHeight !== 0) {
       // needs to still get locked into a position so options line up
-      var currentPos = Math.abs(this.y  % this.optHeight);
+      var currentPos = Math.abs(this.y % this.optHeight);
 
       // create a velocity in the direction it needs to scroll
       this.velocity = (currentPos > (this.optHeight / 2) ? 1 : -1);
@@ -343,8 +343,12 @@ class PickerColumnCmp {
     this.col.selectedIndex = Math.max(Math.abs(Math.round(y / this.optHeight)), 0);
 
     let colElements = this.colEle.nativeElement.querySelectorAll('.picker-opt');
-
-    for (var i = 0; i < this.col.options.length; i++) {
+    if (colElements.length != this.col.options.length) {
+      // TODO: it would be great to find the root of the problem
+      // and implement a good fix, but at least, this prevents an expection
+      console.error("colElements.length!=this.col.options.length");
+    }
+    for (var i = 0; i < colElements.length; i++) {
       var ele: HTMLElement = colElements[i];
       var opt = <any>this.col.options[i];
       var optTop = (i * this.optHeight);
@@ -370,7 +374,7 @@ class PickerColumnCmp {
       // TODO: setting by [style.transform]="o.transform" within the template is currently broke
       ele.style[CSS.transform] = `rotateX(${rotateX}deg) translate3d(${translateX}px,${translateY}px,${translateZ}px)`;
       ele.style[CSS.transitionDuration] = (duration > 0 ? duration + 'ms' : '');
-      ele.classList[this.col.selectedIndex===i ? 'add' : 'remove']('picker-opt-selected');
+      ele.classList[this.col.selectedIndex === i ? 'add' : 'remove']('picker-opt-selected');
       ele.classList[opt.disabled ? 'add' : 'remove']('picker-opt-disabled');
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Under certain circustances the number of DOM children is not the same than the number of options,
this causes an exception by access to undefined during iteration.

This issue can be reproduced randomly, dragging a picker column in order to give it some inertia and then closing the modal while the items are still moving.

```
platform-browser.umd.js:962 EXCEPTION: TypeError: Cannot read property 'style' of undefinedBrowserDomAdapter.logError @ platform-browser.umd.js:962BrowserDomAdapter.logGroup @ platform-browser.umd.js:972ExceptionHandler.call @ core.umd.js:3696(anonymous function) @ core.umd.js:8951schedulerFn @ core.umd.js:6007SafeSubscriber.__tryOrUnsub @ Rx.js:10855SafeSubscriber.next @ Rx.js:10810Subscriber._next @ Rx.js:10766Subscriber.next @ Rx.js:10743Subject._finalNext @ Rx.js:11425Subject._next @ Rx.js:11417Subject.next @ Rx.js:11376EventEmitter.emit @ core.umd.js:5996NgZone._zoneImpl.NgZoneImpl.onError @ core.umd.js:6227NgZoneImpl.inner.inner.fork.onHandleError @ core.umd.js:6096ZoneDelegate.handleError @ zone.js:327Zone.runTask @ zone.js:259ZoneTask.invoke @ zone.js:423
platform-browser.umd.js:962 STACKTRACE:BrowserDomAdapter.logError @ platform-browser.umd.js:962ExceptionHandler.call @ core.umd.js:3698(anonymous function) @ core.umd.js:8951schedulerFn @ core.umd.js:6007SafeSubscriber.__tryOrUnsub @ Rx.js:10855SafeSubscriber.next @ Rx.js:10810Subscriber._next @ Rx.js:10766Subscriber.next @ Rx.js:10743Subject._finalNext @ Rx.js:11425Subject._next @ Rx.js:11417Subject.next @ Rx.js:11376EventEmitter.emit @ core.umd.js:5996NgZone._zoneImpl.NgZoneImpl.onError @ core.umd.js:6227NgZoneImpl.inner.inner.fork.onHandleError @ core.umd.js:6096ZoneDelegate.handleError @ zone.js:327Zone.runTask @ zone.js:259ZoneTask.invoke @ zone.js:423
platform-browser.umd.js:962 TypeError: Cannot read property 'style' of undefined
    at PickerColumnCmp.update (ionic.system.js:21003)
    at PickerColumnCmp.decelerate (ionic.system.js:20943)
    at ZoneDelegate.invokeTask (zone.js:356)
    at Object.NgZoneImpl.inner.inner.fork.onInvokeTask (core.umd.js:6066)
    at ZoneDelegate.invokeTask (zone.js:355)
    at Zone.runTask (zone.js:256)
    at ZoneTask.invoke (zone.js:423)BrowserDomAdapter.logError @ platform-browser.umd.js:962ExceptionHandler.call @ core.umd.js:3699(anonymous function) @ core.umd.js:8951schedulerFn @ core.umd.js:6007SafeSubscriber.__tryOrUnsub @ Rx.js:10855SafeSubscriber.next @ Rx.js:10810Subscriber._next @ Rx.js:10766Subscriber.next @ Rx.js:10743Subject._finalNext @ Rx.js:11425Subject._next @ Rx.js:11417Subject.next @ Rx.js:11376EventEmitter.emit @ core.umd.js:5996NgZone._zoneImpl.NgZoneImpl.onError @ core.umd.js:6227NgZoneImpl.inner.inner.fork.onHandleError @ core.umd.js:6096ZoneDelegate.handleError @ zone.js:327Zone.runTask @ zone.js:259ZoneTask.invoke @ zone.js:423
Rx.js:10858 Uncaught TypeError: Cannot read property 'style' of undefined
```

**Ionic Version**: 2.x