### PR TITLE
perf(scroll): promote scroll-content to its own layer

### DIFF
--- a/src/components/app/structure.scss
+++ b/src/components/app/structure.scss
@@ -198,6 +198,7 @@ scroll-content {
   overflow-y: scroll;
   -webkit-overflow-scrolling: touch;
   will-change: scroll-position;
+  backface-visibility: hidden;
 }
 
 ion-content.js-scroll > scroll-content {


### PR DESCRIPTION
#### Short description of what this resolves:
Scrolling has lots of jank due to chrome repainting `scroll-content` continuously while scrolling.

#### Changes proposed in this pull request:

- add `backface-visibility: hidden` to `scroll-content` to promote it to its own layer so that chrome does not repaint while scrolling

**Ionic Version**: 2.x

