### PR TITLE
fix(app): corected paths to theme from src/components/app/app.scss

### DIFF
--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -1,17 +1,17 @@
 
 // Globals
 // --------------------------------------------------
-@import "../themes/ionic.globals";
+@import "../../themes/ionic.globals";
 
 
 // Normalize
 // --------------------------------------------------
-@import "../themes/normalize";
+@import "../../themes/normalize";
 
 
 // Util
 // --------------------------------------------------
-@import "../themes/util";
+@import "../../themes/util";
 
 
 // App Structure


### PR DESCRIPTION
#### Short description of what this resolves:
Path to themes from src/components/app/app.scss is currently incorrect

#### Changes proposed in this pull request:

-Changes filepath to correctly point to themes folder

**Ionic Version**: 1.x / 2.x

**Fixes**: #

