### PR TITLE
fix(): update package to fix e2e tests on node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "source-map-support": "^0.2.10",
     "strip-sourcemap-loader": "0.0.1",
     "systemjs": "0.19.6",
-    "through2": "^0.6.3",
+    "through2": "2.0.1",
     "tslint": "^3.10.2",
     "tslint-ionic-rules": "0.0.2",
     "typescript": "1.8.7",


### PR DESCRIPTION
#### Short description of what this resolves:
Not being able to run e2e tests on node 6

#### Changes proposed in this pull request:

- update through2 to the latest version

**Ionic Version**: 2.x

**Fixes**: #7301 

