### PR TITLE
(docs) Nav - remove Page component reference

### DIFF
--- a/src/components/nav/nav.ts
+++ b/src/components/nav/nav.ts
@@ -22,8 +22,7 @@ import { ViewController } from './view-controller';
  * For more information on using navigation controllers like Nav or [Tab](../../Tabs/Tab/),
  * take a look at the [NavController API Docs](../NavController/).
  *
- * You must set a root page (where page is any [@Page](../../config/Page/)
- * component) to be loaded initially by any Nav you create, using
+ * You must set a root page to be loaded initially by any Nav you create, using
  * the 'root' property:
  *
  * @usage


### PR DESCRIPTION
#### Short description of what this resolves:
`ion-nav` docs refer to the deprecated Page decorator. The example code is already correct.

#### Changes proposed in this pull request:
- Remove Page component reference in docs

**Ionic Version**: 2.x
