### PR TITLE
feat(content): iOS only scroll bounce

### DIFF
--- a/src/components/button/test/basic/main.html
+++ b/src/components/button/test/basic/main.html
@@ -7,7 +7,7 @@
 </ion-header>
 
 
-<ion-content padding style="text-align:center">
+<ion-content padding style="text-align:center" no-bounce>
 
   <p>
     <button><span>Default</span></button>

--- a/src/components/content/content.ios.scss
+++ b/src/components/content/content.ios.scss
@@ -45,3 +45,27 @@ ion-page.show-page ~ .nav-decor {
 // --------------------------------------------------
 
 @include content-margin($content-ios-margin);
+
+
+// iOS Content Scroll
+// --------------------------------------------------
+
+ion-content:not([no-bounce]) > scroll-content {
+  &::before,
+  &::after {
+    position: absolute;
+
+    width: 1px;
+    height: 1px;
+
+    content: "";
+  }
+
+  &::before {
+    bottom: -1px;
+  }
+
+  &::after {
+    top: -1px;
+  }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
https://github.com/driftyco/ionic/issues/5275


#### Changes proposed in this pull request:

- New `no-bounce` attribute to disable over-scroll bouncing

**Ionic Version**: 2.x

**Fixes**: #5275
