### PR TITLE
fix(loading): clear timeout if dismissed before timeout is done

### DIFF
--- a/src/components/loading/loading-component.ts
+++ b/src/components/loading/loading-component.ts
@@ -35,6 +35,7 @@ export class LoadingCmp {
   private d: any;
   private id: number;
   private showSpinner: boolean;
+  private durationTimeout: number;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -70,10 +71,13 @@ export class LoadingCmp {
     }
 
     // If there is a duration, dismiss after that amount of time
-    this.d.duration ? setTimeout(() => this.dismiss('backdrop'), this.d.duration) : null;
+    this.d.duration ? this.durationTimeout = setTimeout(() => this.dismiss('backdrop'), this.d.duration) : null;
   }
 
   dismiss(role: any): Promise<any> {
+    if (this.d.duration) {
+      clearTimeout(this.durationTimeout);
+    }
     return this._viewCtrl.dismiss(null, role);
   }
 }

--- a/src/components/loading/loading-component.ts
+++ b/src/components/loading/loading-component.ts
@@ -75,7 +75,7 @@ export class LoadingCmp {
   }
 
   dismiss(role: any): Promise<any> {
-    if (this.d.duration) {
+    if (this.durationTimeout) {
       clearTimeout(this.durationTimeout);
     }
     return this._viewCtrl.dismiss(null, role);


### PR DESCRIPTION
#### Short description of what this resolves:
This resolves dismiss getting fired twice if the component is dismissed before the duration is complete.

#### Changes proposed in this pull request:

- if there is a duration clear the timeout if the component is dismissed before the timeout has completed.

**Ionic Version**: 2.x

**Fixes**: #7197 

