### PR TITLE
fix(input-base): corrects issue when type is number and value is set to zero

### DIFF
--- a/src/components/input/input-base.ts
+++ b/src/components/input/input-base.ts
@@ -290,7 +290,7 @@ export class InputBase {
    */
   checkHasValue(inputValue: any) {
     if (this._item) {
-      this._item.setCssClass('input-has-value', !!(inputValue && inputValue !== ''));
+      this._item.setCssClass('input-has-value', inputValue !== null && inputValue !== undefined && inputValue !== '');
     }
   }
 


### PR DESCRIPTION
Correct issue for label not floating up when using ion-input with type="number" and model is changed to a 0.

Ionic Version: 2.0.0-beta.11

Fixes: #8019 

