### PR TITLE
fix(navbar) statusbarPadding not affecting pages navigated to from io…

### DIFF
--- a/src/platform/cordova.ios.scss
+++ b/src/platform/cordova.ios.scss
@@ -10,6 +10,7 @@ $cordova-ios-statusbar-padding-modal-max-width:         $cordova-statusbar-paddi
 ion-nav > ion-page,
 ion-nav > ion-page > ion-header,
 ion-tab > ion-page > ion-header,
+ion-tabs > ion-page > ion-header,
 ion-menu {
   @include toolbar-statusbar-padding($toolbar-ios-height, $content-ios-padding);
   @include toolbar-title-statusbar-padding($toolbar-ios-height, $content-ios-padding);

--- a/src/platform/cordova.md.scss
+++ b/src/platform/cordova.md.scss
@@ -10,6 +10,7 @@ $cordova-md-statusbar-padding-modal-max-width:         $cordova-statusbar-paddin
 ion-nav > ion-page,
 ion-nav > ion-page > ion-header,
 ion-tab > ion-page > ion-header,
+ion-tabs > ion-page > ion-header,
 ion-menu {
   @include toolbar-statusbar-padding($toolbar-md-height, $content-md-padding);
 }

--- a/src/platform/cordova.wp.scss
+++ b/src/platform/cordova.wp.scss
@@ -10,6 +10,7 @@ $cordova-wp-statusbar-padding-modal-max-width:         $cordova-statusbar-paddin
 ion-nav > ion-page,
 ion-nav > ion-page > ion-header,
 ion-tab > ion-page > ion-header,
+ion-tabs > ion-page > ion-header,
 ion-menu {
   @include toolbar-statusbar-padding($toolbar-wp-height, $content-wp-padding);
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Adds CSS selectors for statusbar padding on pages navigated to from an `<ion-tabs>` page

**Ionic Version**:
2.0.0-beta.10

**Fixes**: #7435 