### PR TITLE
Fix: emit (ionSelect) event from ion-option

### DIFF
--- a/src/components/option/option.ts
+++ b/src/components/option/option.ts
@@ -1,5 +1,4 @@
-import { Directive, ElementRef, EventEmitter, Input, Output } from '@angular/core';
-
+import { Directive, ElementRef, EventEmitter, HostListener, Input, Output } from '@angular/core';
 import { isPresent, isTrueProperty } from '../../util/util';
 
 /**
@@ -23,6 +22,16 @@ export class Option {
   @Output() ionSelect: EventEmitter<any> = new EventEmitter();
 
   constructor(private _elementRef: ElementRef) {}
+
+  @HostListener('click', ['$event'])
+  private _click(ev: UIEvent) {
+    console.debug('option, select');
+    ev.preventDefault();
+    ev.stopPropagation();
+
+    this.selected = true;
+    this.ionSelect.emit(this.value);
+  }
 
   /**
    * @input {boolean} Whether or not the option is already selected


### PR DESCRIPTION
#### Short description of what this resolves:

The `ionSelect` event is never emitted on the `ion-option` for the select component.

#### Changes proposed in this pull request:

- Added `HostListener` to handle the `click` event, [equivalent to how the `radio-button` does this](https://github.com/driftyco/ionic/blob/3154cc05f4b848138d557f923d32a1d3fe7468d6/src/components/radio/radio-button.ts#L160-L171).

**Ionic Version**: 2.x

**Fixes**: #6711

