### PR TITLE
fix(dgeni): fix typo processor hide-private-api not run

### DIFF
--- a/scripts/docs/processors/hide-private-api.js
+++ b/scripts/docs/processors/hide-private-api.js
@@ -1,6 +1,6 @@
-module.exports = function removePrivateApi() {
+module.exports = function hidePrivateApi() {
   return {
-    name: 'remove-private-api',
+    name: 'hide-private-api',
     description: 'Prevent the private apis from being rendered',
     $runBefore: ['rendering-docs'],
     $process: function(docs) {


### PR DESCRIPTION
#### Short description of what this resolves:
Adjust  docs generation dgeni

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 2.x

**Fixes**: #

