### PR TITLE
Fixed broken links for Navbar

### DIFF
--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -43,7 +43,7 @@ import { GestureController } from '../../gestures/gesture-controller';
  *
  * ### Navigation Bar Behavior
  *
- * If a [MenuToggle](../MenuToggle) button is added to the [NavBar](../../nav/NavBar) of
+ * If a [MenuToggle](../MenuToggle) button is added to the [Navbar](../../navbar/Navbar) of
  * a page, the button will only appear when the page it's in is currently a root page. The
  * root page is the initial page loaded in the app, or a page that has been set as the root
  * using the [setRoot](../../nav/NavController/#setRoot) method on the [NavController](../../nav/NavController).
@@ -56,9 +56,9 @@ import { GestureController } from '../../gestures/gesture-controller';
  *
  * ### Persistent Menus
  *
- * Persistent menus display the [MenuToggle](../MenuToggle) button in the [NavBar](../../nav/NavBar)
+ * Persistent menus display the [MenuToggle](../MenuToggle) button in the [Navbar](../../navbar/Navbar)
  * on all pages in the navigation stack. To make a menu persistent set `persistent` to `true` on the
- * `<ion-menu>` element. Note that this will only affect the `MenuToggle` button in the `NavBar` attached
+ * `<ion-menu>` element. Note that this will only affect the `MenuToggle` button in the `Navbar` attached
  * to the `Menu` with `persistent` set to true, any other `MenuToggle` buttons will not be affected.
  *
  *


### PR DESCRIPTION
Fixes for Links to Navbar documentation.
Also renamed "NavBar" to "Navbar" to be consistent with the rest of the documentation.