### PR TITLE
Use $item-ios-padding-right variable

### DIFF
--- a/src/components/item/item.ios.scss
+++ b/src/components/item/item.ios.scss
@@ -27,6 +27,7 @@ $item-ios-sliding-content-background:     $list-ios-background-color !default;
 .item-ios {
   position: relative;
 
+  padding-right: $item-ios-padding-right;
   padding-left: $item-ios-padding-left;
 
   border-radius: 0;


### PR DESCRIPTION
#### Short description of what this resolves:

Improper padding for ion-items, not using the actual defined scss variable. This PR only includes fix for iOS, would like feedback before fixing others.
#### Changes proposed in this pull request:
- Make ion item use the scss variable for iOS.

**Ionic Version**: 2.x

**Fixes**: #

I'm not 100% if it's omission was intentional but not using it makes inputs look bad. There's even worse cases for [MD](https://github.com/driftyco/ionic/blob/master/src/components/item/item.md.scss#L29) and [WP](https://github.com/driftyco/ionic/blob/master/src/components/item/item.wp.scss#L31) as well, where they're just set to 0 (not even 0px).

Before: ![Before](https://cloud.githubusercontent.com/assets/53535/18649492/b5b8f606-7e8d-11e6-88e6-69b6e610a651.png)

After: 
![image](https://cloud.githubusercontent.com/assets/53535/18649538/02f7cd34-7e8e-11e6-820b-61f23b224c40.png)
