### PR TITLE
adding scroll-complete event to ionScroll directive

### DIFF
--- a/js/angular/directive/scroll.js
+++ b/js/angular/directive/scroll.js
@@ -31,6 +31,7 @@
  * @param {boolean=} paging Whether to scroll with paging.
  * @param {expression=} on-refresh Called on pull-to-refresh, triggered by an {@link ionic.directive:ionRefresher}.
  * @param {expression=} on-scroll Called whenever the user scrolls.
+ * @param {expression=} on-scroll-complete Called whenever the scrolling paging is completed.
  * @param {boolean=} scrollbar-x Whether to show the horizontal scrollbar. Default true.
  * @param {boolean=} scrollbar-y Whether to show the vertical scrollbar. Default true.
  * @param {boolean=} zooming Whether to support pinch-to-zoom
@@ -66,6 +67,7 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
           direction: '@',
           paging: '@',
           $onScroll: '&onScroll',
+          $onScrollComplete: '&onScrollComplete',
           scroll: '@',
           scrollbarX: '@',
           scrollbarY: '@',
@@ -107,7 +109,8 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
           maxZoom: $scope.$eval($scope.maxZoom) || 3,
           minZoom: $scope.$eval($scope.minZoom) || 0.5,
           preventDefault: true,
-          nativeScrolling: nativeScrolling
+          nativeScrolling: nativeScrolling,
+          scrollingComplete: onScrollComplete
         };
 
         if (isPaging) {
@@ -115,10 +118,17 @@ function($timeout, $controller, $ionicBind, $ionicConfig) {
           scrollViewOptions.bouncing = false;
         }
 
-        $controller('$ionicScroll', {
+        var scrollCtrl = $controller('$ionicScroll', {
           $scope: $scope,
           scrollViewOptions: scrollViewOptions
         });
+
+        function onScrollComplete() {
+          $scope.$onScrollComplete && $scope.$onScrollComplete({
+            scrollTop: scrollCtrl.scrollView.__scrollTop,
+            scrollLeft: scrollCtrl.scrollView.__scrollLeft
+          });
+        }
       }
     }
   };


### PR DESCRIPTION
#### Short description of what this resolves:

The onScrollComplete event is missing from ionScroll directive. This is very handy when using this directive with the paging option enabled. All the infrastructure to handle this event was done, just reusing it for this directive.

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

