### PR TITLE
Fix typo in Sliding Item Docs

### DIFF
--- a/src/components/item/item-sliding.ts
+++ b/src/components/item/item-sliding.ts
@@ -19,7 +19,7 @@ export const enum ItemSideFlags {
  * @name ItemOptions
  * @description
  * The option buttons for an `ion-item-sliding`. These buttons can be placed either on the left or right side.
- * You can combind the `(ionSiwpe)` event plus the `expandable` directive to create a full swipe action for the item.
+ * You can combind the `(ionSwipe)` event plus the `expandable` directive to create a full swipe action for the item.
  *
  * @usage
  *


### PR DESCRIPTION
#### Short description of what this resolves:
Fix type in `ion-sliding-item` API doc.

#### Changes proposed in this pull request:
ionSiwpe -> ionSwipe

**Ionic Version**: 2.x