### PR TITLE
fix(button): outline buttons does not have hairline borders in iOS

### DIFF
--- a/src/components/button/button.ios.scss
+++ b/src/components/button/button.ios.scss
@@ -132,10 +132,6 @@ $button-ios-small-icon-font-size:     1.3em !default;
   }
 }
 
-&.hairlines .button-outline {
-  border-width: $hairlines-width;
-}
-
 // iOS Outline Button Color Mixin
 // --------------------------------------------------
 


### PR DESCRIPTION


**Ionic Version**: 2.x


