### PR TITLE
fix(scroll): memory leak on document event listener

### DIFF
--- a/js/views/scrollViewNative.js
+++ b/js/views/scrollViewNative.js
@@ -554,14 +554,13 @@
       var self = this;
       var container = self.__container;
 
-      container.removeEventListener('resetScrollView', self.resetScrollView);
       container.removeEventListener('scroll', self.onScroll);
-
       container.removeEventListener('scrollChildIntoView', self.scrollChildIntoView);
-      container.removeEventListener('resetScrollView', self.resetScrollView);
 
       container.removeEventListener(ionic.EVENTS.touchstart, self.handleTouchMove);
       container.removeEventListener(ionic.EVENTS.touchmove, self.handleTouchMove);
+
+      document.removeEventListener('resetScrollView', self.resetScrollView);
 
       ionic.tap.removeClonedInputs(container, self);
 


### PR DESCRIPTION
#### Short description of what this resolves:

Memory leak on scrollNative

#### Changes proposed in this pull request:

Remove resetScrollView

**Ionic Version**: 1.x

**Fixes**: #4746

PS. I had created pull request about this before (#4807) but it was closed without any comments what-so-ever. While I understand that maintaining large open-source projects takes lots of time and resources, it is not very encouraging.