### PR TITLE
fix(navigation) move assignment of onDidDismiss to null from destroy …

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -179,6 +179,7 @@ export class ViewController {
     this._onWillDismiss && this._onWillDismiss(data, role);
     return this._nav.remove(this._nav.indexOf(this), 1, options).then(() => {
       this._onDidDismiss && this._onDidDismiss(data, role);
+      this._onDidDismiss = null;
       return data;
     });
   }
@@ -514,7 +515,7 @@ export class ViewController {
       }
     }
 
-    this._nav = this._cmp = this.instance = this._cntDir = this._cntRef = this._hdrDir = this._ftrDir = this._nb = this._onDidDismiss = this._onWillDismiss = null;
+    this._nav = this._cmp = this.instance = this._cntDir = this._cntRef = this._hdrDir = this._ftrDir = this._nb = this._onWillDismiss = null;
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Previous PR incorrectly moved assigned onWillDismiss to null from destroy to dismiss. This moves onWillDismiss back and correctly fixes the issue by moving assignment to null of onDidDismiss from destroy to dismiss.

#### Changes proposed in this pull request:

-onWillDismiss = null returned to destroy function
-onDidDismiss = null moved to dismiss function

**Ionic Version**: 1.x / 2.x

**Fixes**: #
