### PR TITLE
type return for Swiper slide functions

### DIFF
--- a/src/components/slides/swiper-widget.d.ts
+++ b/src/components/slides/swiper-widget.d.ts
@@ -7,7 +7,7 @@ export declare class Swiper {
   isEnd: boolean;
   isBeginning: boolean;
   update(): any;
-  slideNext(runCallbacks: boolean, speed: number);
-  slidePrev(runCallbacks: boolean, speed: number);
-  slideTo(slideIndex: number, speed: number, runCallbacks: boolean);
+  slideNext(runCallbacks: boolean, speed: number): boolean;
+  slidePrev(runCallbacks: boolean, speed: number): boolean;
+  slideTo(slideIndex: number, speed: number, runCallbacks: boolean): boolean;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Build failures with TypeScript's `noImplicitAny` option enabled

#### Changes proposed in this pull request:

- return value types for the slideNext, slidePrev, and slideTo functions of Swiper

**Ionic Version**: 2.x