### PR TITLE
Fixed datetime util ISO string to handle negative timezone offsets

### DIFF
--- a/src/util/datetime-util.ts
+++ b/src/util/datetime-util.ts
@@ -390,15 +390,15 @@ export function convertDataToISO(data: DateTimeData): string {
 }
 
 function twoDigit(val: number): string {
-  return ('0' + (isPresent(val) ? val : '0')).slice(-2);
+  return ('0' + (isPresent(val) ? Math.abs(val) : '0')).slice(-2);
 }
 
 function threeDigit(val: number): string {
-  return ('00' + (isPresent(val) ? val : '0')).slice(-3);
+  return ('00' + (isPresent(val) ? Math.abs(val) : '0')).slice(-3);
 }
 
 function fourDigit(val: number): string {
-  return ('000' + (isPresent(val) ? val : '0')).slice(-4);
+  return ('000' + (isPresent(val) ? Math.abs(val) : '0')).slice(-4);
 }
 
 

--- a/src/util/test/datetime-util.spec.ts
+++ b/src/util/test/datetime-util.spec.ts
@@ -34,6 +34,22 @@ describe('convertDataToISO', () => {
     expect(str).toEqual('1994-12-15T13:47:20.789+05:30');
   });
 
+  it('should convert DateTimeData to datetime string, -300 tz offset', () => {
+    var data: datetime.DateTimeData = {
+      year: 1994,
+      month: 12,
+      day: 15,
+      hour: 13,
+      minute: 47,
+      second: 20,
+      millisecond: 789,
+      tzOffset: -300,
+    };
+
+    var str = datetime.convertDataToISO(data);
+    expect(str).toEqual('1994-12-15T13:47:20.789-05:00');
+  });
+
   it('should convert DateTimeData to datetime string, Z timezone', () => {
     var data: datetime.DateTimeData = {
       year: 1994,


### PR DESCRIPTION
#### Short description of what this resolves:
Changes `twoDigit()` `threeDigit()` and `fourDigit()` utility functions in `datetime-util.ts` to strip provided number of negative signs.

**Ionic Version**: 1.x / 2.x
2.0.0-beta-10

**Fixes**: #7358

