### PR TITLE
Update Ionic Beta 11 install instructions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ $text-input-wp-show-invalid-highlight: $text-input-wp-show-focus-highlight !defa
 1. Run the following command in a terminal to update the npm dependencies:
 
   ```
-  npm install --save ionic-angular @angular/{common,compiler,core,http,forms,platform-browser,platform-browser-dynamic} rxjs@5.0.0-beta.6 zone.js@0.6.12
+  npm install --save ionic-angular @angular/{common,compiler,core,http,platform-browser,platform-browser-dynamic}@2.0.0-rc.4 @angular/forms rxjs@5.0.0-beta.6 zone.js@0.6.12
   ```
 
 2. Update all Overlay components to be presented by their controller instead of `NavController`. For example, to update the popover component, the following code:


### PR DESCRIPTION
#### Short description of what this resolves:

Angular RC5 just has been released, this cause the original install command to fail. I have added the required (RC4) version to the command.

#### Changes proposed in this pull request:

- Update Install instructions

**Ionic Version**: 1.x / 2.x

2.x

**Fixes**: #7647
