### PR TITLE
docs(label): minor link fix

### DIFF
--- a/src/components/label/label.ts
+++ b/src/components/label/label.ts
@@ -47,7 +47,7 @@ import {Directive, ElementRef, Renderer, Input, Optional, Attribute} from '@angu
  *
  * @demo /docs/v2/demos/label/
  * @see {@link ../../../../components#inputs Input Component Docs}
- * @see {@link ../Input Input API Docs}
+ * @see {@link ../../input/Input Input API Docs}
  *
  */
 


### PR DESCRIPTION
#### Short description of what this resolves:

There's a minor link broken, when I have time I may navigate all the docs searching for broken links like this.

#### Changes proposed in this pull request:

- Minor doc link fix

**Ionic Version**: 2.x
