### PR TITLE
Feature/overlays

### DIFF
--- a/src/components/action-sheet/action-sheet.ts
+++ b/src/components/action-sheet/action-sheet.ts
@@ -245,10 +245,9 @@ export class ActionSheet extends ViewController {
 class ActionSheetCmp {
   private d: any;
   private descId: string;
+  private enabled: boolean;
   private hdrId: string;
   private id: number;
-  private created: number;
-  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -258,7 +257,6 @@ class ActionSheetCmp {
     renderer: Renderer
   ) {
     this.d = params.data;
-    this.created = Date.now();
 
     if (this.d.cssClass) {
       renderer.setElementClass(_elementRef.nativeElement, this.d.cssClass, true);

--- a/src/components/action-sheet/action-sheet.ts
+++ b/src/components/action-sheet/action-sheet.ts
@@ -5,7 +5,7 @@ import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {Icon} from '../icon/icon';
 import {isPresent} from '../../util/util';
-import {KeyboardConstants} from '../../util/keyboard-constants';
+import {Key} from '../../util/key';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 
@@ -269,7 +269,6 @@ class ActionSheetCmp {
     if (this.d.subTitle) {
       this.descId = 'acst-subhdr-' + this.id;
     }
-    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -321,8 +320,8 @@ class ActionSheetCmp {
 
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
-    if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === KeyboardConstants.ESCAPE) {
+    if (this.enabled && this._viewCtrl.isLast()) {
+      if (ev.keyCode === Key.ESCAPE) {
         console.debug('actionsheet, escape button');
         this.bdClick();
       }
@@ -330,7 +329,7 @@ class ActionSheetCmp {
   }
 
   click(button: any, dismissDelay?: number) {
-    if (!this.isEnabled()) {
+    if (! this.enabled ) {
       return;
     }
 
@@ -352,7 +351,7 @@ class ActionSheetCmp {
   }
 
   bdClick() {
-    if (this.isEnabled() && this.d.enableBackdropDismiss) {
+    if (this.enabled && this.d.enableBackdropDismiss) {
       if (this.d.cancelButton) {
         this.click(this.d.cancelButton, 1);
 
@@ -364,10 +363,6 @@ class ActionSheetCmp {
 
   dismiss(role: any): Promise<any> {
     return this._viewCtrl.dismiss(null, role);
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 }
 

--- a/src/components/action-sheet/action-sheet.ts
+++ b/src/components/action-sheet/action-sheet.ts
@@ -5,6 +5,7 @@ import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {Icon} from '../icon/icon';
 import {isPresent} from '../../util/util';
+import {KeyboardConstants} from '../../util/keyboard-constants';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 
@@ -247,6 +248,7 @@ class ActionSheetCmp {
   private hdrId: string;
   private id: number;
   private created: number;
+  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -269,6 +271,7 @@ class ActionSheetCmp {
     if (this.d.subTitle) {
       this.descId = 'acst-subhdr-' + this.id;
     }
+    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -315,12 +318,13 @@ class ActionSheetCmp {
     if (focusableEle) {
       focusableEle.focus();
     }
+    this.enabled = true;
   }
 
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
     if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === 27) {
+      if (ev.keyCode === KeyboardConstants.ESCAPE) {
         console.debug('actionsheet, escape button');
         this.bdClick();
       }
@@ -365,8 +369,7 @@ class ActionSheetCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 }
 

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -4,6 +4,7 @@ import {Animation} from '../../animations/animation';
 import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {isPresent} from '../../util/util';
+import {KeyboardConstants} from '../../util/keyboard-constants';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 
@@ -382,6 +383,7 @@ class AlertCmp {
   private inputType: string;
   private created: number;
   private lastClick: number;
+  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -417,6 +419,7 @@ class AlertCmp {
     if (!this.d.message) {
       this.d.message = '';
     }
+    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -467,7 +470,7 @@ class AlertCmp {
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
     if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === 13) {
+      if (ev.keyCode === KeyboardConstants.ENTER) {
         if (this.lastClick + 1000 < Date.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
@@ -478,7 +481,7 @@ class AlertCmp {
           this.btnClick(button);
         }
 
-      } else if (ev.keyCode === 27) {
+      } else if (ev.keyCode === KeyboardConstants.ESCAPE) {
         console.debug('alert, escape button');
         this.bdClick();
       }
@@ -495,6 +498,7 @@ class AlertCmp {
     if (focusableEle) {
       focusableEle.focus();
     }
+    this.enabled = true;
   }
 
   btnClick(button: any, dismissDelay?: number) {
@@ -578,8 +582,7 @@ class AlertCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 }
 

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -4,7 +4,7 @@ import {Animation} from '../../animations/animation';
 import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {isPresent} from '../../util/util';
-import {KeyboardConstants} from '../../util/keyboard-constants';
+import {Key} from '../../util/key';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 
@@ -417,7 +417,6 @@ class AlertCmp {
     if (!this.d.message) {
       this.d.message = '';
     }
-    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -467,8 +466,8 @@ class AlertCmp {
 
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
-    if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === KeyboardConstants.ENTER) {
+    if (this.enabled && this._viewCtrl.isLast()) {
+      if (ev.keyCode === Key.ENTER) {
         if (this.lastClick + 1000 < Date.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
@@ -479,7 +478,7 @@ class AlertCmp {
           this.btnClick(button);
         }
 
-      } else if (ev.keyCode === KeyboardConstants.ESCAPE) {
+      } else if (ev.keyCode === Key.ESCAPE) {
         console.debug('alert, escape button');
         this.bdClick();
       }
@@ -500,7 +499,7 @@ class AlertCmp {
   }
 
   btnClick(button: any, dismissDelay?: number) {
-    if (!this.isEnabled()) {
+    if (!this.enabled) {
       return;
     }
 
@@ -526,7 +525,7 @@ class AlertCmp {
   }
 
   rbClick(checkedInput: any) {
-    if (this.isEnabled()) {
+    if (this.enabled) {
       this.d.inputs.forEach(input => {
         input.checked = (checkedInput === input);
       });
@@ -535,13 +534,13 @@ class AlertCmp {
   }
 
   cbClick(checkedInput: any) {
-    if (this.isEnabled()) {
+    if (this.enabled) {
       checkedInput.checked = !checkedInput.checked;
     }
   }
 
   bdClick() {
-    if (this.isEnabled() && this.d.enableBackdropDismiss) {
+    if (this.enabled && this.d.enableBackdropDismiss) {
       let cancelBtn = this.d.buttons.find(b => b.role === 'cancel');
       if (cancelBtn) {
         this.btnClick(cancelBtn, 1);
@@ -577,10 +576,6 @@ class AlertCmp {
       values[i.name] = i.value;
     });
     return values;
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 }
 

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -376,14 +376,13 @@ class AlertCmp {
     inputs?: any[];
     enableBackdropDismiss?: boolean;
   };
+  private enabled: boolean;
   private hdrId: string;
   private id: number;
-  private subHdrId: string;
-  private msgId: string;
   private inputType: string;
-  private created: number;
   private lastClick: number;
-  private enabled: boolean;
+  private msgId: string;
+  private subHdrId: string;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -406,7 +405,6 @@ class AlertCmp {
     this.subHdrId = 'alert-subhdr-' + this.id;
     this.msgId = 'alert-msg-' + this.id;
     this.activeId = '';
-    this.created = Date.now();
     this.lastClick = 0;
 
     if (this.d.message) {

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -170,10 +170,9 @@ export class Loading extends ViewController {
 })
 class LoadingCmp {
   private d: any;
-  private id: number;
-  private created: number;
-  private showSpinner: boolean;
   private enabled: boolean;
+  private id: number;
+  private showSpinner: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -183,7 +182,6 @@ class LoadingCmp {
     renderer: Renderer
   ) {
     this.d = params.data;
-    this.created = Date.now();
 
     if (this.d.cssClass) {
       renderer.setElementClass(_elementRef.nativeElement, this.d.cssClass, true);

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -170,7 +170,6 @@ export class Loading extends ViewController {
 })
 class LoadingCmp {
   private d: any;
-  private enabled: boolean;
   private id: number;
   private showSpinner: boolean;
 
@@ -188,7 +187,6 @@ class LoadingCmp {
     }
 
     this.id = (++loadingIds);
-    this.enabled = false;
   }
 
   ngOnInit() {
@@ -210,15 +208,10 @@ class LoadingCmp {
 
     // If there is a duration, dismiss after that amount of time
     this.d.duration ? setTimeout(() => this.dismiss('backdrop'), this.d.duration) : null;
-    this.enabled = true;
   }
 
   dismiss(role: any): Promise<any> {
     return this._viewCtrl.dismiss(null, role);
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 }
 

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -173,6 +173,7 @@ class LoadingCmp {
   private id: number;
   private created: number;
   private showSpinner: boolean;
+  private enabled:boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -189,6 +190,7 @@ class LoadingCmp {
     }
 
     this.id = (++loadingIds);
+    this.enabled = false;
   }
 
   ngOnInit() {
@@ -210,6 +212,7 @@ class LoadingCmp {
 
     // If there is a duration, dismiss after that amount of time
     this.d.duration ? setTimeout(() => this.dismiss('backdrop'), this.d.duration) : null;
+    this.enabled = true;
   }
 
   dismiss(role: any): Promise<any> {
@@ -217,8 +220,7 @@ class LoadingCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 }
 

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -173,7 +173,7 @@ class LoadingCmp {
   private id: number;
   private created: number;
   private showSpinner: boolean;
-  private enabled:boolean;
+  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,

--- a/src/components/picker/picker.ts
+++ b/src/components/picker/picker.ts
@@ -5,7 +5,7 @@ import {Animation} from '../../animations/animation';
 import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {isPresent, isString, isNumber, clamp} from '../../util/util';
-import {KeyboardConstants} from '../../util/keyboard-constants';
+import {Key} from '../../util/key';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 import {raf, cancelRaf, CSS, pointerCoord} from '../../util/dom';
@@ -481,7 +481,6 @@ class PickerDisplayCmp {
 
     this.id = (++pickerIds);
     this.lastClick = 0;
-    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -545,8 +544,8 @@ class PickerDisplayCmp {
 
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
-    if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === KeyboardConstants.ENTER) {
+    if (this.enabled && this._viewCtrl.isLast()) {
+      if (ev.keyCode === Key.ENTER) {
         if (this.lastClick + 1000 < Date.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
@@ -557,7 +556,7 @@ class PickerDisplayCmp {
           this.btnClick(button);
         }
 
-      } else if (ev.keyCode === KeyboardConstants.ESCAPE) {
+      } else if (ev.keyCode === Key.ESCAPE) {
         console.debug('picker, escape button');
         this.bdClick();
       }
@@ -578,7 +577,7 @@ class PickerDisplayCmp {
   }
 
   btnClick(button: any, dismissDelay?: number) {
-    if (!this.isEnabled()) {
+    if (!this.enabled) {
       return;
     }
 
@@ -604,7 +603,7 @@ class PickerDisplayCmp {
   }
 
   bdClick() {
-    if (this.isEnabled() && this.d.enableBackdropDismiss) {
+    if (this.enabled && this.d.enableBackdropDismiss) {
       this.dismiss('backdrop');
     }
   }
@@ -624,10 +623,6 @@ class PickerDisplayCmp {
       };
     });
     return selected;
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 }
 

--- a/src/components/picker/picker.ts
+++ b/src/components/picker/picker.ts
@@ -460,10 +460,9 @@ class PickerColumnCmp {
 class PickerDisplayCmp {
   @ViewChildren(PickerColumnCmp) private _cols: QueryList<PickerColumnCmp>;
   private d: PickerOptions;
-  private created: number;
+  private enabled: boolean;
   private lastClick: number;
   private id: number;
-  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -481,7 +480,6 @@ class PickerDisplayCmp {
     }
 
     this.id = (++pickerIds);
-    this.created = Date.now();
     this.lastClick = 0;
     this.enabled = false;
   }

--- a/src/components/picker/picker.ts
+++ b/src/components/picker/picker.ts
@@ -5,6 +5,7 @@ import {Animation} from '../../animations/animation';
 import {Transition, TransitionOptions} from '../../transitions/transition';
 import {Config} from '../../config/config';
 import {isPresent, isString, isNumber, clamp} from '../../util/util';
+import {KeyboardConstants} from '../../util/keyboard-constants';
 import {NavParams} from '../nav/nav-params';
 import {ViewController} from '../nav/view-controller';
 import {raf, cancelRaf, CSS, pointerCoord} from '../../util/dom';
@@ -462,6 +463,7 @@ class PickerDisplayCmp {
   private created: number;
   private lastClick: number;
   private id: number;
+  private enabled: boolean;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -481,6 +483,7 @@ class PickerDisplayCmp {
     this.id = (++pickerIds);
     this.created = Date.now();
     this.lastClick = 0;
+    this.enabled = false;
   }
 
   ionViewLoaded() {
@@ -545,7 +548,7 @@ class PickerDisplayCmp {
   @HostListener('body:keyup', ['$event'])
   private _keyUp(ev: KeyboardEvent) {
     if (this.isEnabled() && this._viewCtrl.isLast()) {
-      if (ev.keyCode === 13) {
+      if (ev.keyCode === KeyboardConstants.ENTER) {
         if (this.lastClick + 1000 < Date.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
@@ -556,7 +559,7 @@ class PickerDisplayCmp {
           this.btnClick(button);
         }
 
-      } else if (ev.keyCode === 27) {
+      } else if (ev.keyCode === KeyboardConstants.ESCAPE) {
         console.debug('picker, escape button');
         this.bdClick();
       }
@@ -573,6 +576,7 @@ class PickerDisplayCmp {
     if (focusableEle) {
       focusableEle.focus();
     }
+    this.enabled = true;
   }
 
   btnClick(button: any, dismissDelay?: number) {
@@ -625,8 +629,7 @@ class PickerDisplayCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 }
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -172,6 +172,7 @@ class PopoverCmp {
   private id: number;
   private created: number;
   private showSpinner: boolean;
+  private enabled: boolean;
 
   constructor(private _loader: DynamicComponentLoader,
     private _elementRef: ElementRef,
@@ -188,6 +189,7 @@ class PopoverCmp {
     }
 
     this.id = (++popoverIds);
+    this.enabled = false;
   }
 
   ionViewWillEnter() {
@@ -204,6 +206,7 @@ class PopoverCmp {
     if (document.activeElement) {
       activeElement.blur();
     }
+    this.enabled = true;
   }
 
   dismiss(role: any): Promise<any> {
@@ -222,8 +225,7 @@ class PopoverCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 }
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -187,7 +187,6 @@ class PopoverCmp {
     }
 
     this.id = (++popoverIds);
-    this.enabled = false;
   }
 
   ionViewWillEnter() {
@@ -217,13 +216,9 @@ class PopoverCmp {
   }
 
   bdClick() {
-    if (this.isEnabled() && this.d.enableBackdropDismiss) {
+    if (this.enabled && this.d.enableBackdropDismiss) {
       this.dismiss('backdrop');
     }
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 }
 

--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -169,10 +169,9 @@ class PopoverCmp {
   @ViewChild('viewport', {read: ViewContainerRef}) viewport: ViewContainerRef;
 
   private d: any;
-  private id: number;
-  private created: number;
-  private showSpinner: boolean;
   private enabled: boolean;
+  private id: number;
+  private showSpinner: boolean;
 
   constructor(private _loader: DynamicComponentLoader,
     private _elementRef: ElementRef,
@@ -182,7 +181,6 @@ class PopoverCmp {
     private _viewCtrl: ViewController
   ) {
     this.d = _navParams.data.opts;
-    this.created = Date.now();
 
     if (this.d.cssClass) {
       _renderer.setElementClass(_elementRef.nativeElement, this.d.cssClass, true);

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -165,6 +165,7 @@ class ToastCmp {
   private created: number;
   private id: number;
   private dismissTimeout: number = undefined;
+  private enabled: boolean;
 
   constructor(
     private _nav: NavController,
@@ -186,6 +187,7 @@ class ToastCmp {
     if (this.d.message) {
       this.hdrId = 'toast-hdr-' + this.id;
     }
+    this.enabled = false;
   }
 
   ionViewDidEnter() {
@@ -207,6 +209,7 @@ class ToastCmp {
           this.dismiss('backdrop');
         }, this.d.duration);
     }
+    this.enabled = true;
   }
 
   cbClick() {
@@ -222,8 +225,7 @@ class ToastCmp {
   }
 
   isEnabled() {
-    let tm = this._config.getNumber('overlayCreatedDiff', 750);
-    return (this.created + tm < Date.now());
+    return this.enabled;
   }
 
 }

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -185,7 +185,6 @@ class ToastCmp {
     if (this.d.message) {
       this.hdrId = 'toast-hdr-' + this.id;
     }
-    this.enabled = false;
   }
 
   ionViewDidEnter() {
@@ -211,7 +210,7 @@ class ToastCmp {
   }
 
   cbClick() {
-    if (this.isEnabled()) {
+    if (this.enabled) {
       this.dismiss('close');
     }
   }
@@ -220,10 +219,6 @@ class ToastCmp {
     clearTimeout(this.dismissTimeout);
     this.dismissTimeout = undefined;
     return this._viewCtrl.dismiss(null, role);
-  }
-
-  isEnabled() {
-    return this.enabled;
   }
 
 }

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -161,11 +161,10 @@ const TOAST_POSITION_BOTTOM: string = 'bottom';
 class ToastCmp {
   private d: any;
   private descId: string;
-  private hdrId: string;
-  private created: number;
-  private id: number;
   private dismissTimeout: number = undefined;
   private enabled: boolean;
+  private hdrId: string;
+  private id: number;
 
   constructor(
     private _nav: NavController,
@@ -177,7 +176,6 @@ class ToastCmp {
   ) {
 
     this.d = params.data;
-    this.created = Date.now();
 
     if (this.d.cssClass) {
       renderer.setElementClass(_elementRef.nativeElement, this.d.cssClass, true);

--- a/src/util/key.ts
+++ b/src/util/key.ts
@@ -1,4 +1,4 @@
-export enum KeyboardConstants {
+export enum Key {
   ENTER = <any> 13,
   ESCAPE = <any> 27,
   TAB = <any> 9

--- a/src/util/keyboard-constants.ts
+++ b/src/util/keyboard-constants.ts
@@ -1,0 +1,5 @@
+export enum KeyboardConstants{
+  ENTER = <any> 13,
+  ESCAPE = <any> 27,
+  TAB = <any> 9
+};

--- a/src/util/keyboard-constants.ts
+++ b/src/util/keyboard-constants.ts
@@ -1,4 +1,4 @@
-export enum KeyboardConstants{
+export enum KeyboardConstants {
   ENTER = <any> 13,
   ESCAPE = <any> 27,
   TAB = <any> 9

--- a/src/util/keyboard.ts
+++ b/src/util/keyboard.ts
@@ -3,6 +3,7 @@ import {Injectable, NgZone} from '@angular/core';
 import {Config} from '../config/config';
 import {Form} from './form';
 import {hasFocusedTextInput, nativeRaf, rafFrames, nativeTimeout} from './dom';
+import {KeyboardConstants} from './keyboard-constants';
 
 /**
  * @name Keyboard
@@ -152,7 +153,7 @@ export class Keyboard {
 
     // default is to add the focus-outline when the tab key is used
     function keyDown(ev: KeyboardEvent) {
-      if (!isKeyInputEnabled && ev.keyCode === 9) {
+      if (!isKeyInputEnabled && ev.keyCode === KeyboardConstants.TAB) {
         isKeyInputEnabled = true;
         enableKeyInput();
       }

--- a/src/util/keyboard.ts
+++ b/src/util/keyboard.ts
@@ -3,7 +3,7 @@ import {Injectable, NgZone} from '@angular/core';
 import {Config} from '../config/config';
 import {Form} from './form';
 import {hasFocusedTextInput, nativeRaf, rafFrames, nativeTimeout} from './dom';
-import {KeyboardConstants} from './keyboard-constants';
+import {Key} from './key';
 
 /**
  * @name Keyboard
@@ -153,7 +153,7 @@ export class Keyboard {
 
     // default is to add the focus-outline when the tab key is used
     function keyDown(ev: KeyboardEvent) {
-      if (!isKeyInputEnabled && ev.keyCode === KeyboardConstants.TAB) {
+      if (!isKeyInputEnabled && ev.keyCode === Key.TAB) {
         isKeyInputEnabled = true;
         enableKeyInput();
       }


### PR DESCRIPTION
This PR does two things:

1.  It sets the enablement of overlays after the ionViewDidEnter event fires instead of the previous method which was to set enabled to true based on a config value that was not set by default, or the default of 3/4 of a second.

2.  Introduces the concept of an enum for KeyboardConstants to reduce the magic numbers we have in our application.