### PR TITLE
fix(input): text input width calculation

### DIFF
--- a/src/components/input/input.ios.scss
+++ b/src/components/input/input.ios.scss
@@ -32,7 +32,7 @@ $text-input-ios-highlight-color-invalid:   color($colors-ios, danger) !default;
   margin: $text-input-ios-margin-top $text-input-ios-margin-right $text-input-ios-margin-bottom $text-input-ios-margin-left;
   padding: 0;
 
-  width: calc(100% - #{$text-input-ios-margin-right} - #{$text-input-ios-margin-left});
+  width: (100% - #{($text-input-ios-margin-right + $text-input-ios-margin-left)});
 }
 
 

--- a/src/components/input/input.ios.scss
+++ b/src/components/input/input.ios.scss
@@ -32,7 +32,7 @@ $text-input-ios-highlight-color-invalid:   color($colors-ios, danger) !default;
   margin: $text-input-ios-margin-top $text-input-ios-margin-right $text-input-ios-margin-bottom $text-input-ios-margin-left;
   padding: 0;
 
-  width: (100% - #{($text-input-ios-margin-right + $text-input-ios-margin-left)});
+  width: calc(100% - #{($text-input-ios-margin-right + $text-input-ios-margin-left)});
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Issue that the width property is invalid ex;
`width: calc(100% - 8px - 0);` which is not a valid calc value.


#### Changes proposed in this pull request:

- Add a part of the calculation using SASS, Add the margin-left and margin right using SASS and then subtract the total using the css calc function. Compiled down would be `calc(100% - 8px);` in case you have a left margin of 10px and right of 20px it would be `calc(100% - 30px);`

**Ionic Version**: 2

**Fixes**: #7388

