### PR TITLE
Ensures that disabled toggles doe not fire events or show animation.

### DIFF
--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -175,7 +175,7 @@ export class Toggle implements AfterContentInit, ControlValueAccessor, OnDestroy
 
 
   private _setChecked(isChecked: boolean) {
-    if (isChecked !== this._checked) {
+    if (!this._disabled && isChecked !== this._checked) {
       this._checked = isChecked;
       if (this._init) {
         this.ionChange.emit(this);


### PR DESCRIPTION
#### Short description of what this resolves:
Ensures that disabled toggles doe not fire events or show animation.

#### Changes proposed in this pull request:
Also check if toggle is disabled before firing the event and animating the toggle. 

**2.0.0-beta.32**

**Fixes**: #7559

