### PR TITLE
added attribute close-menu-on-tap to ion-side-menu-content. Defaults to true

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -146,18 +146,21 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
    */
   self.openPercentage = function(percentage) {
     var p = percentage / 100;
+    var leaveContentActive = false;
 
     if (self.left && percentage >= 0) {
       self.openAmount(self.left.width * p);
+      leaveContentActive = self.left.leaveContentActive;
     } else if (self.right && percentage < 0) {
       self.openAmount(self.right.width * p);
+      leaveContentActive = self.right.leaveContentActive;
     }
 
-    // add the CSS class "menu-open" if the percentage does not
-    // equal 0, otherwise remove the class from the body element
-    $ionicBody.enableClass((percentage !== 0), 'menu-open');
+    // add the CSS class "menu-open" if don't want to leave content active and the
+    // percentage does not equal 0, otherwise remove the class from the body element
+    $ionicBody.enableClass((!leaveContentActive && percentage !== 0), 'menu-open');
 
-    self.content.setCanScroll(percentage == 0);
+    self.content.setCanScroll(leaveContentActive || percentage == 0);
   };
 
   /*

--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -386,6 +386,14 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
     return self.edgeThresholdEnabled;
   };
 
+  $scope.closeMenuOnTap = true;
+  self.closeMenuOnTap = function(closeMenu) {
+    if (arguments.length) {
+      $scope.closeMenuOnTap = !!closeMenu;
+    }
+    return $scope.closeMenuOnTap;
+  };
+
   self.isDraggableTarget = function(e) {
     //Only restrict edge when sidemenu is closed and restriction is enabled
     var shouldOnlyAllowEdgeDrag = self.edgeThresholdEnabled && !self.isOpen();

--- a/js/angular/directive/sideMenu.js
+++ b/js/angular/directive/sideMenu.js
@@ -13,7 +13,8 @@
  * <ion-side-menu
  *   side="left"
  *   width="myWidthValue + 20"
- *   is-enabled="shouldLeftSideMenuBeEnabled()">
+ *   is-enabled="shouldLeftSideMenuBeEnabled()"
+ *   leave-content-active="shouldLeftSideMenuLeaveMainContentActive()">
  * </ion-side-menu>
  * ```
  * For a complete side menu example, see the
@@ -22,6 +23,7 @@
  * @param {string} side Which side the side menu is currently on.  Allowed values: 'left' or 'right'.
  * @param {boolean=} is-enabled Whether this side menu is enabled.
  * @param {number=} width How many pixels wide the side menu should be.  Defaults to 275.
+ * @param {boolean=} leave-content-active Whether this menu should leave main content active when menu is opened.  Defaults to false.
  */
 IonicModule
 .directive('ionSideMenu', function() {
@@ -32,6 +34,7 @@ IonicModule
     compile: function(element, attr) {
       angular.isUndefined(attr.isEnabled) && attr.$set('isEnabled', 'true');
       angular.isUndefined(attr.width) && attr.$set('width', '275');
+      angular.isUndefined(attr.leaveContentActive) && attr.$set('leaveContentActive', 'false');
 
       element.addClass('menu menu-' + attr.side);
 
@@ -41,7 +44,8 @@ IonicModule
         var sideMenu = sideMenuCtrl[$scope.side] = new ionic.views.SideMenu({
           width: attr.width,
           el: $element[0],
-          isEnabled: true
+          isEnabled: true,
+          leaveContentActive: false
         });
 
         $scope.$watch($attr.width, function(val) {
@@ -53,8 +57,10 @@ IonicModule
         $scope.$watch($attr.isEnabled, function(val) {
           sideMenu.setIsEnabled(!!val);
         });
+        $scope.$watch($attr.leaveContentActive, function(val) {
+          sideMenu.setLeaveContentActive(!!val);
+        });
       };
     }
   };
 });
-

--- a/js/angular/directive/sideMenuContent.js
+++ b/js/angular/directive/sideMenuContent.js
@@ -13,7 +13,8 @@
  * ```html
  * <ion-side-menu-content
  *   edge-drag-threshold="true"
- *   drag-content="true">
+ *   drag-content="true"
+ *   close-menu-on-tap="true">
  * </ion-side-menu-content>
  * ```
  * For a complete side menu example, see the
