### PR TITLE
Updated Storage to LocalStorage and set local type

### DIFF
--- a/src/platform/storage/local-storage.ts
+++ b/src/platform/storage/local-storage.ts
@@ -21,8 +21,11 @@ import { StorageEngine } from './storage';
  *   template: `<ion-content></ion-content>`
  * });
  * export class MyClass{
+ * 
+ *  public local: LocalStorage;
+ * 
  *  constructor(){
- *    this.local = new Storage(LocalStorage);
+ *    this.local = new LocalStorage(LocalStorage);
  *    this.local.set('didTutorial', 'true');
  *  }
  *}


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

The code in the example would not work for me in Ionic v2 beta 10, but creating a new LocalStorage class rather than a Storage class as well as setting the local type of this.local to type LocalStorage solved this for me.