### PR TITLE
fix(toast): close toasts when two or more are open

### DIFF
--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -1,4 +1,4 @@
-import {Component, ElementRef, Renderer, Output, EventEmitter} from '@angular/core';
+import {Component, ElementRef, Renderer, Output, EventEmitter, AfterViewInit} from '@angular/core';
 
 import {ActionSheet, ActionSheetOptions} from '../action-sheet/action-sheet';
 import {Animation} from '../../animations/animation';
@@ -158,7 +158,7 @@ const TOAST_POSITION_BOTTOM: string = 'bottom';
     '[attr.aria-describedby]': 'descId',
   },
 })
-class ToastCmp {
+class ToastCmp implements AfterViewInit {
   private d: any;
   private descId: string;
   private hdrId: string;
@@ -188,7 +188,7 @@ class ToastCmp {
     }
   }
 
-  ionViewDidEnter() {
+  ngAfterViewInit() {
     const { activeElement }: any = document;
     if (activeElement) {
       activeElement.blur();

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -189,6 +189,16 @@ class ToastCmp implements AfterViewInit {
   }
 
   ngAfterViewInit() {
+    // if there's a `duration` set, automatically dismiss.
+    if (this.d.duration) {
+      this.dismissTimeout =
+        setTimeout(() => {
+          this.dismiss('backdrop');
+        }, this.d.duration);
+    }
+  }
+
+  ionViewDidEnter() {
     const { activeElement }: any = document;
     if (activeElement) {
       activeElement.blur();
@@ -198,14 +208,6 @@ class ToastCmp implements AfterViewInit {
 
     if (focusableEle) {
       focusableEle.focus();
-    }
-
-    // if there's a `duration` set, automatically dismiss.
-    if (this.d.duration) {
-      this.dismissTimeout =
-        setTimeout(() => {
-          this.dismiss('backdrop');
-        }, this.d.duration);
     }
   }
 

--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -26,7 +26,7 @@ const _reflect: any = Reflect;
 /**
  * @name ionicBootstrap
  * @description
- * `ionicBootstrap` allows you to bootstrap your entire application. Similar to Angualr's `bootstrap`, `ionicBootstrap`
+ * `ionicBootstrap` allows you to bootstrap your entire application. Similar to Angular's `bootstrap`, `ionicBootstrap`
  * takes a root component in order to start the app. You can pass along any providers that you may want to inject into your
  * app as an array for the second argument. You can also pass a config object as the third argument to configure your app's settings.
  *


### PR DESCRIPTION
#### Short description of what this resolves:
If you open two or more toasts at a time, that have a duration, they will now all close when their duration runs out instead of being stuck open.

#### Changes proposed in this pull request:

- Remove code from ionViewDidEnter and put inside ngAfterViewInit

**Ionic Version**: 2.x

**Fixes**: #6657 

