### PR TITLE
fix(Menu): fix right overlay menu when rotating device

### DIFF
--- a/src/components/menu/menu-types.ts
+++ b/src/components/menu/menu-types.ts
@@ -137,8 +137,8 @@ class MenuOverlayType extends MenuType {
     let closedX: string, openedX: string;
     if (menu.side === 'right') {
       // right side
-      closedX = platform.width() + 'px';
-      openedX = (platform.width() - menu.width() - 8) + 'px';
+      closedX = menu.width() + 'px';
+      openedX = '0px';
 
     } else {
       // left side

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -90,7 +90,8 @@ ion-menu[type=overlay] {
 }
 
 ion-menu[type=overlay][side=right] {
-  left: 8px;
+  left: auto;
+	right: 0;
 }
 
 ion-menu[type=push][side=right] {


### PR DESCRIPTION
#### Short description of what this resolves:
Using overlay type menu on side="right" causes the menu to be shown in the middle of the screen when rotating the device.

#### Changes proposed in this pull request:

- Change CSS for right menu and logic for translateX

**Ionic Version**: 2.x

**Fixes**: #6740 

