### PR TITLE
feat(select): add ability set selected text

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -119,7 +119,7 @@ export const SELECT_VALUE_ACCESSOR = new Provider(
   selector: 'ion-select',
   template: `
     <div *ngIf="!_text" class="select-placeholder select-text">{{placeholder}}</div>
-    <div *ngIf="_text" class="select-text">{{_text}}</div>
+    <div *ngIf="_text" class="select-text">{{selectedText || _text}}</div>
     <div class="select-icon">
       <div class="select-icon-inner"></div>
     </div>
@@ -184,6 +184,11 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
    * @input {string} The interface the select should use: `action-sheet` or `alert`. Default: `alert`.
    */
   @Input() interface: string = '';
+  
+  /**
+   * @input {string} The selected text should be showen.
+   */
+  @Input() selectedText: string = '';
 
   /**
    * @output {any} Any expression you want to evaluate when the selection has changed.


### PR DESCRIPTION
Added ability set selected text like md-selected-text

**Ionic Version**: 2.x

Example:
**before**:
<img width="331" alt="screen shot 2016-07-16 at 15 01 53" src="https://cloud.githubusercontent.com/assets/8962340/16894680/66a80be2-4b66-11e6-8de2-10e4b9b6572d.png">

**after**:
```html
<ion-select [(ngModel)]="currency" [selectedText]="selectedText()">
	<ion-option *ngFor="let cur of currencies;" [value]="cur">
		{{cur.symbol}} ({{cur.code}}) {{cur.name}}
	</ion-option>
</ion-select>
```
```ts
public selectedText() {
    return this.currency.symbol;
}
```
<img width="329" alt="screen shot 2016-07-16 at 15 02 27" src="https://cloud.githubusercontent.com/assets/8962340/16894682/759e9c92-4b66-11e6-84e3-7a043a6e796b.png">

//cc @adamdbradley @brandyscarney 