### PR TITLE
fix(): slides not rendering correctly

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -396,7 +396,7 @@ export class Slides extends Ion {
     setTimeout(() => {
       var swiper = new Swiper(this.getNativeElement().children[0], options);
       this.slider = swiper;
-    });
+    }, 300);
 
     /*
     * TODO: Finish this
@@ -736,7 +736,7 @@ export class Slides extends Ion {
       if (this.length() > 10) {
         this.showPager = false;
       }
-    });
+    }, 300);
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Slides that are on the first page of an app getting stuck and not being able to be swiped about 70% of the time

#### Changes proposed in this pull request:

- add 300ms delays to two timeouts

**Ionic Version**: 2.x
