### PR TITLE
docs(nav-controller): fix insertPages jsdocs

### DIFF
--- a/src/components/nav/nav-controller.ts
+++ b/src/components/nav/nav-controller.ts
@@ -571,7 +571,7 @@ export class NavController extends Ion {
    * in and become the active page.
    *
    * @param {number} insertIndex  The index where you want to insert the page.
-   * @param {array<{page: Page, params=: any}>} insertPages  An array of objects, each with a `page` and optionally `params` property.
+   * @param {Array<{page: Page, params?: any}>} insertPages  An array of objects, each with a `page` and optionally `params` property.
    * @param {object} [opts={}] Nav options to go with this transition.
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */


### PR DESCRIPTION
My IDE warned me that the parameter `insertPages` wasn't defined in JSDocs. 