### PR TITLE
fix(bootstrap): skip cssReady() if platform is "core"

### DIFF
--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -48,13 +48,23 @@ export function ionicBootstrap(appRootComponent: any, customProviders?: Array<an
   // automatically set "ion-app" selector to users root component
   addSelector(appRootComponent, 'ion-app');
 
-  cssReady(() => {
+  // Do not check if CSS is ready if isBrowser flag is set to true
+  // since it makes the site loading slow (~8 seconds)
+  if (config.isBrowser) {
     // call angular bootstrap
     bootstrap(appRootComponent, providers).then(ngComponentRef => {
       // ionic app has finished bootstrapping
       ionicPostBootstrap(ngComponentRef);
     });
-  });
+  } else {
+    cssReady(() => {
+      // call angular bootstrap
+      bootstrap(appRootComponent, providers).then(ngComponentRef => {
+        // ionic app has finished bootstrapping
+        ionicPostBootstrap(ngComponentRef);
+      });
+    });
+  }
 }
 
 

--- a/src/config/bootstrap.ts
+++ b/src/config/bootstrap.ts
@@ -42,15 +42,23 @@ const _reflect: any = Reflect;
  * ```
  */
 export function ionicBootstrap(appRootComponent: any, customProviders?: Array<any>, config?: any) {
+  // create an instance of Config
+  if (!(config instanceof Config)) {
+    config = new Config(config);
+  }
+
   // get all Ionic Providers
   let providers = ionicProviders(customProviders, config);
+
+  const platform = new Platform();
+  this.initializePlatform(platform, config);
 
   // automatically set "ion-app" selector to users root component
   addSelector(appRootComponent, 'ion-app');
 
-  // Do not check if CSS is ready if isBrowser flag is set to true
+  // Do not check if CSS is ready if platform is 'core'
   // since it makes the site loading slow (~8 seconds)
-  if (config.isBrowser) {
+  if (platform.is('core')) {
     // call angular bootstrap
     bootstrap(appRootComponent, providers).then(ngComponentRef => {
       // ionic app has finished bootstrapping
@@ -118,13 +126,7 @@ export function ionicProviders(customProviders?: Array<any>, config?: any): any[
 
   // create an instance of Platform
   let platform = new Platform();
-
-  // initialize platform
-  platform.setUrl(window.location.href);
-  platform.setUserAgent(window.navigator.userAgent);
-  platform.setNavigatorPlatform(window.navigator.platform);
-  platform.load(config);
-  config.setPlatform(platform);
+  this.initializePlatform(platform, config);
 
   let clickBlock = new ClickBlock();
   let events = new Events();
@@ -258,4 +260,16 @@ export function addSelector(type: any, selector: string) {
       _reflect.defineMetadata('annotations', annotations, type);
     }
   }
+}
+
+/**
+ * @private
+ */
+export function initializePlatform(platform: Platform, config: Config) {
+  // initialize platform
+  platform.setUrl(window.location.href);
+  platform.setUserAgent(window.navigator.userAgent);
+  platform.setNavigatorPlatform(window.navigator.platform);
+  platform.load(config);
+  config.setPlatform(platform);
 }


### PR DESCRIPTION
#### Short description of what this resolves:
If ionic is used in desktop (browser) it takes ~8-10 seconds for cssReady() function to bootstrap the app delaying the site being displayed.

We're using this in prod environment :)

#### Changes proposed in this pull request:

- Check if `platform.is('core')` and skip `cssReady()` if `true`

**Ionic Version**: 2.0.0-beta.10

