### PR TITLE
refactor(transitions): add transition data attribute to NavOptions an…

### DIFF
--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -505,7 +505,8 @@ export class NavController extends Ion {
     enteringView.setLeavingOpts({
       keyboardClose: false,
       direction: 'back',
-      animation: enteringView.getTransitionName('back')
+      animation: enteringView.getTransitionName('back'),
+      transitionData: opts.transitionData
     });
 
     // start the transition
@@ -1157,7 +1158,8 @@ export class NavController extends Ion {
         duration: opts.duration,
         easing: opts.easing,
         renderDelay: opts.transitionDelay || this._trnsDelay,
-        isRTL: this.config.platform.isRTL()
+        isRTL: this.config.platform.isRTL(),
+        transitionData: opts.transitionData
       };
 
       let transAnimation = Transition.createTransition(enteringView,
@@ -1779,6 +1781,7 @@ export interface NavOptions {
   postLoad?: Function;
   progressAnimation?: boolean;
   climbNav?: boolean;
+  transitionData?: any;
 }
 
 const STATE_ACTIVE = 'active';

--- a/src/transitions/transition.ts
+++ b/src/transitions/transition.ts
@@ -36,6 +36,7 @@ export interface TransitionOptions {
   direction: string;
   renderDelay?: number;
   isRTL?: boolean;
+  transitionData?: any;
 }
 
 let TransitionRegistry = {};


### PR DESCRIPTION
This PR allows for the user to pass some sort of data from either an event or just user data to the transition.  I used this to grab the coordinates of a touch/click event to send to the transition for the image gallery demo.  This will be important for custom transitions.