### PR TITLE
fix(select): fire events after select is dismissed

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -249,7 +249,7 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
       text: this.cancelText,
       role: 'cancel',
       handler: () => {
-        overlay.dismiss().then(() => {
+        overlay.onDidDismiss(() => {
           this.ionCancel.emit(null);
         });
       }
@@ -279,7 +279,7 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
           text: input.text,
           handler: () => {
             this.onChange(input.value);
-            overlay.dismiss().then(() => {
+            overlay.onDidDismiss(() => {
               this.ionChange.emit(input.value);
             });
           }
@@ -326,7 +326,7 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
         text: this.okText,
         handler: (selectedValues: any) => {
           this.onChange(selectedValues);
-          overlay.dismiss().then(() => {
+          overlay.onDidDismiss(() => {
             this.ionChange.emit(selectedValues);
           });
         }

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -249,7 +249,9 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
       text: this.cancelText,
       role: 'cancel',
       handler: () => {
-        this.ionCancel.emit(null);
+        overlay.dismiss().then(() => {
+          this.ionCancel.emit(null);
+        });
       }
     }];
 
@@ -277,7 +279,9 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
           text: input.text,
           handler: () => {
             this.onChange(input.value);
-            this.ionChange.emit(input.value);
+            overlay.dismiss().then(() => {
+              this.ionChange.emit(input.value);
+            });
           }
         };
       }));
@@ -322,7 +326,9 @@ export class Select implements AfterContentInit, ControlValueAccessor, OnDestroy
         text: this.okText,
         handler: (selectedValues: any) => {
           this.onChange(selectedValues);
-          this.ionChange.emit(selectedValues);
+          overlay.dismiss().then(() => {
+            this.ionChange.emit(selectedValues);
+          });
         }
       });
 


### PR DESCRIPTION
#### Short description of what this resolves:
`ionCancel` and `ionChange` now fire after the select is dismissed so that users can easily open other overlay components in the handlers for those events.

#### Changes proposed in this pull request:

- fire events after component is dismissed

**Ionic Version**: 2.x

**Fixes**: #7510 

