### PR TITLE
fix(navigation): move assignment of _onWillDismiss to null from _dest…

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -179,6 +179,7 @@ export class ViewController {
     this._onWillDismiss && this._onWillDismiss(data, role);
     return this._nav.remove(this._nav.indexOf(this), 1, options).then(() => {
       this._onDidDismiss && this._onDidDismiss(data, role);
+      this._onWillDismiss = null;
       return data;
     });
   }
@@ -514,7 +515,7 @@ export class ViewController {
       }
     }
 
-    this._nav = this._cmp = this.instance = this._cntDir = this._cntRef = this._hdrDir = this._ftrDir = this._nb = this._onDidDismiss = this._onWillDismiss = null;
+    this._nav = this._cmp = this.instance = this._cntDir = this._cntRef = this._hdrDir = this._ftrDir = this._nb = this._onDidDismiss = null;
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:

Currently the destroy method, which is being called when dismissing a modal, clears the onDidDismiss callback, so the callback is always null when it will be called

#### Changes proposed in this pull request:

-Move the assignment of onDidDismiss to null from destroy method to dismiss method to ensure callbacks are called before being set to null

**Ionic Version**: 1.x / 2.x

**Fixes**: #

…roy to dismiss