### PR TITLE
fix(range): keeps sliding after releasing mouse outside the window

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -415,7 +415,7 @@ export class Range {
 
     } else {
       removes.push(renderer.listenGlobal('body', 'mousemove', this.pointerMove.bind(this)));
-      removes.push(renderer.listenGlobal('body', 'mouseup', this.pointerUp.bind(this)));
+      removes.push(renderer.listenGlobal('window', 'mouseup', this.pointerUp.bind(this)));
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
closes #6802

#### Changes proposed in this pull request:

- Easy fix, listening for window.mouseup event instead of body.mouseup


**Ionic Version**: 2.x

