### PR TITLE
chore(build): change gulp prepublish process to create es2015 modules

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,7 +57,8 @@ var tscReporter = {
 // See: https://github.com/Microsoft/TypeScript/issues/4801
 // and https://github.com/ivogabe/gulp-typescript/issues/211
 var babelOptions = {
-  modules: 'system',
+  presets: ['es2015'],
+  plugins: ['transform-es2015-modules-systemjs'],
   moduleIds: true,
   getModuleId: function(name) {
     return 'ionic-angular/' + name;
@@ -257,6 +258,21 @@ function tsCompile(options, cacheName){
     .pipe(cache(cacheName, { optimizeMemory: true }))
     .pipe(tsc(options, undefined, tscReporter));
 }
+
+gulp.task('bundle.es6', function() {
+  var babel = require('gulp-babel');
+
+  gulp.src([
+      'src/components/slides/swiper-widget.js'
+    ])
+    .pipe(gulp.dest('dist/esm/components/slides'));
+
+  return tsCompile(getTscOptions('es6'), 'bundle.es6')
+    .pipe(babel({
+      presets: ['es2015-native-modules']
+    }))
+    .pipe(gulp.dest('dist/esm'));
+});
 
 /**
  * Compiles Ionic Sass sources to stylesheets and outputs them to dist/bundles.
@@ -720,7 +736,7 @@ gulp.task('karma', ['tests'], function(done) {
 gulp.task('karma-watch', ['watch.tests', 'bundle.system'], function() {
   watchTask('bundle.system');
   var karma = require('karma').server;
-  return karma.start({ configFile: __dirname + '/scripts/karma/karma-watch.conf.js' })
+  return karma.start({ configFile: __dirname + '/scripts/karma/karma-watch.conf.js'})
 });
 
 
@@ -938,7 +954,7 @@ gulp.task('build.release', function(done){
   runSequence(
     'clean',
     'copy.libs',
-    ['bundle', 'sass', 'fonts', 'copy.scss'],
+    ['bundle', 'bundle.es6', 'sass', 'fonts', 'copy.scss'],
     done
   );
 });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "zone.js": "^0.6.12"
   },
   "devDependencies": {
+    "babel-plugin-transform-es2015-modules-systemjs": "^6.9.0",
+    "babel-preset-es2015": "^6.9.0",
+    "babel-preset-es2015-native-modules": "^6.6.0",
     "canonical-path": "0.0.2",
     "connect": "^3.3.4",
     "conventional-changelog": "^0.5.3",
@@ -45,7 +48,7 @@
     "glob": "^5.0.14",
     "gulp": "~3.8.10",
     "gulp-autoprefixer": "^2.3.0",
-    "gulp-babel": "^5.3.0",
+    "gulp-babel": "^6.1.2",
     "gulp-cached": "^1.1.0",
     "gulp-concat": "~2.5.0",
     "gulp-connect": "^2.2.0",

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -4,6 +4,8 @@
   "description": "An advanced HTML5 mobile app framework built on Angular2",
   "license": "MIT",
   "keywords": ["ionic", "framework", "mobile", "app", "hybrid", "webapp", "cordova"],
+  "main": "index.js",
+  "jsnext:main": "esm/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/driftyco/ionic.git#2.0`"


### PR DESCRIPTION
#### Short description of what this resolves:
This pr will add es2015 modules to the publishing process.

#### Changes proposed in this pull request:

- Update gulp to create es2015 modules in esm directory for publishing
- Update gulp-babel to use 6 so that we can rely on babel 6 transforms and presets

**Ionic Version**: 2.x
