### PR TITLE
Add startAutoplay method reference

### DIFF
--- a/src/components/slides/swiper-widget.d.ts
+++ b/src/components/slides/swiper-widget.d.ts
@@ -10,4 +10,5 @@ export declare class Swiper {
   slideNext(runCallbacks: boolean, speed: number): boolean;
   slidePrev(runCallbacks: boolean, speed: number): boolean;
   slideTo(slideIndex: number, speed: number, runCallbacks: boolean): boolean;
+  startAutoplay(): any;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes the TypeScript compiler error when using `Slides.getSlides().startAutoplay()`

As specified in the Swiper [docs](http://idangero.us/swiper/api)

`mySwiper.startAutoplay();` 
**start auto play. It may be useful for custom "Play" and "Pause" buttons**
#### Changes proposed in this pull request:
- Adding startAutoplay() method reference

**Ionic Version**: 2.0-beta.11
