### PR TITLE
fix(gestures): fixes scroll issue with hammer config

### DIFF
--- a/src/config/providers.ts
+++ b/src/config/providers.ts
@@ -1,6 +1,7 @@
 import { enableProdMode, PLATFORM_DIRECTIVES, provide } from '@angular/core';
 import { disableDeprecatedForms, provideForms } from '@angular/forms';
 import { HTTP_PROVIDERS } from '@angular/http';
+import { HAMMER_GESTURE_CONFIG } from '@angular/platform-browser';
 
 import { ActionSheetController } from '../components/action-sheet/action-sheet';
 import { AlertController } from '../components/alert/alert';
@@ -10,6 +11,7 @@ import { closest, nativeTimeout } from '../util/dom';
 import { Events } from '../util/events';
 import { FeatureDetect } from '../util/feature-detect';
 import { Form } from '../util/form';
+import { IonicGestureConfig } from '../gestures/ionic-gesture-config';
 import { GestureController } from '../gestures/gesture-controller';
 import { IONIC_DIRECTIVES } from './directives';
 import { isPresent } from '../util/util';
@@ -80,6 +82,8 @@ export function ionicProviders(customProviders?: Array<any>, config?: any): any[
     ToastController,
     Translate,
   ];
+
+  providers.push( {provide: HAMMER_GESTURE_CONFIG, useClass: IonicGestureConfig} );
 
   if (isPresent(customProviders)) {
     providers.push(customProviders);

--- a/src/gestures/ionic-gesture-config.ts
+++ b/src/gestures/ionic-gesture-config.ts
@@ -1,0 +1,25 @@
+import {Injectable} from '@angular/core';
+import {HammerGestureConfig} from '@angular/platform-browser';
+
+/* this class override the default angular gesture config.
+ * The motivation for this is enabling pinch, rotate or
+ * any other multi-touch gestures block scrolling.
+ */
+
+/**
+ * @private
+ */
+@Injectable()
+export class IonicGestureConfig extends HammerGestureConfig {
+  
+  buildHammer(element: HTMLElement) {
+    var mc = new (<any> window).Hammer(element);
+
+    for (let eventName in this.overrides) {
+      mc.get(eventName).set(this.overrides[eventName]);
+    }
+
+    return mc;
+  }
+
+}

--- a/src/gestures/test/ionic-gesture-config.spec.ts
+++ b/src/gestures/test/ionic-gesture-config.spec.ts
@@ -1,0 +1,31 @@
+import { IonicGestureConfig } from '../../../src/gestures/ionic-gesture-config';
+
+export function run() {
+
+  describe('IonicGestureConfig', () => {
+    it('should create a new instance of hammer', () => {
+      // arrange
+      let instance = new IonicGestureConfig();
+      let expectedParam = { name: "expectedParam"};
+      let expectedHammerInstance = { name: "hammer"};
+      
+      let actualParam : any = null;
+      let callCount = 0;
+
+      (<any> window).Hammer = (param: any) => {
+        callCount++;
+        actualParam = param;
+        return expectedHammerInstance;
+      };
+      
+      // act
+      let returnValue = instance.buildHammer( <HTMLElement> <any> expectedParam);
+
+      // assert
+      expect(returnValue.name).toEqual(expectedHammerInstance.name);
+      expect(callCount).toEqual(1);
+      expect(actualParam.name).toEqual(expectedParam.name);
+    });
+  })
+
+}


### PR DESCRIPTION
This PR is tested (on iPhone 6s) and lets scrolling work with hammer gestures again.  swipe, pan, press, tap all work again and the app can scroll as needed.  Multi-touch gestures in the default config were "blocking" scrolling.

closes #6897