### PR TITLE
fix(toast): toast will now be enabled

### DIFF
--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -195,6 +195,7 @@ class ToastCmp implements AfterViewInit {
           this.dismiss('backdrop');
         }, this.d.duration);
     }
+    this.enabled = true;
   }
 
   ionViewDidEnter() {
@@ -208,7 +209,6 @@ class ToastCmp implements AfterViewInit {
     if (focusableEle) {
       focusableEle.focus();
     }
-    this.enabled = true;
   }
 
   cbClick() {


### PR DESCRIPTION
#### Short description of what this resolves:
Toast will now be enabled even when other toasts, or other components that have `fireOtherLifecycleEvents` set to false, have been opened before.

#### Changes proposed in this pull request:

- move `this.enable` to `ngAfterViewInit`

**Ionic Version**: 2.0.0

