### PR TITLE
fix(ionTabs): center tabbar content

### DIFF
--- a/src/components/tabs/tabs.ios.scss
+++ b/src/components/tabs/tabs.ios.scss
@@ -18,6 +18,7 @@ $tab-button-ios-inactive-color:       $toolbar-ios-inactive-color !default;
 ion-tabbar {
   border-top: 1px solid $toolbar-ios-border-color;
   background: $tabbar-ios-background;
+  justify-content: center;
 }
 
 ion-tabs[tabbarPlacement=top] ion-tabbar {


### PR DESCRIPTION
#### Short description of what this resolves:
Aligns content of ionTabs to the center

#### Changes proposed in this pull request:

- add `  justify-content: center;` to tabs.ios.scss

**Ionic Version**: 1.x / 2.x 
2.x


