### PR TITLE
make sure rapidUpdate doesnt fire before slider is ready

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -396,6 +396,8 @@ export class Slides extends Ion {
     setTimeout(() => {
       var swiper = new Swiper(this.getNativeElement().children[0], options);
       this.slider = swiper;
+
+      this.rapidUpdate();
     }, 300);
 
     /*
@@ -866,8 +868,6 @@ export class Slide {
   ) {
     this.ele = elementRef.nativeElement;
     this.ele.classList.add('swiper-slide');
-
-    slides.rapidUpdate();
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
#### Short description of what this resolves:

If your ion-slide elements are not direct descendants of ion-slider then you get to a situation where the ngOnInit is fired after the ion-slider constructor is firing the rapidUpdate call. This means that the update method cannot find this.slides and fails.
#### Changes proposed in this pull request:
## Proposal is to move the initialisation of rapid update until after this.slider is there
## 
## 

**Ionic Version**: 1.x / 2.x
2
**Fixes**: #
