### PR TITLE
fix undefined exception when using translate pipe without arguments

### DIFF
--- a/src/translation/translate_pipe.ts
+++ b/src/translation/translate_pipe.ts
@@ -21,11 +21,7 @@ export class TranslatePipe implements PipeTransform {
   constructor(translate: Translate) {
     this.translate = translate;
   }
-  transform(value, args) {
-    let lang;
-    if (args.length > 0) {
-      lang = args[0];
-    }
+  transform(value, lang) {
     return this.translate.translate(value, lang);
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

It fixes undefined exception in beta.7 when using translate pipe without arguments, eg: 

{{"app_name" | translate}}

#### Changes proposed in this pull request:

**Ionic Version**: 2.0.0-beta.7

**Fixes**: #

