### PR TITLE
EventEmitters on Menu open/close

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Ionic 2 is the next generation of [Ionic](http://ionicframework.com/), the open-
 
 Ionic 2 is based on the new [2.x version of AngularJS](https://angular.io/), and comes with many significant performance, usability, and feature improvements.
 
-See [Adam Bradley](http://twitter.com/adamdbradley)'s [Building apps with Ionic 2](http://adamdbradley.github.io/building-with-ionic2) slides for a quick overview of Ionic 2.
+See the [Building apps with Ionic 2](http://adamdbradley.github.io/building-with-ionic2) slides for a quick overview of Ionic 2.
 
 ### Try Ionic 2
 

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -284,6 +284,16 @@ export class Menu extends Ion {
    */
   @Output() opening: EventEmitter<number> = new EventEmitter();
 
+  /**
+   * @output {event} When the menu has been opened.
+   */
+  @Output() opened: EventEmitter<boolean> = new EventEmitter();
+
+  /**
+   * @output {event} When the menu has been closed.
+   */
+  @Output() closed: EventEmitter<boolean> = new EventEmitter();
+
   constructor(
     private _menuCtrl: MenuController,
     private _elementRef: ElementRef,
@@ -473,6 +483,7 @@ export class Menu extends Ion {
     // keep opening/closing the menu disabled for a touch more yet
     // only add listeners/css if it's enabled and isOpen
     // and only remove listeners/css if it's not open
+    // emit opened/closed events
     if ((this._isEnabled && isOpen) || !isOpen) {
       this._prevent();
 
@@ -484,10 +495,12 @@ export class Menu extends Ion {
 
       if (isOpen) {
         this._cntEle.addEventListener('click', this.onContentClick);
+        this.opened.emit(true);
 
       } else {
         this.getNativeElement().classList.remove('show-menu');
         this.getBackdropElement().classList.remove('show-backdrop');
+        this.closed.emit(true);
       }
     }
   }


### PR DESCRIPTION
#### Short description of what this resolves:
Creates opened/closed events after a menu opens/closes. This allows code to watch for when the menu state changes. One example of this being useful is when using the native Cordova Maps Plugin, which needs to be set to "unclickable" whenever a DOM element is floating above it (otherwise, the map continues to get clicked in the background). 

#### Changes proposed in this pull request:
- add opened/closed EventEmitters on Menu

**Ionic Version**: 1.x / 2.x
2.0

**Fixes**: #
Fixes #5163 