@@ -24,6 +25,7 @@
    *  - If a non-zero number is given, that many pixels is used as the maximum allowed distance from the edge that starts dragging the side menu.
    *  - If true is given, the default number of pixels (25) is used as the maximum allowed distance.
    *  - If false or 0 is given, the edge drag threshold is disabled, and dragging from anywhere on the content is allowed.
+ * @param {boolean=} close-menu-on-tap Whether the content tap should close side menus.  Default true.
  *
  */
 IonicModule
@@ -59,9 +61,15 @@ function($timeout, $ionicGesture, $window) {
           });
         }
 
+        if (isDefined(attr.closeMenuOnTap)) {
+          $scope.$watch(attr.closeMenuOnTap, function(value) {
+            sideMenuCtrl.closeMenuOnTap(value);
+          });
+        }
+
         // Listen for taps on the content to close the menu
         function onContentTap(gestureEvt) {
-          if (sideMenuCtrl.getOpenAmount() !== 0) {
+          if (sideMenuCtrl.closeMenuOnTap() && sideMenuCtrl.getOpenAmount() !== 0) {
             sideMenuCtrl.close();
             gestureEvt.gesture.srcEvent.preventDefault();
             startCoord = null;

--- a/js/views/sideMenuView.js
+++ b/js/views/sideMenuView.js
@@ -11,6 +11,7 @@
       this.el = opts.el;
       this.isEnabled = (typeof opts.isEnabled === 'undefined') ? true : opts.isEnabled;
       this.setWidth(opts.width);
+      this.leaveContentActive = opts.leaveContentActive;
     },
     getFullWidth: function() {
       return this.width;
@@ -31,6 +32,9 @@
       if(this.el.style.zIndex !== '-1') {
         this.el.style.zIndex = '-1';
       }
+    },
+    setLeaveContentActive: function(leaveContentActive) {
+      this.leaveContentActive = leaveContentActive;
     }
   });
 

--- a/test/unit/angular/controller/sideMenuController.unit.js
+++ b/test/unit/angular/controller/sideMenuController.unit.js
@@ -69,6 +69,18 @@ describe('$ionicSideMenus controller', function() {
     expect(ctrl.right.isEnabled).toEqual(true);
   });
 
+  // Menu leaveContentActive
+  it('should set leaveContentActive', function() {
+    ctrl.left.setLeaveContentActive(true);
+    ctrl.right.setLeaveContentActive(true);
+    expect(ctrl.left.leaveContentActive).toEqual(true);
+    expect(ctrl.right.leaveContentActive).toEqual(true);
+    ctrl.left.setLeaveContentActive(false);
+    ctrl.right.setLeaveContentActive(false);
+    expect(ctrl.left.leaveContentActive).toEqual(false);
+    expect(ctrl.right.leaveContentActive).toEqual(false);
+  });
+
   // Menu widths
   it('should init widths', function() {
     expect(ctrl.left.width).toEqual(270);

--- a/test/unit/angular/directive/sideMenu.unit.js
+++ b/test/unit/angular/directive/sideMenu.unit.js
@@ -219,6 +219,20 @@ describe('Ionic Angular Side Menu', function() {
 
   }));
 
+  it('should closeMenuOnTap', inject(function($compile, $rootScope) {
+    var el = $compile('<ion-side-menus><div ion-side-menu-content></div></ion-side-menus>')($rootScope.$new());
+    $rootScope.$apply();
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(true);
+    expect(el.scope().closeMenuOnTap).toBe(true);
+
+    el.controller('ionSideMenus').closeMenuOnTap(false);
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(false);
+    expect(el.scope().closeMenuOnTap).toBe(false);
+
+    el.controller('ionSideMenus').closeMenuOnTap(true);
+    expect(el.controller('ionSideMenus').closeMenuOnTap()).toBe(true);
+    expect(el.scope().closeMenuOnTap).toBe(true);
+  }));
 });
 
 describe('Ionic Side Menu Content Directive', function () {


### PR DESCRIPTION
#### Short description of what this resolves:
This is useful when you don't want to close the menu when users tap on main content.

#### Changes proposed in this pull request:

- added attribute "close-menu-on-tap" to "ion-side-menu-content" directive. Defaults to true.

**Ionic Version**: 1.x