### PR TITLE
docs(): note about ion-img outside virtualscroll

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -115,6 +115,9 @@ import { VirtualFooter, VirtualHeader, VirtualItem } from './virtual-item';
  * makes a HTTP request for the image file. HTTP requests, image
  * decoding, and image rendering can cause issues while scrolling. For virtual
  * scrolling, the natural effects of the `<img>` are not desirable features.
+ * 
+ * Note: `<ion-img>` should only be used with Virtual Scroll. If you are using
+ * an image outside of Virtual Scroll you should use the standard `<img>` tag.
  *
  * ```html
  * <ion-list [virtualScroll]="items">


### PR DESCRIPTION
#### Changes proposed in this pull request:

- adds a note about not using ion-img outside of virtual scroll

**Ionic Version**: 2.x
