### PR TITLE
fix(7923): add input focus text color

### DIFF
--- a/src/components/label/label.ios.scss
+++ b/src/components/label/label.ios.scss
@@ -5,6 +5,7 @@
 // --------------------------------------------------
 
 $label-ios-text-color:         #7f7f7f !default;
+$label-ios-text-color-focused: color($colors-ios, primary) !default;
 $label-ios-margin:             $item-ios-padding-top ($item-ios-padding-right / 2) $item-ios-padding-bottom 0 !default;
 
 
@@ -48,6 +49,11 @@ ion-label[floating] {
   transform: translate3d(0, 27px, 0);
   transform-origin: left top;
   transition: transform 150ms ease-in-out;
+}
+
+.input-has-focus ion-label[stacked],
+.input-has-focus ion-label[floating] {
+  color: $label-ios-text-color-focused;
 }
 
 .input-has-focus ion-label[floating],


### PR DESCRIPTION
#### Short description of what this resolves:
Focus on Input doesn't change label color on iOS


#### Changes proposed in this pull request:

- Add focused color on the label

In case the desired behaviour is not to have a focused color. The value for the variable can be set to null !default; so that there is no css generated. And if the consumer wants to add a color he can do so.

**Ionic Version**: 2

**Fixes**: #7923

