### PR TITLE
docs: fix link to Storage

### DIFF
--- a/src/platform/storage/local-storage.ts
+++ b/src/platform/storage/local-storage.ts
@@ -28,7 +28,7 @@ import { StorageEngine } from './storage';
  *}
  *```
  * @demo /docs/v2/demos/local-storage/
- * @see {@link /docs/v2/platform/storage/ Storage Platform Docs}
+ * @see {@link /docs/v2/platform/storage/Storage/ Storage Platform Docs}
  */
 export class LocalStorage extends StorageEngine {
   constructor(options = {}) {


### PR DESCRIPTION
#### Short description of what this resolves:
broken link at the bottom of
http://ionicframework.com/docs/v2/api/platform/storage/LocalStorage/

**Ionic Version**: 2.x