### PR TITLE
Removes the 'modal-open' class from body only when there are no more modals shown

### DIFF
--- a/js/angular/service/modal.js
+++ b/js/angular/service/modal.js
@@ -242,7 +242,9 @@ function($rootScope, $ionicBody, $compile, $timeout, $ionicPlatform, $ionicTempl
       }
 
       return $timeout(function() {
-        $ionicBody.removeClass(self.viewType + '-open');
+        if (!modalStack.length) {
+          $ionicBody.removeClass(self.viewType + '-open');
+        }
         self.el.classList.add('hide');
       }, self.hideDelay || 320);
     },


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, the modal-open class is removed when you remove a modal, even if there are still other modals visible. This PR will retain the modal-open class until there are no more visible modals.

#### Changes proposed in this pull request:

- Check length of modalStack before removing the modal-open class

**Ionic Version**: 1.x 
