### PR TITLE
feat(slides): add return type to methods & add no implicit any to true

### DIFF
--- a/src/components/slides/swiper-widget.d.ts
+++ b/src/components/slides/swiper-widget.d.ts
@@ -7,7 +7,7 @@ export declare class Swiper {
   isEnd: boolean;
   isBeginning: boolean;
   update(): any;
-  slideNext(runCallbacks: boolean, speed: number);
-  slidePrev(runCallbacks: boolean, speed: number);
-  slideTo(slideIndex: number, speed: number, runCallbacks: boolean);
+  slideNext(runCallbacks: boolean, speed: number): void;
+  slidePrev(runCallbacks: boolean, speed: number): void;
+  slideTo(slideIndex: number, speed: number, runCallbacks: boolean): void;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es5",
     "module": "commonjs",
     "declaration": true,
+    "noImlicitAny": true,
     "outDir": "dist"
   },
   "exclude": [


### PR DESCRIPTION
#### Short description of what this resolves:

Error when using `"noImplicitAny": true` as the return types for  the below methods where missing:

  slideNext
  slidePrev
  slideTo

#### Changes proposed in this pull request:

- Add typings

**Ionic Version**:  2.x

**Fixes**: #

