### PR TITLE
Add mode config property to config readme

### DIFF
--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -92,6 +92,7 @@ import { isObject, isDefined, isFunction, isArray } from '../util/util';
  * | `menuType`               | `string`            | Type of menu to display. Available options: `"overlay"`, `"reveal"`, `"push"`.                                                                   |
  * | `modalEnter`             | `string`            | The name of the transition to use while a modal is presented.                                                                                    |
  * | `modalLeave`             | `string`            | The name of the transition to use while a modal is dismiss.                                                                                      |
+ * | `mode`                   | `string`            | The mode to use throughout the application.                                                                                     |
  * | `pageTransition`         | `string`            | The name of the transition to use while changing pages.                                                                                          |
  * | `pageTransitionDelay`    | `number`            | The delay in milliseconds before the transition starts while changing pages.                                                                     |
  * | `pickerEnter`            | `string`            | The name of the transition to use while a picker is presented.                                                                                   |


### PR DESCRIPTION
#### Short description of what this resolves:

In the config documentation there isn't explicit documentation on how to set the global mode for an application. I added the mode config property to the list of config properties.

#### Changes proposed in this pull request:

- Adds 'mode' to list of config properties in config documentation

**Ionic Version**: 2.0.0-beta.8 and greater

**Fixes**: Issue mentioned here: https://github.com/driftyco/ionic/issues/5312
