### PR TITLE
docs(platform): correct a minor typo of "hardware"

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -317,7 +317,7 @@ export class Platform {
   * with a hardware back button in the same sense an Android or Windows device
   * does. It's important to note that this event does not emit when the Ionic
   * app's back button within the navbar is clicked, but this event is only
-  * referencing the platform's hardward back button.
+  * referencing the platform's hardware back button.
   */
   backButton: EventEmitter<Event> = new EventEmitter();
 


### PR DESCRIPTION
#### Short description of what this resolves:

"hardware" is mistyped "hardward"
#### Changes proposed in this pull request:

- Correct that. That's all.

**Ionic Version**: 2.x