### PR TITLE
(docs) Modal - remove unused Page component import

### DIFF
--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -37,7 +37,7 @@ import { windowDimensions } from '../../util/dom';
  *
  * @usage
  * ```ts
- * import { Page, Modal, NavController, NavParams } from 'ionic-angular';
+ * import { Modal, NavController, NavParams } from 'ionic-angular';
  *
  * @Component(...)
  * class HomePage {


### PR DESCRIPTION
#### Short description of what this resolves:
Documentation fix - the Modal dialog documentation previously used the Page decorator. This was updated in 73635f393974dc6c44f69cf7814d22243f80a5c5 to use the Component decorator instead, but the Page import still exists. This commit removes it.

#### Changes proposed in this pull request:

- Remove unused import in documentation

**Ionic Version**: 2.x

**Fixes**: #

The Page decorator usage was removed in 73635f393974dc6c44f69cf7814d22243f80a5c5, but the import is still there.