### PR TITLE
fix(animation): ele as string selector

### DIFF
--- a/src/animations/animation.ts
+++ b/src/animations/animation.ts
@@ -68,13 +68,13 @@ export class Animation {
     var i: number;
 
     if (ele) {
-      if (ele.length) {
+      if (typeof ele === 'string') {
+        ele = document.querySelectorAll(ele);
         for (i = 0; i < ele.length; i++) {
           this._addEle(ele[i]);
         }
 
-      } else if (typeof ele === 'string') {
-        ele = document.querySelectorAll(ele);
+      } else if (ele.length) {
         for (i = 0; i < ele.length; i++) {
           this._addEle(ele[i]);
         }


### PR DESCRIPTION
#### Short description of what this resolves:

fix allowing to create `Animation` providing string element selector

#### Changes proposed in this pull request:

- change the order of `if` blocks in `element` method as strings has also `length` and so the second block was never executed

**Ionic Version**: 2.x
