### PR TITLE
fix(scroll): scroll complete event not triggered

### DIFF
--- a/js/views/scrollView.js
+++ b/js/views/scrollView.js
@@ -2044,7 +2044,11 @@ ionic.views.Scroll = ionic.views.View.inherit({
             // Deactivate pull-to-refresh when decelerating
             if (!self.__refreshActive) {
               self.__startDeceleration(timeStamp);
+            } else {
+              self.__scrollingComplete();
             }
+          } else {
+            self.__scrollingComplete();
           }
         } else {
           self.__scrollingComplete();


### PR DESCRIPTION
#### Short description of what this resolves:

This resolves https://github.com/driftyco/ionic/issues/7272
#### Changes proposed in this pull request:
- Call the __scrollingComplete in the additional places where it should happen

**Ionic Version**: 1.x / 2.x

1.x

**Fixes**: #
#7272

When using the ionic  js scroll the on scroll complete doesn't trigger on devices in certain circumstances

closes #7272
