### PR TITLE
Checks if scrollView is present

### DIFF
--- a/js/angular/directive/refresher.js
+++ b/js/angular/directive/refresher.js
@@ -101,7 +101,9 @@ IonicModule
 
         $scope.$on('scroll.refreshComplete', function() {
           $scope.$evalAsync(function() {
-            scrollCtrl.scrollView.finishPullToRefresh();
+            if(scrollCtrl.scrollView){
+              scrollCtrl.scrollView.finishPullToRefresh();
+            }
           });
         });
       }


### PR DESCRIPTION
#### Short description of what this resolves:
If the scroll.refreshComplete message is broadcast and the DOM has not been rendered, the refresher will throw.  We had a standard refresh that could be set by a pull, or simply a view activation. 

#### Changes proposed in this pull request:
Check to see of the scrollView is present before calling a pullToRefresh.

**Ionic Version**: 1.x / 2.x

**Fixes**: #

