### PR TITLE
Update Changelog to use exact Ionic versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -151,7 +151,7 @@ $text-input-wp-show-invalid-highlight: $text-input-wp-show-focus-highlight !defa
 1. Run the following command in a terminal to update the npm dependencies:
 
   ```
-  npm install --save --save-exact ionic-angular @angular/common@2.0.0-rc.4 @angular/compiler@2.0.0-rc.4 @angular/core@2.0.0-rc.4 @angular/http@2.0.0-rc.4 @angular/platform-browser@2.0.0-rc.4 @angular/platform-browser-dynamic@2.0.0-rc.4 @angular/forms rxjs@5.0.0-beta.6 zone.js@0.6.12
+  npm install --save --save-exact ionic-angular@2.0.0-beta.11 @angular/common@2.0.0-rc.4 @angular/compiler@2.0.0-rc.4 @angular/core@2.0.0-rc.4 @angular/http@2.0.0-rc.4 @angular/platform-browser@2.0.0-rc.4 @angular/platform-browser-dynamic@2.0.0-rc.4 @angular/forms@0.2.0 rxjs@5.0.0-beta.6 zone.js@0.6.12
   ```
 
 2. Update all Overlay components to be presented by their controller instead of `NavController`. For example, to update the popover component, the following code:


### PR DESCRIPTION
#### Short description of what this resolves:

Upon testing the `npm install` command, npm install Ionic Beta 10 and `angular/forms 0.3.0`. `angular/forms 0.3.0` required angular RC-5, so a Missing Peer warning was issued.

I think it would be better to have them exact like the others

#### Changes proposed in this pull request:

- Add exact beta 11 version to `ionic-angular`
- Add exact 0.2.0 version `@angular/forms`

**Ionic Version**: 2.0