### PR TITLE
fix(tabs): swipeBackEnabled works with tabs as expected

### DIFF
--- a/src/components/input/native-input.ts
+++ b/src/components/input/native-input.ts
@@ -31,7 +31,7 @@ export class NativeInput {
   }
 
   @HostListener('input', ['$event'])
-  private _change(ev) {
+  private _change(ev: any) {
     this.valueChange.emit(ev.target.value);
   }
 
@@ -40,9 +40,9 @@ export class NativeInput {
     var self = this;
 
     self.focusChange.emit(true);
-
-    function docTouchEnd(ev) {
-      var tapped: HTMLElement = ev.target;
+    
+    function docTouchEnd(ev: TouchEvent) {
+      var tapped = <HTMLElement>ev.target;
       if (tapped && self.element()) {
         if (tapped.tagName !== 'INPUT' && tapped.tagName !== 'TEXTAREA' && !tapped.classList.contains('input-cover')) {
           self.element().blur();
@@ -178,7 +178,7 @@ export class NativeInput {
 
 }
 
-function cloneInput(focusedInputEle, addCssClass) {
+function cloneInput(focusedInputEle: any, addCssClass: string) {
   let clonedInputEle = focusedInputEle.cloneNode(true);
   clonedInputEle.classList.add('cloned-input');
   clonedInputEle.classList.add(addCssClass);
@@ -191,7 +191,7 @@ function cloneInput(focusedInputEle, addCssClass) {
   return clonedInputEle;
 }
 
-function removeClone(focusedInputEle, queryCssClass) {
+function removeClone(focusedInputEle: any, queryCssClass: string) {
   let clonedInputEle = focusedInputEle.parentElement.querySelector('.' + queryCssClass);
   if (clonedInputEle) {
     clonedInputEle.parentNode.removeChild(clonedInputEle);

--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -1784,6 +1784,13 @@ export class NavController extends Ion {
   }
 
   /**
+   * @private
+   */
+  isSwipeBackEnabled(): boolean {
+    return this._sbEnabled;
+  }
+
+  /**
    * Returns the root `NavController`.
    * @returns {NavController}
    */

--- a/src/components/nav/nav.ts
+++ b/src/components/nav/nav.ts
@@ -191,7 +191,6 @@ export class Nav extends NavController implements AfterViewInit {
   get swipeBackEnabled(): boolean {
     return this._sbEnabled;
   }
-
   set swipeBackEnabled(val: boolean) {
     this._sbEnabled = isTrueProperty(val);
   }

--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -202,6 +202,17 @@ export class Tab extends NavController {
   }
 
   /**
+   * @input {boolean} Whether it's possible to swipe-to-go-back on this tab or not.
+   */
+  @Input()
+  get swipeBackEnabled(): boolean {
+    return this._sbEnabled;
+  }
+  set swipeBackEnabled(val: boolean) {
+    this._sbEnabled = isTrueProperty(val);
+  }
+
+  /**
    * @output {Tab} Method to call when the current tab is selected
    */
   @Output() ionSelect: EventEmitter<Tab> = new EventEmitter();
@@ -221,6 +232,10 @@ export class Tab extends NavController {
     super(parentTabs, app, config, keyboard, elementRef, zone, renderer, compiler);
 
     parentTabs.add(this);
+
+    if (parentTabs.rootNav) {
+      this._sbEnabled = parentTabs.rootNav.isSwipeBackEnabled();
+    }    
 
     this._panelId = 'tabpanel-' + this.id;
     this._btnId = 'tab-' + this.id;

--- a/src/components/tabs/test/advanced/index.ts
+++ b/src/components/tabs/test/advanced/index.ts
@@ -411,7 +411,7 @@ class Tab3Page1 {
 
 
 @Component({
-  template: '<ion-nav [root]="root"></ion-nav>'
+  template: '<ion-nav [root]="root" swipeBackEnabled="false"></ion-nav>'
 })
 class E2EApp {
   root = SignIn;

--- a/src/components/tabs/test/advanced/tabs.html
+++ b/src/components/tabs/test/advanced/tabs.html
@@ -1,6 +1,6 @@
 
 <ion-tabs preloadTabs="false" (ionChange)="onTabChange()">
-  <ion-tab tabTitle="Recents" tabIcon="call" [root]="tab1Root" [rootParams]="params"></ion-tab>
+  <ion-tab tabTitle="Recents" tabIcon="call" [root]="tab1Root" [rootParams]="params" swipeBackEnabled="true"></ion-tab>
   <ion-tab tabTitle="Favorites" tabIcon="star" [root]="tab2Root"></ion-tab>
   <ion-tab tabTitle="Settings" tabIcon="settings" [root]="tab3Root"></ion-tab>
   <ion-tab tabTitle="Chat" tabIcon="chatbubbles" (ionSelect)="chat()"></ion-tab>


### PR DESCRIPTION
#### Short description of what this resolves:
https://github.com/driftyco/ionic/issues/6099

>No problem @manucorporat . I was able to reproduce it simply by switching the application to a tabs setup. I used the supplied tabs.ts and tabs.html. It seems that the swipeBackEnabled works when not using tabs, but is overridden when using tabs. Perhaps because tabs have their own navigation stack?
http://plnkr.co/edit/fB3VofAwyYoFcEF009Co
Note: I was using mobile safari on an iPhone to test this plunker. Let me know if there is a way around this for now. I can't seem to find one. I tried adding swipeBackEnabled to the actual tabs component and that didn't seem to work either." 


^ reported by @iaguilera14 (https://github.com/driftyco/ionic/issues/6099#issuecomment-226223015)

#### Changes proposed in this pull request:

- swipeBackEnabled input work in `<ion-tab>`  

 ```html
<ion-tab tabTitle="Recents" tabIcon="call" [root]="tab1Root" [rootParams]="params" swipeBackEnabled="true"></ion-tab>
```

- `ion-tab` inherits the `swipeBackEnabled` property from his nav controller parent.

**Ionic Version**: 2.x


