### PR TITLE
perf(item): apply will-change only when list is active

### DIFF
--- a/src/components/item/item-reorder.scss
+++ b/src/components/item/item-reorder.scss
@@ -24,7 +24,12 @@ ion-reorder {
 }
 
 .reorder-enabled {
+  ion-reorder {
+    display: flex;
+  }
+}
 
+.reorder-list-active {
   .item,
   .item-wrapper {
     transition: transform 300ms;
@@ -32,12 +37,6 @@ ion-reorder {
     will-change: transform;
   }
 
-  ion-reorder {
-    display: flex;
-  }
-}
-
-.reorder-list-active {
   .item-inner {
     pointer-events: none;
   }


### PR DESCRIPTION
#### Short description of what this resolves:
This fixes layers being made for each list item even when a user is not actually reordering when using reorder. This change means that `will-change` only gets applied when the user is actually reordering the list, and as soon as the user has "dropped" the item the layers get removed. Previous behavior created a layer for every list item even when a user was not reordering the list, causing high memory usage and bad scrolling perf. This has been tested on chrome 52 on desktop (the latest stable), and a Nexus 7 running Android 6.0.1 (completely stock).

The video below is of me using a reordered list with this fix with the layer viewer option in chrome dev tools on. 
[will-change-fix.zip](https://github.com/driftyco/ionic/files/412652/will-change-fix.zip)

**Ionic Version**: 2.x

