### PR TITLE
fix(slides): Removing a slide via *ngIf now properly removes the slid…

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -902,12 +902,16 @@ export class Slide {
 
   constructor(
     elementRef: ElementRef,
-    @Host() slides: Slides
+    @Host() private slides: Slides
   ) {
     this.ele = elementRef.nativeElement;
     this.ele.classList.add('swiper-slide');
 
     slides.rapidUpdate();
+  }
+
+  ngOnDestroy() {
+    this.slides.rapidUpdate();
   }
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Removing a slide by using *ngIf would not remove that slide and the bullet from the pager

#### Changes proposed in this pull request:
slides.rapidUpdate() is already called in each Slide constructor. I'm simply calling that function in the ngOnDestroy() function as well.

**Ionic Version**:  2.x

**Fixes**: #6651 