### PR TITLE
@ViewChild argument close string mistake 

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -114,7 +114,7 @@ import {isBlank, isTrueProperty} from '../../util/util';
  *```ts
  * export class TabsPage {
  *
- * @ViewChild('myTabs) tabRef: Tabs
+ * @ViewChild('myTabs') tabRef: Tabs
  *
  * onPageDidEnter() {
  *   this.tabRef.select(2);


### PR DESCRIPTION
#### Short description of what this resolves:
Remove the error of example code at Documentation

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

In the doc page the whole content of @ViewChild is as the argument string as shown --
'''
@ViewChild('myTabs) tabRef: Tabs  //Not closed the argument

 onPageDidEnter() {
   this.tabRef.select(2);
  }
  }
'''