### PR TITLE
i think it should be(refresh) not (ionRefresh)

### DIFF
--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -25,7 +25,7 @@ import { PointerEvents, UIEventManager } from '../../util/ui-event-manager';
  * ```html
  * <ion-content>
  *
- *   <ion-refresher (ionRefresh)="doRefresh($event)">
+ *   <ion-refresher (refresh)="doRefresh($event)">
  *     <ion-refresher-content></ion-refresher-content>
  *   </ion-refresher>
  *
@@ -59,7 +59,7 @@ import { PointerEvents, UIEventManager } from '../../util/ui-event-manager';
  *  ```html
  *  <ion-content>
  *
- *    <ion-refresher (ionRefresh)="doRefresh($event)">
+ *    <ion-refresher (refresh)="doRefresh($event)">
  *      <ion-refresher-content
  *        pullingIcon="arrow-dropdown"
  *        pullingText="Pull to refresh"


### PR DESCRIPTION
#### Short description of what this resolves:

seems like there is no binding with (ionRefresh), but there is  a binding with (refresh) 
#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

the event seems to be named refresh not ionRefresh, so the expression binding should be done with the refresh instead of refreshing