### PR TITLE
Replacing ionRefresh with refresh

### DIFF
--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -25,7 +25,7 @@ import {CSS, pointerCoord, transitionEnd} from '../../util/dom';
  * ```html
  * <ion-content>
  *
- *   <ion-refresher (ionRefresh)="doRefresh($event)">
+ *   <ion-refresher (refresh)="doRefresh($event)">
  *     <ion-refresher-content></ion-refresher-content>
  *   </ion-refresher>
  *
@@ -59,7 +59,7 @@ import {CSS, pointerCoord, transitionEnd} from '../../util/dom';
  *  ```html
  *  <ion-content>
  *
- *    <ion-refresher (ionRefresh)="doRefresh($event)">
+ *    <ion-refresher (refresh)="doRefresh($event)">
  *      <ion-refresher-content
  *        pullingIcon="arrow-dropdown"
  *        pullingText="Pull to refresh"


### PR DESCRIPTION
#### Short description of what this resolves:
ionRefresh event should be replaced with refresh

#### Changes proposed in this pull request:

The two documentation samples were changed.

**Ionic Version**:  2.x

**Fixes**: #

The documentation refers to ionRefesh as the event to bind the function to, but it should be refresh.