### PR TITLE
Remove resetScrollView event listener on ScrollNative cleanup

### DIFF
--- a/js/views/scrollViewNative.js
+++ b/js/views/scrollViewNative.js
@@ -554,11 +554,11 @@
       var self = this;
       var container = self.__container;
 
-      container.removeEventListener('resetScrollView', self.resetScrollView);
+      document.removeEventListener('resetScrollView', self.resetScrollView);
+
       container.removeEventListener('scroll', self.onScroll);
 
       container.removeEventListener('scrollChildIntoView', self.scrollChildIntoView);
-      container.removeEventListener('resetScrollView', self.resetScrollView);
 
       container.removeEventListener(ionic.EVENTS.touchstart, self.handleTouchMove);
       container.removeEventListener(ionic.EVENTS.touchmove, self.handleTouchMove);


### PR DESCRIPTION
#### Short description of what this resolves:

Memory leak caused by ScrollNative after cleanup method was called.
#### Changes proposed in this pull request:

On ScrollNative cleanup:
- remove resetScrollView event listener from document instead of container (as resetScrollView event was previously added to the document);
- remove resetScrollView event duplicate.

**Ionic Version**: 1.3.1

**Fixes**: #
