### PR TITLE
Sliding Items work with list reorder

### DIFF
--- a/demos/item-sliding/index.ts
+++ b/demos/item-sliding/index.ts
@@ -1,17 +1,52 @@
-import { Component } from '@angular/core';
+import { Component, ViewEncapsulation } from '@angular/core';
 
 import { ionicBootstrap, ItemSliding, NavController, Toast } from 'ionic-angular';
 
 
 @Component({
-  templateUrl: 'main.html'
+  templateUrl: 'main.html',
+  encapsulation: ViewEncapsulation.None
 })
 class ApiDemoPage {
   chats: any[];
   logins: any[];
+  editButton: string = 'Edit';
+  editing: boolean = false;
 
   constructor(private nav: NavController) {
     this.chats = [
+    {
+      img: './avatar-cher.png',
+      name: 'Cher',
+      message: 'Ugh. As if.',
+      time: '9:38 pm'
+    }, {
+      img: './avatar-dionne.png',
+      name: 'Dionne',
+      message: 'Mr. Hall was way harsh.',
+      time: '8:59 pm'
+    }, {
+      img: './avatar-murray.png',
+      name: 'Murray',
+      message: 'Excuse me, "Ms. Dione."',
+      time: 'Wed'
+    },
+    {
+      img: './avatar-cher.png',
+      name: 'Cher',
+      message: 'Ugh. As if.',
+      time: '9:38 pm'
+    }, {
+      img: './avatar-dionne.png',
+      name: 'Dionne',
+      message: 'Mr. Hall was way harsh.',
+      time: '8:59 pm'
+    }, {
+      img: './avatar-murray.png',
+      name: 'Murray',
+      message: 'Excuse me, "Ms. Dione."',
+      time: 'Wed'
+    },
     {
       img: './avatar-cher.png',
       name: 'Cher',
@@ -47,6 +82,15 @@ class ApiDemoPage {
         name: 'Codepen',
         username: 'administrator',
     }];
+  }
+
+  toggleEdit() {
+    this.editing = !this.editing;
+    if (this.editing) {
+      this.editButton = 'Done';
+    } else {
+      this.editButton = 'Edit';
+    }
   }
 
   more(item: ItemSliding) {

--- a/demos/item-sliding/main.html
+++ b/demos/item-sliding/main.html
@@ -2,19 +2,24 @@
 
   <ion-navbar>
     <ion-title>Item Sliding</ion-title>
+    <ion-buttons end>
+      <button (click)="toggleEdit()">{{editButton}}</button>
+    </ion-buttons>
   </ion-navbar>
 
 </ion-header>
 
 
-<ion-content class="outer-content">
+<ion-content class="outer-content" fullscreen>
 
-  <ion-list class="chat-sliding-demo">
+  <ion-list class="chat-sliding-demo" [sliding]="!editing">
     <ion-list-header>
       Chats
     </ion-list-header>
 
-    <ion-item-sliding *ngFor="let chat of chats; let ref = index" [ref]="ref" #item>
+    <ion-item-group [reorder]="editing">
+
+    <ion-item-sliding *ngFor="let chat of chats" #item>
       <ion-item>
         <ion-avatar item-left>
           <img [src]="chat.img">
@@ -41,13 +46,14 @@
         </button>
       </ion-item-options>
 
-      <ion-item-options side="left">
+      <ion-item-options side="left" (ionSwipe)="archive(item)">
         <button primary expandable (click)="archive(item)">
           <ion-icon name="archive"></ion-icon>
           Archive
         </button>
       </ion-item-options>
     </ion-item-sliding>
+    </ion-item-group>
   </ion-list>
 
   <ion-list class="login-sliding-demo">
@@ -86,6 +92,12 @@
 <style>
   #download-spinner {
     display: none;
+  }
+  
+  div.toolbar-background {
+    background-color: rgba(255, 255, 255, 0.65);
+    -webkit-backdrop-filter: saturate(180%) blur(20px);
+    backdrop-filter: saturate(180%) blur(20px);
   }
 
   svg circle {

--- a/scripts/demos/index.template.dev.html
+++ b/scripts/demos/index.template.dev.html
@@ -20,13 +20,12 @@
   <script>
   System.config({
     map: {
-      '@angular/core': '/node_modules/@angular/core/core.umd.js',
-      '@angular/compiler': '/node_modules/@angular/compiler/compiler.umd.js',
-      '@angular/common': '/node_modules/@angular/common/common.umd.js',
-      '@angular/http': '/node_modules/@angular/http/http.umd.js',
-      '@angular/platform-browser': '/node_modules/@angular/platform-browser/platform-browser.umd.js',
-      '@angular/platform-browser-dynamic': '/node_modules/@angular/platform-browser-dynamic/platform-browser-dynamic.umd.js',
-      '@angular/router': '/node_modules/@angular/router/router.umd.js',
+      '@angular/core': '/node_modules/@angular/core/bundles/core.umd.js',
+      '@angular/compiler': '/node_modules/@angular/compiler/bundles/compiler.umd.js',
+      '@angular/common': '/node_modules/@angular/common/bundles/common.umd.js',
+      '@angular/http': '/node_modules/@angular/http/bundles/http.umd.js',
+      '@angular/platform-browser': '/node_modules/@angular/platform-browser/bundles/platform-browser.umd.js',
+      '@angular/platform-browser-dynamic': '/node_modules/@angular/platform-browser-dynamic/bundles/platform-browser-dynamic.umd.js',
       'ionic-angular': '/src'
     },
     packages: {

--- a/src/components/item/item-reorder.scss
+++ b/src/components/item/item-reorder.scss
@@ -24,7 +24,9 @@ ion-reorder {
 
 .reorder-enabled {
 
-  .item {
+  .item, .item-wrapper {
+    transition: transform 300ms;
+
     will-change: transform;
   }
 
@@ -40,6 +42,7 @@ ion-reorder {
 }
 
 
+.item-wrapper.reorder-active,
 .item.reorder-active {
   z-index: 4;
 

--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -1,6 +1,171 @@
-import { Component, ElementRef, forwardRef, Inject } from '@angular/core';
+import { Component, Directive, ElementRef, EventEmitter, forwardRef, Input, NgZone, Renderer, Inject, Optional, Output } from '@angular/core';
 
+import { Content } from '../content/content';
+import { CSS } from '../../util/dom';
 import { Item } from './item';
+import { ItemReorderGesture } from '../item/item-reorder-gesture';
+import { isTrueProperty } from '../../util/util';
+
+export interface ReorderIndexes {
+  from: number;
+  to: number;
+}
+
+/**
+ * @private
+ */
+@Directive({
+  selector: '[reorder]',
+  host: {
+    '[class.reorder-enabled]': '_enableReorder',
+  }
+})
+export class Reorder {
+  private _enableReorder: boolean = false;
+  private _reorderGesture: ItemReorderGesture;
+  private _lastToIndex: number = -1;
+  private _element: HTMLElement;
+
+  @Output() ionItemReorder: EventEmitter<ReorderIndexes> = new EventEmitter<ReorderIndexes>();
+
+  constructor(
+    elementRef: ElementRef,
+    private _rendered: Renderer,
+    private _zone: NgZone,
+    @Optional() private _content: Content) {
+    this._element = elementRef.nativeElement;
+  }
+
+  /**
+   * @private
+   */
+  ngOnDestroy() {
+    this._element = null;
+    this._reorderGesture && this._reorderGesture.destroy();
+  }
+
+
+  @Input()
+  get reorder(): boolean {
+    return this._enableReorder;
+  }
+  set reorder(val: boolean) {
+    this._enableReorder = isTrueProperty(val);
+
+    if (!this._enableReorder) {
+      this._reorderGesture && this._reorderGesture.destroy();
+      this._reorderGesture = null;
+
+    } else if (!this._reorderGesture) {
+      console.debug('enableReorderItems');
+      this._reorderGesture = new ItemReorderGesture(this);
+    }
+  }
+
+  /**
+   * @private
+   */
+  reorderStart() {
+    let children = this._element.children;
+    let len = children.length;
+    this.setCssClass('reorder-active', true);
+    for (let i = 0; i < len; i++) {
+      children[i]['$ionIndex'] = i;
+    }
+  }
+
+  /**
+   * @private
+   */
+  reorderEmit(fromIndex: number, toIndex: number) {
+    this.reorderReset();
+    if (fromIndex !== toIndex) {
+      this._zone.run(() => {
+        this.ionItemReorder.emit({
+          from: fromIndex,
+          to: toIndex,
+        });
+      });
+    }
+  }
+
+  /**
+   * @private
+   */
+  scrollContent(scroll: number) {
+    let scrollTop = this._content.getScrollTop() + scroll;
+    if (scroll !== 0) {
+      this._content.scrollTo(0, scrollTop, 0);
+    }
+    return scrollTop;
+  }
+
+  /**
+   * @private
+   */
+  reorderReset() {
+    let children = this._element.children;
+    let len = children.length;
+
+    this.setCssClass('reorder-active', false);
+    let transform = CSS.transform;
+    for (let i = 0; i < len; i++) {
+      children[i].style[transform] = '';
+    }
+    this._lastToIndex = -1;
+  }
+
+  /**
+   * @private
+   */
+  reorderMove(fromIndex: number, toIndex: number, itemHeight: number) {
+    if (this._lastToIndex === -1) {
+      this._lastToIndex = fromIndex;
+    }
+    let lastToIndex = this._lastToIndex;
+    this._lastToIndex = toIndex;
+
+    // TODO: I think both loops can be merged into a single one
+    // but I had no luck last time I tried
+
+    /********* DOM READ ********** */
+    let children = this._element.children;
+
+    /********* DOM WRITE ********* */
+    let transform = CSS.transform;
+    if (toIndex >= lastToIndex) {
+      for (var i = lastToIndex; i <= toIndex; i++) {
+        if (i !== fromIndex) {
+          children[i].style[transform] = (i > fromIndex)
+            ? `translateY(${-itemHeight}px)` : '';
+        }
+      }
+    }
+
+    if (toIndex <= lastToIndex) {
+      for (var i = toIndex; i <= lastToIndex; i++) {
+        if (i !== fromIndex) {
+          children[i].style[transform] = (i < fromIndex)
+            ? `translateY(${itemHeight}px)` : '';
+        }
+      }
+    }
+  }
+
+  /**
+   * @private
+   */
+  setCssClass(classname: string, add: boolean) {
+    this._rendered.setElementClass(this._element, classname, add);
+  }
+
+  /**
+   * @private
+   */
+  getNativeElement(): HTMLElement {
+    return this._element;
+  }
+}
 
 /**
  * @private
@@ -11,8 +176,18 @@ import { Item } from './item';
 })
 export class ItemReorder {
   constructor(
-    @Inject(forwardRef(() => Item)) item: Item,
-    elementRef: ElementRef) {
-    elementRef.nativeElement['$ionComponent'] = item;
+    @Inject(forwardRef(() => Item)) private item: Item,
+    private elementRef: ElementRef) {
   }
+
+  ngAfterContentInit() {
+    let item = this.item.getNativeElement();
+    if (item.parentNode.nodeName === 'ION-ITEM-SLIDING') {
+      this.elementRef.nativeElement['$ionReorderNode'] = item.parentNode;
+    } else {
+      this.elementRef.nativeElement['$ionReorderNode'] = item;
+    }
+  }
+
+
 }

--- a/src/components/item/item-sliding-gesture.ts
+++ b/src/components/item/item-sliding-gesture.ts
@@ -70,38 +70,40 @@ export class ItemSlidingGesture extends DragGesture {
   }
 
   onDragEnd(ev: any) {
-    if (this.selectedContainer) {
-      ev.preventDefault();
+    if (!this.selectedContainer) {
+      return;
+    }
+    ev.preventDefault();
 
-      let openAmount = this.selectedContainer.endSliding(ev.velocityX);
-      this.selectedContainer = null;
+    let openAmount = this.selectedContainer.endSliding(ev.velocityX);
+    this.selectedContainer = null;
 
-      // TODO: I am not sure listening for a tap event is the best idea
-      // we should try mousedown/touchstart
-      if (openAmount === 0) {
-        this.openContainer = null;
-        this.off('tap', this.onTap);
-        this.onTap = null;
-      } else if (!this.onTap) {
-        this.onTap = (event: any) => this.onTapCallback(event);
-        this.on('tap', this.onTap);
-      }
+    // TODO: I am not sure listening for a tap event is the best idea
+    // we should try mousedown/touchstart
+    if (openAmount === 0) {
+      this.openContainer = null;
+      this.off('tap', this.onTap);
+      this.onTap = null;
+    } else if (!this.onTap) {
+      this.onTap = (event: any) => this.onTapCallback(event);
+      this.on('tap', this.onTap);
     }
   }
 
   closeOpened(): boolean {
-    if (this.openContainer) {
-      this.openContainer.close();
-      this.openContainer = null;
-      this.selectedContainer = null;
-      this.off('tap', this.onTap);
-      this.onTap = null;
-      return true;
+    if (!this.openContainer) {
+      return false;
     }
-    return false;
+    this.openContainer.close();
+    this.openContainer = null;
+    this.selectedContainer = null;
+    this.off('tap', this.onTap);
+    this.onTap = null;
+    return true;
   }
 
   unlisten() {
+    this.closeOpened();
     super.unlisten();
     this.list = null;
   }

--- a/src/components/item/item-sliding.scss
+++ b/src/components/item/item-sliding.scss
@@ -71,9 +71,11 @@ ion-item-sliding.active-slide {
     z-index: $z-index-item-options + 1;
 
     opacity: 1;
-    transition: all 300ms cubic-bezier(.36, .66, .04, 1);
+    transition: transform 500ms cubic-bezier(.36, .66, .04, 1); 
 
     pointer-events: none;
+
+    will-change: transform;
   }
 
   ion-item-options {

--- a/src/components/item/item.ts
+++ b/src/components/item/item.ts
@@ -294,11 +294,6 @@ export class Item {
   /**
    * @private
    */
-  @Input() index: number;
-
-  /**
-   * @private
-   */
   id: string;
 
   /**
@@ -308,7 +303,6 @@ export class Item {
 
   constructor(form: Form, private _renderer: Renderer, private _elementRef: ElementRef) {
     this.id = form.nextId().toString();
-    _elementRef.nativeElement['$ionComponent'] = this;
   }
 
   /**
@@ -331,20 +325,6 @@ export class Item {
     if (this._inputs.length > 1) {
       this.setCssClass('item-multiple-inputs', true);
     }
-  }
-
-  /**
-   * @private
-   */
-  setCssClass(cssClass: string, shouldAdd: boolean) {
-    this._renderer.setElementClass(this._elementRef.nativeElement, cssClass, shouldAdd);
-  }
-
-  /**
-   * @private
-   */
-  setCssStyle(property: string, value: string) {
-    this._renderer.setElementStyle(this._elementRef.nativeElement, property, value);
   }
 
   /**
@@ -406,15 +386,22 @@ export class Item {
   /**
    * @private
    */
-  getNativeElement() {
-    return this._elementRef.nativeElement;
+  setCssClass(cssClass: string, shouldAdd: boolean) {
+    this._renderer.setElementClass(this._elementRef.nativeElement, cssClass, shouldAdd);
   }
 
   /**
    * @private
    */
-  height(): number {
-    return this._elementRef.nativeElement.offsetHeight;
+  setCssStyle(property: string, value: string) {
+    this._renderer.setElementStyle(this._elementRef.nativeElement, property, value);
+  }
+
+  /**
+   * @private
+   */
+  getNativeElement(): HTMLElement {
+    return this._elementRef.nativeElement;
   }
 }
 

--- a/src/components/item/test/reorder/index.ts
+++ b/src/components/item/test/reorder/index.ts
@@ -1,5 +1,5 @@
 import {Component, ChangeDetectorRef} from '@angular/core';
-import {ionicBootstrap} from '../../../../../src';
+import {ionicBootstrap, reorderArray} from '../../../../../src';
 
 
 @Component({
@@ -21,9 +21,7 @@ class E2EPage {
   }
 
   reorder(indexes: any) {
-    let element = this.items[indexes.from];
-    this.items.splice(indexes.from, 1);
-    this.items.splice(indexes.to, 0, element);
+    this.items = reorderArray(this.items, indexes);
   }
 }
 

--- a/src/components/item/test/reorder/main.html
+++ b/src/components/item/test/reorder/main.html
@@ -10,8 +10,7 @@
 <ion-content>
   
   <ion-list [reorder]="isReordering" (ionItemReorder)="reorder($event)">
-    <ion-item *ngFor="let item of items; let index=index"
-    [index]="index"
+    <ion-item *ngFor="let item of items"
     [style.background]="'rgb('+(255-item*4)+','+(255-item*4)+','+(255-item*4)+')'"
     [style.height]="item*2+35+'px'"> 
       {{item}}

--- a/src/components/list/list.ts
+++ b/src/components/list/list.ts
@@ -4,8 +4,6 @@ import { Content } from '../content/content';
 import { Ion } from '../ion';
 import { isTrueProperty } from '../../util/util';
 import { ItemSlidingGesture } from '../item/item-sliding-gesture';
-import { ItemReorderGesture } from '../item/item-reorder-gesture';
-import { nativeTimeout } from '../../util/dom';
 
 /**
  * The List is a widely used interface element in almost any mobile app,
@@ -25,20 +23,13 @@ import { nativeTimeout } from '../../util/dom';
  */
 @Directive({
   selector: 'ion-list',
-  host: {
-    '[class.reorder-enabled]': '_enableReorder',
-  }
 })
 export class List extends Ion {
-  private _enableReorder: boolean = false;
-  private _enableSliding: boolean = false;
+  private _enableSliding: boolean = true;
+  private _containsSlidingItems: boolean = false;
   private _slidingGesture: ItemSlidingGesture;
-  private _reorderGesture: ItemReorderGesture;
-  private _lastToIndex: number = -1;
 
-  @Output() ionItemReorder: EventEmitter<{ from: number, to: number }> = new EventEmitter<{ from: number, to: number }>();
-
-  constructor(elementRef: ElementRef, private _rendered: Renderer, private _zone: NgZone, @Optional() private _content: Content) {
+  constructor(elementRef: ElementRef, private _rendered: Renderer) {
     super(elementRef);
   }
 
@@ -47,7 +38,6 @@ export class List extends Ion {
    */
   ngOnDestroy() {
     this._slidingGesture && this._slidingGesture.destroy();
-    this._reorderGesture && this._reorderGesture.destroy();
   }
 
   /**
@@ -70,19 +60,37 @@ export class List extends Ion {
    * ```
    * @param {boolean} shouldEnable whether the item-sliding should be enabled or not
    */
-  enableSlidingItems(shouldEnable: boolean) {
-    if (this._enableSliding === shouldEnable) {
-      return;
-    }
+  @Input()
+  get sliding(): boolean {
+    return this._enableSliding;
+  }
+  set sliding(val: boolean) {
+    this._enableSliding = isTrueProperty(val);
+    this._updateSlidingState();
+  }
 
-    this._enableSliding = shouldEnable;
-    if (shouldEnable) {
-      console.debug('enableSlidingItems');
-      nativeTimeout(() => this._slidingGesture = new ItemSlidingGesture(this));
-    } else {
+
+  /**
+   * @private
+   */
+  containsSlidingItem(contains: boolean) {
+    this._containsSlidingItems = contains;
+    this._updateSlidingState();
+  }
+
+  
+  private _updateSlidingState() {
+    let shouldSlide = this._enableSliding && this._containsSlidingItems;
+    if (!shouldSlide) {
       this._slidingGesture && this._slidingGesture.unlisten();
+      this._slidingGesture = null;
+
+    } else if (!this._slidingGesture) {
+      console.debug('enableSlidingItems');
+      this._slidingGesture = new ItemSlidingGesture(this);
     }
   }
+
 
   /**
    * Close the open sliding item.
@@ -106,111 +114,6 @@ export class List extends Ion {
   closeSlidingItems() {
     this._slidingGesture && this._slidingGesture.closeOpened();
   }
-
-  setCssClass(classname: string, add: boolean) {
-    this._rendered.setElementClass(this.getNativeElement(), classname, add);
-  }
-
-  reorderStart() {
-    this.setCssClass('reorder-active', true);
-  }
-
-  /**
-   * @private
-   */
-  reorderEmit(fromIndex: number, toIndex: number) {
-    this.reorderReset();
-    if (fromIndex !== toIndex) {
-      this._zone.run(() => {
-        this.ionItemReorder.emit({
-          from: fromIndex,
-          to: toIndex,
-        });
-      });
-    }
-  }
-
-  /**
-   * @private
-   */
-  scrollContent(scroll: number) {
-    let scrollTop = this._content.getScrollTop() + scroll;
-    if (scroll !== 0) {
-      this._content.scrollTo(0, scrollTop, 0);
-    }
-    return scrollTop;
-  }
-
-  /**
-   * @private
-   */
-  reorderReset() {
-    let children = this.elementRef.nativeElement.children;
-    let len = children.length;
-    this.setCssClass('reorder-active', false);
-    for (let i = 0; i < len; i++) {
-      children[i].style.transform = '';
-    }
-    this._lastToIndex = -1;
-  }
-
-  /**
-   * @private
-   */
-  reorderMove(fromIndex: number, toIndex: number, itemHeight: number) {
-    if (this._lastToIndex === -1) {
-      this._lastToIndex = fromIndex;
-    }
-    let lastToIndex = this._lastToIndex;
-    this._lastToIndex = toIndex;
-
-    // TODO: I think both loops can be merged into a single one
-    // but I had no luck last time I tried
-
-    /********* DOM READ ********** */
-    let children = this.elementRef.nativeElement.children;
-
-    /********* DOM WRITE ********* */
-    if (toIndex >= lastToIndex) {
-      for (var i = lastToIndex; i <= toIndex; i++) {
-        if (i !== fromIndex) {
-          children[i].style.transform = (i > fromIndex)
-            ? `translateY(${-itemHeight}px)` : '';
-        }
-      }
-    }
-
-    if (toIndex <= lastToIndex) {
-      for (var i = toIndex; i <= lastToIndex; i++) {
-        if (i !== fromIndex) {
-          children[i].style.transform = (i < fromIndex)
-            ? `translateY(${itemHeight}px)` : '';
-        }
-      }
-    }
-  }
-
-  @Input()
-  get reorder(): boolean {
-    return this._enableReorder;
-  }
-
-  set reorder(val: boolean) {
-    let enabled = isTrueProperty(val);
-    if (this._enableReorder === enabled) {
-      return;
-    }
-
-    this._enableReorder = enabled;
-    if (enabled) {
-      console.debug('enableReorderItems');
-      nativeTimeout(() => this._reorderGesture = new ItemReorderGesture(this));
-
-    } else {
-      this._reorderGesture && this._reorderGesture.destroy();
-    }
-  }
-
 }
 
 

--- a/src/config/directives.ts
+++ b/src/config/directives.ts
@@ -19,6 +19,7 @@ import { Tabs } from '../components/tabs/tabs';
 import { Tab } from '../components/tabs/tab';
 import { List, ListHeader } from '../components/list/list';
 import { Item, ItemContent } from '../components/item/item';
+import { Reorder } from '../components/item/item-reorder';
 import { ItemSliding, ItemOptions } from '../components/item/item-sliding';
 import { VirtualScroll } from '../components/virtual-scroll/virtual-scroll';
 import { VirtualItem, VirtualHeader, VirtualFooter } from '../components/virtual-scroll/virtual-item';
@@ -145,6 +146,7 @@ export const IONIC_DIRECTIVES: any[] = [
   ItemContent,
   ItemSliding,
   ItemOptions,
+  Reorder,
   VirtualScroll,
   VirtualItem,
   VirtualHeader,

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export * from './util/click-block';
 export * from './util/events';
 export * from './util/keyboard';
 export * from './util/form';
+export { reorderArray } from './util/util';
 
 export * from './animations/animation';
 export * from './transitions/page-transition';

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -175,3 +175,11 @@ export function getQuerystring(url: string): any {
   }
   return queryParams;
 }
+
+
+export function reorderArray(array: any[], indexes: {from: number, to: number}): any[] {
+  let element = array[indexes.from];
+  array.splice(indexes.from, 1);
+  array.splice(indexes.to, 0, element);
+  return array;
+}


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

- New `ion-list` attribute: `sliding`. Sliding can be disabled by setting:
`<ion-list sliding="false">`
- New `ItemBase` class for common methods between `Item` and `ItemSliding`
- SlidingItem animation should be slower

**Ionic Version**:  2.x

**Fixes**: #6845 (and more...)
