### PR TITLE
refactor(nav-controller): support multiple transitions via child-nav …

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -17,6 +17,7 @@ export class App {
   private _titleSrv: Title = new Title();
   private _rootNav: any = null;
   private _appInjector: Injector;
+  private _numTransitions: number = 0;
 
   constructor(
     private _config: Config,
@@ -71,6 +72,40 @@ export class App {
       }
     }
   }
+
+  /**
+   * @private
+   * This method is used to allow multiple navigation transitions to happen
+   * independently of each and declare when they're starting
+   * so the app can activate/deactive according to the
+   * aggregate of all active transitions
+   */
+   registerTransition(duration: number = 700) {
+     this._numTransitions++;
+     let newDisabledTime = Date.now() + duration;
+     if ( ! this._disTime || newDisabledTime >= this._disTime ) {
+        this._disTime = newDisabledTime;
+        this.setEnabled(false, duration);
+     }
+   }
+
+   /**
+    * @private
+    * This method is used to delcare a navigation transition is complete
+    * so the app can respond activate/deactivate according to the
+    * aggregate of all active transitions
+    */
+    transitionComplete() {
+      this._numTransitions--;
+      if ( this._numTransitions <= 0 ) {
+        // if the number of transition is less than or equal
+        // to zero, set it to zero (just to make sure),
+        // enable the app, and then null out _disTime
+        this._numTransitions = 0;
+        this.setEnabled(true);
+        this._disTime = null;
+      }
+    }
 
   /**
    * @private

--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -86,6 +86,90 @@ describe('IonicApp', () => {
 
   });
 
+  describe('registerTransition', () => {
+    it('should disable app when registering a transition', () => {
+      // arrange
+      app._numTransitions = 0;
+      spyOn(app, "setEnabled");
+      let DURATION = 300;
+      // act
+      app.registerTransition(DURATION);
+      // assert
+      expect(app._numTransitions).toEqual(1);
+      expect(app.setEnabled).toHaveBeenCalledWith(false, DURATION);
+    });
+
+    it('should correctly track number of transitions', () => {
+      // arrange
+      app._numTransitions = 0;
+      spyOn(app, "setEnabled");
+
+      // act and assertions together
+
+      // register a transition, check data
+      app.registerTransition(300);
+      expect(app._numTransitions).toEqual(1);
+      expect(app.setEnabled).toHaveBeenCalledWith(false, 300);
+      // reset the spy
+      app.setEnabled.calls.reset();
+
+      // register a transition, check data
+      app.registerTransition(30);
+      expect(app._numTransitions).toEqual(2);
+      expect(app.setEnabled).not.toHaveBeenCalled();
+      // reset the spy
+      app.setEnabled.calls.reset();
+
+      // register a transition, check data
+      app.registerTransition(30);
+      expect(app._numTransitions).toEqual(3);
+      expect(app.setEnabled).not.toHaveBeenCalled();
+      // reset the spy
+      app.setEnabled.calls.reset();
+
+      // register a transition, check data
+      app.registerTransition(300);
+      expect(app._numTransitions).toEqual(4);
+      expect(app.setEnabled).toHaveBeenCalledWith(false, 300);
+    });
+  });
+
+  describe('transitionComplete', () => {
+    it('should decrement the number of transitions', () => {
+      // arrange
+      app._numTransitions = 1;
+      spyOn(app, "setEnabled");
+      // act
+      app.transitionComplete();
+      // assert
+      expect(app._numTransitions).toEqual(0);
+      expect(app.setEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('should reset numTransitions to 0 if below zero', () => {
+      // arrange
+      app._numTransitions = 0;
+      spyOn(app, "setEnabled");
+      // act
+      app.transitionComplete();
+      // assert
+      expect(app._numTransitions).toEqual(0);
+      expect(app.setEnabled).toHaveBeenCalledWith(true);
+    });
+
+    it('should not call setEnabled if numTransition > 0', () => {
+      // arrange
+      app._numTransitions = 2;
+      spyOn(app, "setEnabled");
+      // act
+      app.transitionComplete();
+      // assert
+      expect(app._numTransitions).toEqual(1);
+      expect(app.setEnabled).not.toHaveBeenCalled();
+    });
+
+  });
+
   var app: App;
   var config: Config;
   var platform: Platform;

--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -1182,11 +1182,8 @@ export class NavController extends Ion {
       }
 
       let duration = transAnimation.getDuration();
-      let enableApp = (duration < 64);
-      // block any clicks during the transition and provide a
-      // fallback to remove the clickblock if something goes wrong
-      this._app.setEnabled(enableApp, duration);
-      this.setTransitioning(!enableApp, duration);
+      this._app.registerTransition(duration);
+      this.setTransitioning(true, duration);
 
       if (enteringView.viewType) {
         transAnimation.before.addClass(enteringView.viewType);
@@ -1330,8 +1327,8 @@ export class NavController extends Ion {
         enteringView.state = STATE_INACTIVE;
       }
 
-      // allow clicks and enable the app again
-      this._app && this._app.setEnabled(true);
+      // mark the transition as complete
+      this._app && this._app.transitionComplete();
       this.setTransitioning(false);
 
       if (direction !== null && hasCompleted && !this.isPortal) {


### PR DESCRIPTION
This is a PR that tracks the number of active transitions and delegates the enable/disabling of the app to the number of active transitions.

Basically... When navigating to a page with a child-nav, the app would be disabled from the initial transition to a page, then the subsequent child nav event would reactivate the app.