### PR TITLE
Update virtual-scroll docs to use let syntax

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -34,7 +34,7 @@ import {VirtualFooter, VirtualHeader, VirtualItem} from './virtual-item';
  * ```html
  * <ion-list [virtualScroll]="items">
  *
- *   <ion-item *virtualItem="#item">
+ *   <ion-item *virtualItem="let item">
  *     {% raw %}{{ item }}{% endraw %}
  *   </ion-item>
  *
@@ -55,11 +55,11 @@ import {VirtualFooter, VirtualHeader, VirtualItem} from './virtual-item';
  * ```html
  * <ion-list [virtualScroll]="items" [headerFn]="myHeaderFn">
  *
- *   <ion-item-divider *virtualHeader="#header">
+ *   <ion-item-divider *virtualHeader="let header">
  *     Header: {% raw %}{{ header }}{% endraw %}
  *   </ion-item-divider>
  *
- *   <ion-item *virtualItem="#item">
+ *   <ion-item *virtualItem="let item">
  *     Item: {% raw %}{{ item }}{% endraw %}
  *   </ion-item>
  *
@@ -119,7 +119,7 @@ import {VirtualFooter, VirtualHeader, VirtualItem} from './virtual-item';
  * ```html
  * <ion-list [virtualScroll]="items">
  *
- *   <ion-item *virtualItem="#item">
+ *   <ion-item *virtualItem="let item">
  *     <ion-avatar item-left>
  *       <ion-img [src]="item.avatarUrl"></ion-img>
  *     </ion-avatar>


### PR DESCRIPTION
Change `#item` to `let item` syntax for the VirtualScroll component. This changed in beta7 due to the angular2 update to RC1. See https://github.com/driftyco/ionic/blob/2.0/CHANGELOG.md#angular-update-to-200-rc1

**Ionic Version**: 2.0.0-beta.8

