### PR TITLE
docs(readme): fix link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ To try Ionic 2 today, visit the [Ionic 2 Docs](http://ionicframework.com/docs/v2
 
 ### Contributing to Ionic 2
 
-See [CONTRIBUTING.md](https://github.com/driftyco/ionic/blob/2.0/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/driftyco/ionic/blob/master/.github/CONTRIBUTING.md)
 
 ### Ionic 2 Examples
 


### PR DESCRIPTION
#### Short description of what this resolves:

Current link in readme is broken.

#### Changes proposed in this pull request:

Link to correct location of CONTRIBUTING.md
-
-
-

**Ionic Version**: 1.x / 2.x

