### PR TITLE
fix(searchbar): cant remove default attributes in safari

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -227,8 +227,8 @@ export class Searchbar {
    */
   positionInputPlaceholder(inputEle: HTMLElement, iconEle: HTMLElement) {
     if (this.shouldAlignLeft()) {
-      inputEle.removeAttribute('style');
-      iconEle.removeAttribute('style');
+      inputEle.setAttribute('style', '');
+      iconEle.setAttribute('style', '');
     } else {
       // Create a dummy span to get the placeholder width
       let tempSpan = document.createElement('span');


### PR DESCRIPTION
#### Short description of what this resolves:
In webkit you cannot remove "default" attributes so this fix hacks around that limitation.

#### Changes proposed in this pull request:

- use `setAttribute('style', '')` instead of `removeAttribute('style')`

**Ionic Version**: 2.x

**Fixes**: #7386 

