### PR TITLE
Adding "justDraggable" option to the "range" component

### DIFF
--- a/src/components/range/test/basic/page1.html
+++ b/src/components/range/test/basic/page1.html
@@ -19,12 +19,12 @@
 
   <ion-list>
     <ion-item>
-      <ion-range [(ngModel)]="singleValue" danger pin="true" (ionChange)="rangeChange($event)" [debounce]="100"></ion-range>
+      <ion-range [(ngModel)]="singleValue" danger pin="true" (ionChange)="rangeChange($event)" [debounce]="100" justDraggable="true"></ion-range>
     </ion-item>
 
     <ion-item>
       <ion-label>no init value, default min/max, {{singleValue}}</ion-label>
-      <ion-range [(ngModel)]="singleValue"></ion-range>
+      <ion-range [(ngModel)]="singleValue" justDraggable="true"></ion-range>
     </ion-item>
 
     <ion-item>

--- a/src/components/range/test/basic/page1.html
+++ b/src/components/range/test/basic/page1.html
@@ -19,12 +19,12 @@
 
   <ion-list>
     <ion-item>
-      <ion-range [(ngModel)]="singleValue" danger pin="true" (ionChange)="rangeChange($event)" [debounce]="100" justDraggable="true"></ion-range>
+      <ion-range [(ngModel)]="singleValue" danger pin="true" (ionChange)="rangeChange($event)" [debounce]="100" ></ion-range>
     </ion-item>
 
     <ion-item>
       <ion-label>no init value, default min/max, {{singleValue}}</ion-label>
-      <ion-range [(ngModel)]="singleValue" justDraggable="true"></ion-range>
+      <ion-range [(ngModel)]="singleValue"></ion-range>
     </ion-item>
 
     <ion-item>
@@ -94,6 +94,11 @@
     <ion-item>
       <ion-label>dual, step=3, snaps, {{dualValue2 | json}}</ion-label>
       <ion-range dualKnobs="true" [(ngModel)]="dualValue2" min="21" max="72" step="3" snaps="true"></ion-range>
+    </ion-item>
+
+    <ion-item>
+      <ion-label>justDraggable range, drag knob </ion-label>
+      <ion-range [(ngModel)]="singleValue" justDraggable="true"></ion-range>
     </ion-item>
 
   </ion-list>


### PR DESCRIPTION
#### Short description of what this resolves:
This commit resolves #6956 issue. 


#### Changes proposed in this pull request:
we added a new option named: "justDraggable" to "range" component that is false by default. while it is set to true, range is working only if user drags the knob. In other words, range value does not change by one click or dragging somewhere else in the range bar. 
-
-
-

**Ionic Version**: 2.x 

**Fixes**: #6956
