### PR TITLE
SCSS Fix typo "scroll-cotent"

### DIFF
--- a/src/components/app/structure.scss
+++ b/src/components/app/structure.scss
@@ -68,7 +68,7 @@ ion-tabs,
   height: 100%;
 }
 
-ion-tab scroll-cotent {
+ion-tab scroll-content {
   display: none;
 }
 
@@ -80,7 +80,7 @@ ion-tab.show-tab {
   transform: translateY(0);
 }
 
-ion-tab.show-tab scroll-cotent {
+ion-tab.show-tab scroll-content {
   display: block;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
`scroll-cotent` is probably a typo, meant `scroll-content`?

#### Changes proposed in this pull request:

- Corrected `scroll-cotent`, now `scroll-content` in src/components/app/structure.scss

**Ionic Version**: 2.x

**Fixes**: #

