### PR TITLE
fix(select): Added trackBy property to allow selecting the object by …

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -176,6 +176,12 @@ export class Select {
   @Input() interface: string = '';
 
   /**
+   * @input {string} The name of the object property that should be used to determine which option is selected
+   * This is only used when the options are objects
+   */
+  @Input() trackBy: string = '';
+
+  /**
    * @output {any} Any expression you want to evaluate when the selection has changed.
    */
   @Output() change: EventEmitter<any> = new EventEmitter();
@@ -366,10 +372,19 @@ export class Select {
 
     if (this._options) {
       this._options.forEach(option => {
-        // check this option if the option's value is in the values array
-        option.checked = this._values.some(selectValue => {
-          return isCheckedProperty(selectValue, option.value);
-        });
+        if (this.trackBy) {
+          // If a trackBy property was provided, then assume the values are objects.
+          // check this option if the trackBy property of the option is the same as model
+          option.checked = this._values.some(selectValue => {
+            return isCheckedProperty(selectValue[this.trackBy], option.value[this.trackBy]);
+          });
+        }
+        else {
+          // check this option if the option's value is in the values array
+          option.checked = this._values.some(selectValue => {
+            return isCheckedProperty(selectValue, option.value);
+          });
+        }
 
         if (option.checked) {
           this._texts.push(option.text);


### PR DESCRIPTION
#### Short description of what this resolves:
ion-select currently cannot select the correct value if:

1. The values are objects
2. The ngModel binding is tied to a completely separate object, even it it has the exact same values.

This is due the ion-select only wanting to select objects based on object equality.

#### Changes proposed in this pull request:

- Add 'trackBy' property that represents the property within the object that will be considered, as opposed to the object itself.

**I'm open to other approaches. I've also considered just looking at each and every property within the object, but that seems expensive, especially if the object has many/nested properties**

Usage:
```
<ion-select [(ngModel)]="someObject" trackBy="idProperty"></ion-select>
```

**Ionic Version**: 2.x

**Fixes**: #6625 