### PR TITLE
docs(nav-bar): Remove strange </table></br> tags

### DIFF
--- a/js/angular/directive/navBar.js
+++ b/js/angular/directive/navBar.js
@@ -42,7 +42,6 @@
  * @param {boolean=} no-tap-scroll By default, the navbar will scroll the content
  * to the top when tapped.  Set no-tap-scroll to true to disable this behavior.
  *
- * </table><br/>
  */
 IonicModule
 .directive('ionNavBar', function() {


### PR DESCRIPTION
#### Short description of what this resolves:

There is a strange `</table>` tag in the documentation.
I think it is a typo.

#### Changes proposed in this pull request:

Remove it.

**Ionic Version**: 1.x
