### PR TITLE
perf(sliding-item): add contain to prevent repainting

### DIFF
--- a/src/components/item/item.md.scss
+++ b/src/components/item/item.md.scss
@@ -228,4 +228,5 @@ ion-item-divider {
 
 ion-item-sliding {
   background-color: $item-md-sliding-content-background;
+  contain: paint;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Currently when a sliding item is slid and closed the entire list gets repainted again, which with a big list can be very costly. Adding `contain: paint` allows the browser to not have to repaint the entire list and instead just repaint the item that was slid.

With this change:
![with-contain](https://cloud.githubusercontent.com/assets/8823093/17677138/1543bcbc-62f7-11e6-8c82-13254bb55678.gif)

Without this change:
![no-contain](https://cloud.githubusercontent.com/assets/8823093/17677159/291afa7a-62f7-11e6-8af1-bc47bc8948a9.gif)



#### Changes proposed in this pull request:

- add `contain: paint` to `ion-item-sliding` in the md sass since chrome is the only browser that supports contain.

**Ionic Version**: 2.x
