### PR TITLE
Bugfix/chip attr colors

### DIFF
--- a/src/components/chip/chip.ios.scss
+++ b/src/components/chip/chip.ios.scss
@@ -9,11 +9,9 @@
 
 @each $color-name, $color-base, $color-contrast in get-colors($colors-ios) {
 
-  ion-chip {
-    ion-icon[#{$color-name}] {
-      color: $color-contrast;
-      background-color: $color-base;
-    }
+  ion-icon[#{$color-name}] {
+    color: $color-contrast;
+    background-color: $color-base;
   }
 
 }

--- a/src/components/chip/chip.md.scss
+++ b/src/components/chip/chip.md.scss
@@ -9,11 +9,9 @@
 
 @each $color-name, $color-base, $color-contrast in get-colors($colors-md) {
 
-  ion-chip {
-    ion-icon[#{$color-name}] {
-      color: $color-contrast;
-      background-color: $color-base;
-    }
+  ion-icon[#{$color-name}] {
+    color: $color-contrast;
+    background-color: $color-base;
   }
 
 }

--- a/src/components/chip/chip.wp.scss
+++ b/src/components/chip/chip.wp.scss
@@ -9,11 +9,9 @@
 
 @each $color-name, $color-base, $color-contrast in get-colors($colors-wp) {
 
-  ion-chip {
-    ion-icon[#{$color-name}] {
-      color: $color-contrast;
-      background-color: $color-base;
-    }
+  ion-icon[#{$color-name}] {
+    color: $color-contrast;
+    background-color: $color-base;
   }
 
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Issue that the color attributes are not working on the ion-chip component because of an extra selector

#### Changes proposed in this pull request:

-Remove extra SCSS selector for ion-chip
-
-

**Ionic Version**: 2
