### PR TITLE
Added the import statement to the usage example.

### DIFF
--- a/src/platform/storage/sql.ts
+++ b/src/platform/storage/sql.ts
@@ -17,6 +17,8 @@ const win: any = window;
  *
  * @usage
  ```js
+ * import {Storage, IStorageEngine} from 'node_modules\ionic-angular\platform\storage'
+ * 
  * let storage = new Storage(SqlStorage, options);
  * storage.set('name', 'Max');
  * storage.get('name').then((name) => {


### PR DESCRIPTION
#### Short description of what this resolves:
- Problems in typescript where Storage is unknown or where you are directed to the wrong Storage interface by your IDE

#### Changes proposed in this pull request:

- Added the import statement in the usage example

**Ionic Version**: 1.x / 2.x

**Fixes**: #

It is very useful for users to know where Storage comes from especially since e.g. WebStorm will autocomplete the search for Storage to a different interface.