### PR TITLE
Check rootNav history stack before android hardware back button closes the app

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -25,11 +25,14 @@ export class App {
   ) {
     platform.backButton.subscribe(() => {
       let activeNav = this.getActiveNav();
+      let rootNav = this.getRootNav();
       if (activeNav) {
-        if (activeNav.length() === 1) {
-          platform.exitApp();
-        } else {
+        if (activeNav.length() > 1) {
           activeNav.pop();
+        } else if (rootNav && rootNav.length() > 1) {
+          rootNav.pop();
+        } else {
+          platform.exitApp();
         }
       }
     });


### PR DESCRIPTION
#### Short description of what this resolves:
The hardware back button only checked the activeNav history stack, causing the app to exit while the rootNav still had history. 

#### Changes proposed in this pull request:

-Check the rootNav history stack before exiting the app
-
-

**Ionic Version**:  2.x

**Fixes**: #6756 

