### PR TITLE
Remove brackets around src for ion-img

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -126,7 +126,7 @@ import { VirtualFooter, VirtualHeader, VirtualItem } from './virtual-item';
  *
  *   <ion-item *virtualItem="let item">
  *     <ion-avatar item-left>
- *       <ion-img [src]="item.avatarUrl"></ion-img>
+ *       <ion-img src="{{ item.avatarUrl }}"></ion-img>
  *     </ion-avatar>
  *    {% raw %} {{ item.firstName }} {{ item.lastName }}{% endraw %}
  *   </ion-item>


### PR DESCRIPTION
#### Short description of what this resolves:

The notation [src] used on ion-img is not working for the last version of Ionic 2. Removing it and adding curly braces for the value called into src.

#### Changes proposed in this pull request:

- Remove brackets around src
- Add curly braces around the value called into src. 

**Ionic Version**: 1.x / 2.x

**Fixes**: #

I removed the brackets around src.