### PR TITLE
fix(loading/toast): clear timeout if dismissed

### DIFF
--- a/src/components/loading/loading-component.ts
+++ b/src/components/loading/loading-component.ts
@@ -43,7 +43,6 @@ export class LoadingCmp {
   };
   private id: number;
   private showSpinner: boolean;
-  private durationTimeout: number;
 
   constructor(
     private _viewCtrl: ViewController,
@@ -79,16 +78,10 @@ export class LoadingCmp {
     let activeElement: any = document.activeElement;
     if (document.activeElement) {
       activeElement.blur();
-    }
-
-    // If there is a duration, dismiss after that amount of time
-    this.d.duration ? this.durationTimeout = setTimeout(() => this.dismiss('backdrop'), this.d.duration) : null;
+    }    
   }
 
-  dismiss(role: any): Promise<any> {
-    if (this.durationTimeout) {
-      clearTimeout(this.durationTimeout);
-    }
+  dismiss(role: any): Promise<any> {    
     return this._viewCtrl.dismiss(null, role);
   }
 }

--- a/src/components/loading/loading.ts
+++ b/src/components/loading/loading.ts
@@ -13,6 +13,8 @@ import { ViewController } from '../nav/view-controller';
  */
 export class Loading extends ViewController {
   private _app: App;
+  private duration: number;
+  private durationTimeout: number;
 
   constructor(app: App, opts: LoadingOptions = {}) {
     opts.showBackdrop = isPresent(opts.showBackdrop) ? !!opts.showBackdrop : true;
@@ -21,6 +23,7 @@ export class Loading extends ViewController {
     super(LoadingCmp, opts);
     this._app = app;
     this.isOverlay = true;
+    this.duration = opts.duration;
 
     // by default, loading indicators should not fire lifecycle events of other views
     // for example, when an loading indicators enters, the current active view should
@@ -51,7 +54,18 @@ export class Loading extends ViewController {
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */
   present(navOptions: NavOptions = {}) {
-    return this._app.present(this, navOptions);
+    return this._app.present(this, navOptions)
+      .then(() => {
+        // If there is a duration, dismiss after that amount of time
+        this.duration ? this.durationTimeout = setTimeout(() => this.dismiss('backdrop'), this.duration) : null;
+      });
+  }
+
+  dismiss(data?: any, role?: any, navOptions: NavOptions = {}) {
+    if (this.durationTimeout) {
+      clearTimeout(this.durationTimeout);
+    }
+    return super.dismiss(data, role, navOptions);
   }
 
   /**

--- a/src/components/toast/toast-component.ts
+++ b/src/components/toast/toast-component.ts
@@ -45,7 +45,6 @@ export class ToastCmp implements AfterViewInit {
     position?: string;
   };
   private descId: string;
-  private dismissTimeout: number = undefined;
   private enabled: boolean;
   private hdrId: string;
   private id: number;
@@ -73,14 +72,7 @@ export class ToastCmp implements AfterViewInit {
     }
   }
 
-  ngAfterViewInit() {
-    // if there's a `duration` set, automatically dismiss.
-    if (this.d.duration) {
-      this.dismissTimeout =
-        setTimeout(() => {
-          this.dismiss('backdrop');
-        }, this.d.duration);
-    }
+  ngAfterViewInit() {    
     this.enabled = true;
   }
 
@@ -104,8 +96,6 @@ export class ToastCmp implements AfterViewInit {
   }
 
   dismiss(role: any): Promise<any> {
-    clearTimeout(this.dismissTimeout);
-    this.dismissTimeout = undefined;
     return this._viewCtrl.dismiss(null, role);
   }
 

--- a/src/components/toast/toast.ts
+++ b/src/components/toast/toast.ts
@@ -12,6 +12,8 @@ import { ViewController } from '../nav/view-controller';
  */
 export class Toast extends ViewController {
   private _app: App;
+  private duration: number;
+  private durationTimeout: number;
 
   constructor(app: App, opts: ToastOptions = {}) {
     opts.dismissOnPageChange = isPresent(opts.dismissOnPageChange) ? !!opts.dismissOnPageChange : false;
@@ -24,6 +26,7 @@ export class Toast extends ViewController {
     }
 
     this.isOverlay = true;
+    this.duration = opts.duration;
 
     // by default, toasts should not fire lifecycle events of other views
     // for example, when an toast enters, the current active view should
@@ -61,7 +64,18 @@ export class Toast extends ViewController {
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */
   present(navOptions: NavOptions = {}) {
-    return this._app.present(this, navOptions);
+    return this._app.present(this, navOptions)
+      .then(() => {
+        // If there is a duration, dismiss after that amount of time
+        this.duration ? this.durationTimeout = setTimeout(() => this.dismiss('backdrop'), this.duration) : null;
+      });
+  }
+
+  dismiss(data?: any, role?: any, navOptions: NavOptions = {}) {
+    if (this.durationTimeout) {
+      clearTimeout(this.durationTimeout);
+    }
+    return super.dismiss(data, role, navOptions);
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:

When you manually dismiss a Loading or Toast that has a duration, the timeout is not correctly cleared and it will fire again and dismiss whatever item is open (a second Loading or another modal, etc).

There was an attempted fix for this in #7229 but that doesn't address dismissing it from code (because you call .dismiss() on the returned Loading or Toast and not on the LoadingCmp or ToastCmp).

I have a beta 11 plunker that demonstrates this: http://plnkr.co/edit/tiyv0nExKb4V7JZKyhol?p=preview

#### Changes proposed in this pull request:

- Move duration timeout and timeout clearing logic to the Loading/Toast view controllers.

**Ionic Version**: 2.x

**Fixes**: #7197

