### PR TITLE
fix(navigation): keep the click block up longer if the keyboard is open

### DIFF
--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -1178,7 +1178,12 @@ export class NavController extends Ion {
         transAnimation.duration(0);
       }
 
-      let duration = transAnimation.getDuration();
+      let KEYBOARD_DURATION_PADDING = 0;
+      if ( this._keyboard.isOpen() ){
+        // add 700ms to the click block just to be sure the keyboard is closed
+        KEYBOARD_DURATION_PADDING = 700;
+      }
+      let duration = transAnimation.getDuration() + KEYBOARD_DURATION_PADDING;
       let enableApp = (duration < 64);
       // block any clicks during the transition and provide a
       // fallback to remove the clickblock if something goes wrong

--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -1178,12 +1178,12 @@ export class NavController extends Ion {
         transAnimation.duration(0);
       }
 
-      let KEYBOARD_DURATION_PADDING = 0;
-      if ( this._keyboard.isOpen() ){
-        // add 700ms to the click block just to be sure the keyboard is closed
-        KEYBOARD_DURATION_PADDING = 700;
+      let keyboardDurationPadding = 0;
+      if ( this._keyboard.isOpen() ) {
+        // add XXms to the duration the app is disabled when the keyboard is open
+        keyboardDurationPadding = 600;
       }
-      let duration = transAnimation.getDuration() + KEYBOARD_DURATION_PADDING;
+      let duration = transAnimation.getDuration() + keyboardDurationPadding;
       let enableApp = (duration < 64);
       // block any clicks during the transition and provide a
       // fallback to remove the clickblock if something goes wrong


### PR DESCRIPTION
The PR adds 700ms of padding to the duration if the keyboard is open.  Typically on iOS, it takes about ~550ms of time to close the keyboard on my iPhone 6S.  Once the transition is complete, the click block is disabled per the existing app logic.  Basically, this has minimal to none effect on Android.  On iOS, where it takes a bit to dismiss the keyboard, this prevents another transition from happening until the transition is complete, which will take ~550ms longer than usual when the keyboard is open.