### PR TITLE
refactor(inset-modal): refactor to ensure transition completes in time

### DIFF
--- a/src/animations/animation.ts
+++ b/src/animations/animation.ts
@@ -247,7 +247,7 @@ export class Animation {
     var i: number;
     var duration: number = isDefined(opts.duration) ? opts.duration : self._dur;
 
-    console.debug('Animation, play, duration', duration, 'easing', self._easing);
+    console.debug('Animation, play, duration', duration, 'easing', self._easing, 'ts', Date.now());
 
     // always default that an animation does not tween
     // a tween requires that an Animation class has an element
@@ -361,7 +361,7 @@ export class Animation {
     var self = this;
 
     function onTransitionEnd(ev: any) {
-      console.debug('Animation onTransitionEnd', ev.target.nodeName, ev.propertyName);
+      console.debug('Animation onTransitionEnd', ev.target.nodeName, ev.propertyName, 'ts', Date.now());
 
       // ensure transition end events and timeouts have been cleared
       self._clearAsync();
@@ -377,7 +377,7 @@ export class Animation {
     }
 
     function onTransitionFallback() {
-      console.debug('Animation onTransitionFallback');
+      console.debug('Animation onTransitionFallback', 'ts', Date.now());
       // oh noz! the transition end event didn't fire in time!
       // instead the fallback timer when first
 

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -59,7 +59,7 @@ export class App {
    * something goes wrong during a transition and the app wasn't re-enabled correctly.
    */
   setEnabled(isEnabled: boolean, duration: number = 700) {
-    const CLICK_BLOCK_PADDING = 64;
+    const CLICK_BLOCK_PADDING = 128;
     this._disTime = (isEnabled ? 0 : Date.now() + duration + CLICK_BLOCK_PADDING);
 
     if (this._clickBlock) {

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -62,12 +62,13 @@ export class App {
     this._disTime = (isEnabled ? 0 : Date.now() + duration);
 
     if (this._clickBlock) {
-      if (duration > 32) {
-        // only do a click block if the duration is longer than XXms
-        this._clickBlock.show(true, duration + 64);
-
-      } else {
+      if ( isEnabled || duration <= 32 ) {
+        // disable the click block if it's enabled, or the duration is tiny
         this._clickBlock.show(false, 0);
+      }
+      else {
+        // show the click block for duration + some number
+        this._clickBlock.show(true, duration + 64);
       }
     }
   }

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -59,7 +59,8 @@ export class App {
    * something goes wrong during a transition and the app wasn't re-enabled correctly.
    */
   setEnabled(isEnabled: boolean, duration: number = 700) {
-    this._disTime = (isEnabled ? 0 : Date.now() + duration);
+    const CLICK_BLOCK_PADDING = 64;
+    this._disTime = (isEnabled ? 0 : Date.now() + duration + CLICK_BLOCK_PADDING);
 
     if (this._clickBlock) {
       if ( isEnabled || duration <= 32 ) {
@@ -68,7 +69,7 @@ export class App {
       }
       else {
         // show the click block for duration + some number
-        this._clickBlock.show(true, duration + 64);
+        this._clickBlock.show(true, duration + CLICK_BLOCK_PADDING);
       }
     }
   }

--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -86,6 +86,77 @@ describe('IonicApp', () => {
 
   });
 
+  describe('setEnabled', () => {
+    it('should disable click block when app is enabled', () => {
+      // arrange
+      let mockClickBlock = {
+        show: () => {}
+      };
+
+      spyOn(mockClickBlock, 'show');
+
+      app._clickBlock = mockClickBlock;
+
+      // act
+      app.setEnabled(true);
+
+      // assert
+      expect(mockClickBlock.show).toHaveBeenCalledWith(false, 0);
+    });
+
+    it('should disable click block when app is disabled but duration of less than 32 passed', () => {
+      // arrange
+      let mockClickBlock = {
+        show: () => {}
+      };
+
+      spyOn(mockClickBlock, 'show');
+
+      app._clickBlock = mockClickBlock;
+
+      // act
+      app.setEnabled(false, 20);
+
+      // assert
+      expect(mockClickBlock.show).toHaveBeenCalledWith(false, 0);
+    });
+
+    it('should enable click block when false is passed with duration', () => {
+      // arrange
+      let mockClickBlock = {
+        show: () => {}
+      };
+
+      spyOn(mockClickBlock, 'show');
+
+      app._clickBlock = mockClickBlock;
+
+      // act
+      app.setEnabled(false, 200);
+
+      // assert
+      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 200 + 64);
+    });
+
+    it('should enable click block when false is passed w/o duration', () => {
+      // arrange
+      let mockClickBlock = {
+        show: () => {}
+      };
+
+      spyOn(mockClickBlock, 'show');
+
+      app._clickBlock = mockClickBlock;
+
+      // act
+      app.setEnabled(false);
+
+      // assert
+      // 700 is the default
+      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 700 + 64);
+    });
+  });
+
   var app: App;
   var config: Config;
   var platform: Platform;

--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -135,7 +135,7 @@ describe('IonicApp', () => {
       app.setEnabled(false, 200);
 
       // assert
-      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 200 + 64);
+      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 200 + 128);
     });
 
     it('should enable click block when false is passed w/o duration', () => {
@@ -153,7 +153,21 @@ describe('IonicApp', () => {
 
       // assert
       // 700 is the default
-      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 700 + 64);
+      expect(mockClickBlock.show).toHaveBeenCalledWith(true, 700 + 128);
+    });
+
+    it('disTime should be not be zero when enabled', () => {
+      app._disTime = null;
+      app.setEnabled(false);
+
+      expect(app._disTime).not.toEqual(0);
+    });
+
+    it('disTime should be not be zero when enabled', () => {
+      app._disTime = null;
+      app.setEnabled(true);
+
+      expect(app._disTime).toEqual(0);
     });
   });
 

--- a/src/components/modal/modal.ios.scss
+++ b/src/components/modal/modal.ios.scss
@@ -5,3 +5,8 @@
 
 $modal-ios-background-color:          $background-ios-color !default;
 $modal-ios-border-radius:             5px !default;
+
+.modal-wrapper {
+  // hidden by default to prevent flickers, the animation will show it
+  transform: translate3d(0, 100%, 0);
+}

--- a/src/components/modal/modal.md.scss
+++ b/src/components/modal/modal.md.scss
@@ -4,3 +4,8 @@
 // --------------------------------------------------
 
 $modal-md-background-color:          $background-md-color !default;
+
+.modal-wrapper {
+  opacity: .01;
+  transform: translate3d(0, 40px, 0);
+}

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -10,7 +10,7 @@ $modal-inset-width:                          600px !default;
 $modal-inset-height-small:                   500px !default;
 $modal-inset-height-large:                   600px !default;
 
-.modal {
+ion-modal {
   position: absolute;
   top: 0;
   left: 0;
@@ -22,7 +22,7 @@ $modal-inset-height-large:                   600px !default;
 
   ion-backdrop {
     @media not all and (min-width: $modal-inset-min-width) and (min-height: $modal-inset-min-height-small) {
-      display: none;
+      visibility: hidden;
     }
   }
 }

--- a/src/components/modal/modal.scss
+++ b/src/components/modal/modal.scss
@@ -31,8 +31,6 @@ ion-modal {
   z-index: 10;
 
   height: 100%;
-  // hidden by default to prevent flickers, the animation will show it
-  transform: translate3d(0, 100%, 0);
 
   @media only screen and (min-width: $modal-inset-min-width) and (min-height: $modal-inset-min-height-small) {
     position: absolute;

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -8,6 +8,8 @@ import {Transition, TransitionOptions} from '../../transitions/transition';
 import {ViewController} from '../nav/view-controller';
 import {windowDimensions} from '../../util/dom';
 
+import {nativeRaf, CSS} from '../../util/dom';
+
 /**
  * @name Modal
  * @description
@@ -184,36 +186,43 @@ export class ModalCmp {
 /**
  * Animations for modals
  */
-class ModalSlideIn extends Transition {
-  constructor(enteringView: ViewController, leavingView: ViewController, opts: TransitionOptions) {
-    super(opts);
+ class ModalSlideIn extends Transition {
+   constructor(enteringView: ViewController, leavingView: ViewController, opts: TransitionOptions) {
+     super(opts);
 
-    let ele = enteringView.pageRef().nativeElement;
-    let backdrop = new Animation(ele.querySelector('ion-backdrop'));
-    backdrop.fromTo('opacity', 0.01, 0.4);
-    let wrapper = new Animation(ele.querySelector('.modal-wrapper'));
-    let page = <HTMLElement> ele.querySelector('ion-page');
+     let ele = enteringView.pageRef().nativeElement;
+     let backdropEle = ele.querySelector('ion-backdrop');
+     let backdrop = new Animation(backdropEle);
+     let wrapper = new Animation(ele.querySelector('.modal-wrapper'));
+     let page = <HTMLElement> ele.querySelector('ion-page');
+     let pageAnimation = new Animation(page);
 
-    // auto-add page css className created from component JS class name
-    let cssClassName = pascalCaseToDashCase((<Modal>enteringView).modalViewType);
-    page.classList.add(cssClassName);
+     // auto-add page css className created from component JS class name
+     let cssClassName = pascalCaseToDashCase((<Modal>enteringView).modalViewType);
+     pageAnimation.before.addClass(cssClassName);
+     pageAnimation.before.addClass('show-page');
 
-    wrapper.fromTo('translateY', '100%', '0%');
+     backdrop.fromTo('opacity', 0.01, 0.4);
+     wrapper.fromTo('translateY', '100%', '0%');
 
-    const DURATION = 400;
-    const EASING = 'cubic-bezier(0.36,0.66,0.04,1)';
-    this.element(enteringView.pageRef()).easing(EASING).duration(DURATION).add(backdrop).add(wrapper);
-    this.element(new ElementRef(page)).easing(EASING).duration(DURATION).before.addClass('show-page');
 
-    if (enteringView.hasNavbar()) {
-      // entering page has a navbar
-      let enteringNavBar = new Animation(enteringView.navbarRef());
-      enteringNavBar.before.addClass('show-navbar');
-      this.add(enteringNavBar);
-    }
-  }
-}
-Transition.register('modal-slide-in', ModalSlideIn);
+     this
+       .element(enteringView.pageRef())
+       .easing('cubic-bezier(0.36,0.66,0.04,1)')
+       .duration(400)
+       .add(backdrop)
+       .add(wrapper)
+       .add(pageAnimation);
+
+     if (enteringView.hasNavbar()) {
+       // entering page has a navbar
+       let enteringNavBar = new Animation(enteringView.navbarRef());
+       enteringNavBar.before.addClass('show-navbar');
+       this.add(enteringNavBar);
+     }
+   }
+ }
+ Transition.register('modal-slide-in', ModalSlideIn);
 
 
 class ModalSlideOut extends Transition {
@@ -221,9 +230,7 @@ class ModalSlideOut extends Transition {
     super(opts);
 
     let ele = leavingView.pageRef().nativeElement;
-
     let backdrop = new Animation(ele.querySelector('ion-backdrop'));
-    backdrop.fromTo('opacity', 0.4, 0.0);
     let wrapperEle = <HTMLElement> ele.querySelector('.modal-wrapper');
     let wrapperEleRect = wrapperEle.getBoundingClientRect();
     let wrapper = new Animation(wrapperEle);
@@ -232,6 +239,7 @@ class ModalSlideOut extends Transition {
     // so it's off-screen
     let screenDimensions = windowDimensions();
     wrapper.fromTo('translateY', '0px', `${screenDimensions.height - wrapperEleRect.top}px`);
+    backdrop.fromTo('opacity', 0.4, 0.0);
 
     this
       .element(leavingView.pageRef())
@@ -250,20 +258,26 @@ class ModalMDSlideIn extends Transition {
 
     let ele = enteringView.pageRef().nativeElement;
     let backdrop = new Animation(ele.querySelector('ion-backdrop'));
-    backdrop.fromTo('opacity', 0.01, 0.4);
     let wrapper = new Animation(ele.querySelector('.modal-wrapper'));
-    wrapper.fromTo('translateY', '40px', '0px');
     let page = <HTMLElement> ele.querySelector('ion-page');
-
+    let pageAnimation = new Animation(page);
 
     // auto-add page css className created from component JS class name
     let cssClassName = pascalCaseToDashCase((<Modal>enteringView).modalViewType);
-    page.classList.add(cssClassName);
+    pageAnimation.before.addClass(cssClassName);
+    pageAnimation.before.addClass('show-page');
+
+
+    backdrop.fromTo('opacity', 0.01, 0.4);
+    wrapper.fromTo('translateY', '40px', '0px');
 
     const DURATION = 280;
     const EASING = 'cubic-bezier(0.36,0.66,0.04,1)';
-    this.element(enteringView.pageRef()).easing(EASING).duration(DURATION).fadeIn().add(backdrop).add(wrapper);
-    this.element(new ElementRef(page)).easing(EASING).duration(DURATION).before.addClass('show-page');
+    this.element(enteringView.pageRef()).easing(EASING).duration(DURATION)
+      .fadeIn()
+      .add(backdrop)
+      .add(wrapper)
+      .add(pageAnimation);
 
     if (enteringView.hasNavbar()) {
       // entering page has a navbar
@@ -282,8 +296,9 @@ class ModalMDSlideOut extends Transition {
 
     let ele = leavingView.pageRef().nativeElement;
     let backdrop = new Animation(ele.querySelector('ion-backdrop'));
-    backdrop.fromTo('opacity', 0.4, 0.0);
     let wrapper = new Animation(ele.querySelector('.modal-wrapper'));
+
+    backdrop.fromTo('opacity', 0.4, 0.0);
     wrapper.fromTo('translateY', '0px', '40px');
 
     this

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -270,11 +270,11 @@ class ModalMDSlideIn extends Transition {
 
     backdrop.fromTo('opacity', 0.01, 0.4);
     wrapper.fromTo('translateY', '40px', '0px');
+    wrapper.fromTo('opacity', '0.01', '1.0');
 
     const DURATION = 280;
     const EASING = 'cubic-bezier(0.36,0.66,0.04,1)';
     this.element(enteringView.pageRef()).easing(EASING).duration(DURATION)
-      .fadeIn()
       .add(backdrop)
       .add(wrapper)
       .add(pageAnimation);
@@ -300,12 +300,12 @@ class ModalMDSlideOut extends Transition {
 
     backdrop.fromTo('opacity', 0.4, 0.0);
     wrapper.fromTo('translateY', '0px', '40px');
+    wrapper.fromTo('opacity', '1.0', '0.00');
 
     this
       .element(leavingView.pageRef())
       .duration(200)
       .easing('cubic-bezier(0.47,0,0.745,0.715)')
-      .fadeOut()
       .add(wrapper)
       .add(backdrop);
   }

--- a/src/components/modal/modal.wp.scss
+++ b/src/components/modal/modal.wp.scss
@@ -4,3 +4,8 @@
 // --------------------------------------------------
 
 $modal-wp-background-color:          $background-wp-color !default;
+
+.modal-wrapper {
+  opacity: .01;
+  transform: translate3d(0, 40px, 0);
+}

--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -160,6 +160,10 @@ function setupDom(window: Window, document: Document, config: Config, platform: 
     bodyEle.classList.add('enable-hover');
   }
 
+  if (config.get('clickBlock')) {
+    clickBlock.enable();
+  }
+
   // run feature detection tests
   featureDetect.run(window, document);
 }

--- a/src/util/click-block.ts
+++ b/src/util/click-block.ts
@@ -27,7 +27,6 @@ export class ClickBlock {
     if (this._enabled) {
       if (shouldShow) {
         show(expire);
-
       } else {
         hide();
       }


### PR DESCRIPTION
This commit included several things:

1.  Add click-block support back to the app after it was lost in the bootstrap changes

2.  Clean up some buggy logic in the "appEnabled" method, added tests to validate them

3.  CSS changes to speed up a transition

4.  Changes to the transition

