### PR TITLE
Changed CSS selector for ion-spinner

### DIFF
--- a/src/components/spinner/spinner.ts
+++ b/src/components/spinner/spinner.ts
@@ -88,7 +88,7 @@ import { Config } from '../../config/config';
  * of `background-color`.
  *
  * ```css
- * ion-spinner svg {
+ * ion-spinner * {
  *   width: 28px;
  *   height: 28px;
  *   stroke: #444;


### PR DESCRIPTION
#### Short description of what this resolves:
The current Ionic2 Documentation states that you select the spinner via CSS using `ionic-spinner svg`.

This is no longer the case per Mike: https://forum.ionicframework.com/t/ion-spinner-color/46324/6

#### Changes proposed in this pull request:

- Just a simple CSS selector update

**Ionic Version**: 1.x / 2.x

**Fixes**: #