### PR TITLE
Update popover.ts

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -86,10 +86,11 @@ export class Popover extends ViewController {
  * To dismiss the popover after creation, call the `dismiss()` method on the
  * `Popover` instance. The popover can also be dismissed from within the popover's
  * view by calling the `dismiss()` method on the [ViewController](../../nav/ViewController).
- * The `onDidDismiss` function can be called to perform an action after the popover
- * is dismissed. The popover will dismiss when the backdrop is clicked, but this
- * can be disabled by setting `enableBackdropDismiss` to `false` in the popover
- * options.
+ * The `dismiss()` call accepts an optional parameter that will be passed to the callback described
+ * as follows. The `onDidDismiss(<func>)` function can be called to set up a callback action that will
+ * be performed after the popover is dismissed, receiving the parameter passed to `dismiss()`.
+ * The popover will dismiss when the backdrop is clicked by implicitly performing `dismiss(null)`,
+ * but this can be disabled by setting `enableBackdropDismiss` to `false` in the popover options.
  *
  * > Note that after the component is dismissed, it will not be usable anymore and
  * another one must be created. This can be avoided by wrapping the creation and


### PR DESCRIPTION
#### Short description of what this resolves: Documenation of Popover's dismiss behavior.


#### Changes proposed in this pull request: Documentation / comments only

**Ionic Version**: 2.x

**Fixes**: 
Clarify that that unfortunately-named Popover.onDidDismiss() is not a callback, but rather *sets up* an arbitrary callback. Also explain dismiss()'s argument and its relation to said callback.