### PR TITLE
feat(toast): disableBackdrop option

### DIFF
--- a/ionic/components/toast/test/basic/index.ts
+++ b/ionic/components/toast/test/basic/index.ts
@@ -48,6 +48,16 @@ class E2EPage {
     this.nav.present(toast);
   }
 
+  showDisabledBackdropToast() {
+    const toast = Toast.create({
+      message: 'User can interact with content even when the toast is diplayed',
+      disableBackdrop: true,
+    });
+
+    toast.onDismiss(this.dismissHandler);
+    this.nav.present(toast);
+  }
+
   showDismissDurationToast() {
     const toast = Toast.create({
       message: 'I am dismissed after 1.5 seconds',

--- a/ionic/components/toast/test/basic/main.html
+++ b/ionic/components/toast/test/basic/main.html
@@ -5,6 +5,7 @@
 <ion-content padding>
   <button block (click)="showToast()">Show Toast and Navigate</button>
   <button block (click)="showLongToast()">Show Long Toast</button>
+  <button block (click)="showDisabledBackdropToast()">Show Long Toast without backdrop</button>
   <br />
   <button block (click)="showDismissDurationToast()">Custom (1.5s) Duration</button>
   <button block (click)="showToastWithCloseButton()" class="e2eOpenToast">With closeButtonText</button>

--- a/ionic/components/toast/toast.scss
+++ b/ionic/components/toast/toast.scss
@@ -20,6 +20,10 @@ ion-toast {
   height: $toast-width;
 }
 
+.disable-backdrop {
+  pointer-events: none;
+}
+
 .toast-container {
   display: flex;
 

--- a/ionic/components/toast/toast.ts
+++ b/ionic/components/toast/toast.ts
@@ -64,6 +64,7 @@ export class Toast extends ViewController {
   constructor(opts: ToastOptions = {}) {
     opts.enableBackdropDismiss = isPresent(opts.enableBackdropDismiss) ? !!opts.enableBackdropDismiss : true;
     opts.dismissOnPageChange = isPresent(opts.dismissOnPageChange) ? !!opts.dismissOnPageChange : false;
+    opts.disableBackdrop = isPresent(opts.disableBackdrop) ? !!opts.disableBackdrop : false;
 
     super(ToastCmp, opts);
     this.viewType = 'toast';
@@ -106,6 +107,7 @@ export class Toast extends ViewController {
    *  | closeButtonText       | `string`  | "Close"         | Text to display in the close button.                                                                          |
    *  | enableBackdropDismiss | `boolean` | true            | Whether the toast should be dismissed by tapping the backdrop.                                                |
    *  | dismissOnPageChange   | `boolean` | false           | Whether to dismiss the toast when navigating to a new page.                                                   |
+   *  | disableBackdrop       | `boolean` | false           | Whether to disable the backdrop to allow user interaction while toast is being displayed.                        |
    *
    * @param {object} opts Toast options. See the above table for available options.
    */
@@ -136,6 +138,7 @@ export class Toast extends ViewController {
     'role': 'dialog',
     '[attr.aria-labelledby]': 'hdrId',
     '[attr.aria-describedby]': 'descId',
+    '[class.disable-backdrop]':'disableBackdrop',
   },
 })
 class ToastCmp {
@@ -145,6 +148,7 @@ class ToastCmp {
   private created: number;
   private id: number;
   private dismissTimeout: number = undefined;
+  private disableBackdrop: boolean = false;
 
   constructor(
     private _nav: NavController,
@@ -165,6 +169,10 @@ class ToastCmp {
     this.id = (++toastIds);
     if (this.d.message) {
       this.hdrId = 'toast-hdr-' + this.id;
+    }
+
+    if (this.d.disableBackdrop) {
+      this.disableBackdrop = this.d.disableBackdrop
     }
   }
 
@@ -222,6 +230,7 @@ export interface ToastOptions {
   closeButtonText?: string;
   enableBackdropDismiss?: boolean;
   dismissOnPageChange?: boolean;
+  disableBackdrop?: boolean;
 }
 
 class ToastSlideIn extends Transition {


### PR DESCRIPTION
#### Short description of what this resolves:
Allows user to disable backdrop while toast is displayed in order to allow user interaction

#### Changes proposed in this pull request:
- add `pointer-events: none` to host

**Ionic Version**: 2.x

**Fixes**: #6291

