### PR TITLE
fix(click-block): click block is now showing on all screns.  It wasn'…

### DIFF
--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -187,7 +187,7 @@ function setupDom(window: Window, document: Document, config: Config, platform: 
     bodyEle.classList.add('enable-hover');
   }
 
-  if (config.get('clickBlock')) {
+  if ( config.get('clickBlock') !== false ) {
     clickBlock.enable();
   }
 

--- a/src/platform/registry.ts
+++ b/src/platform/registry.ts
@@ -95,7 +95,6 @@ Platform.register({
   ],
   settings: {
     autoFocusAssist: 'delay',
-    clickBlock: true,
     hoverCSS: false,
     inputBlurring: isIOSDevice,
     inputCloning: isIOSDevice,
@@ -150,7 +149,6 @@ Platform.register({
   settings: {
     mode: 'wp',
     autoFocusAssist: 'immediate',
-    clickBlock: true,
     hoverCSS: false
   },
   isMatch(p: Platform): boolean {


### PR DESCRIPTION
This change enables the click block on all devices unless it is explicitly set to false.

@adamdbradley, I tried a few permutations of getting the config value as a boolean, etc and this seemed to be the best way to do it.

Thanks,
Dan