### PR TITLE
Update to use reorder icon

### DIFF
--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -294,7 +294,7 @@ export class ItemReorder {
  */
 @Component({
   selector: 'ion-reorder',
-  template: `<ion-icon name="menu"></ion-icon>`
+  template: `<ion-icon name="reorder"></ion-icon>`
 })
 export class Reorder {
   constructor(


### PR DESCRIPTION
#### Short description of what this resolves:
Reorder template was using the wrong icon.

#### Changes proposed in this pull request:
Change from menu icon to reorder icon.

**Ionic Version**: 1.x / 2.x
2.x
**Fixes**: #

Reorder template is currently using the menu icon instead of reorder icon. I updated the template to use proper reorder icon.