### PR TITLE
Fix path (nav->navbar) typo in docs

### DIFF
--- a/src/components/toolbar/toolbar.ts
+++ b/src/components/toolbar/toolbar.ts
@@ -135,7 +135,7 @@ export class ToolbarBase extends Ion {
  * @name Toolbar
  * @description
  * A Toolbar is a generic bar that is positioned above or below content.
- * Unlike a [Navbar](../../nav/Navbar), a toolbar can be used as a subheader.
+ * Unlike a [Navbar](../../navbar/Navbar), a toolbar can be used as a subheader.
  * When toolbars are placed within an `<ion-header>` or `<ion-footer>`,
  * the toolbars stay fixed in their respective location. When placed within
  * `<ion-content>`, toolbars will scroll with the content.


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

