### PR TITLE
feat(range): range can be disabled

### DIFF
--- a/src/components/range/range.ios.scss
+++ b/src/components/range/range.ios.scss
@@ -12,7 +12,7 @@ $range-ios-slider-height:                     42px !default;
 $range-ios-hit-width:                         42px !default;
 $range-ios-hit-height:                        $range-ios-slider-height !default;
 
-$range-ios-bar-height:                        1px !default;
+$range-ios-bar-height:                        2px !default;
 $range-ios-bar-background-color:              #bdbdbd !default;
 $range-ios-bar-active-background-color:       color($colors-ios, primary) !default;
 
@@ -66,6 +66,8 @@ ion-range {
 
   width: 100%;
   height: $range-ios-bar-height;
+
+  border-radius: 1px;
 
   background: $range-ios-bar-background-color;
 
@@ -165,6 +167,11 @@ ion-range {
 .range-knob-pressed .range-pin {
   transform: translate3d(0, 0, 0) scale(1);
 }
+
+.range-disabled {
+  opacity: 0.5;
+}
+
 
 // Generate iOS Range Colors
 // --------------------------------------------------

--- a/src/components/range/range.md.scss
+++ b/src/components/range/range.md.scss
@@ -220,6 +220,19 @@ ion-range:not(.range-has-pin) .range-knob-pressed .range-knob {
 
 @include md-range-min();
 
+.range-disabled {
+  .range-bar-active {
+    background-color: $range-md-bar-background-color;
+  }
+
+  .range-knob {
+    transform: scale(.55);
+    background-color: $range-md-bar-background-color;
+    outline: 5px solid white;
+  }
+
+}
+
 
 // Generate Material Design Range Colors
 // --------------------------------------------------

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -356,6 +356,12 @@ export class Range {
    * @private
    */
   pointerDown(ev: UIEvent) {
+    // TODO: we could stop listening for events instead of checking this._disabled.
+    // since there are a lot of events involved, this solution is
+    // enough for the moment
+    if (this._disabled) {
+      return;
+    }
     console.debug(`range, ${ev.type}`);
 
     // prevent default so scrolling does not happen

--- a/src/components/range/test/basic/page1.html
+++ b/src/components/range/test/basic/page1.html
@@ -44,6 +44,14 @@
     </ion-item>
 
     <ion-item>
+      <ion-label>disabled</ion-label>
+      <ion-range min="20" max="80" step="2" [(ngModel)]="singleValue3" disabled=true>
+        <ion-icon small range-left name="sunny"></ion-icon>
+        <ion-icon range-right name="sunny"></ion-icon>
+      </ion-range>
+    </ion-item>
+
+    <ion-item>
       <ion-label>step=100, snaps, {{singleValue4}}</ion-label>
       <ion-range min="1000" max="2000" step="100" snaps="true" secondary [(ngModel)]="singleValue4"></ion-range>
     </ion-item>


### PR DESCRIPTION
#### Short description of what this resolves:
This PR allows range to be disabled + iOS style has been improved:

iOS before:
<img width="376" alt="screen shot 2016-06-08 at 11 53 43" src="https://cloud.githubusercontent.com/assets/127379/15890414/b3a20b38-2d6f-11e6-80d4-6ac1948ffbb2.png">

iOS after:
<img width="376" alt="screen shot 2016-06-08 at 11 52 27" src="https://cloud.githubusercontent.com/assets/127379/15890418/b9ffc290-2d6f-11e6-928e-ee3f1f2ffa33.png">


Disable state iOS:
<img width="375" alt="screen shot 2016-06-08 at 11 52 44" src="https://cloud.githubusercontent.com/assets/127379/15890431/c3e922b0-2d6f-11e6-9bc9-520485134633.png">


Disable state MD:
<img width="406" alt="screen shot 2016-06-08 at 11 53 00" src="https://cloud.githubusercontent.com/assets/127379/15890440/cf9d8fa6-2d6f-11e6-9fe5-d022b9b817e5.png">


**Ionic Version**: 2.x
