### PR TITLE
Fix docs platform

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -823,7 +823,9 @@ interface BackButtonAction {
   priority: number;
 }
 
-
+/**
+ * @private
+ */
 export function setupPlatform(platformConfigs: {[key: string]: PlatformConfig}, queryParams: QueryParams, userAgent: string, navigatorPlatform: string, docDirection: string, docLanguage: string, zone: NgZone): Platform {
   const p = new Platform();
   p.setDefault('core');
@@ -838,8 +840,19 @@ export function setupPlatform(platformConfigs: {[key: string]: PlatformConfig}, 
   return p;
 }
 
-
+/**
+ * @private
+ */
 export const UserAgentToken = new OpaqueToken('USERAGENT');
+/**
+ * @private
+ */
 export const NavigatorPlatformToken = new OpaqueToken('NAVPLT');
+/**
+ * @private
+ */
 export const DocumentDirToken = new OpaqueToken('DOCDIR');
+/**
+ * @private
+ */
 export const DocLangToken = new OpaqueToken('DOCLANG');

--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -106,6 +106,9 @@ export class Events {
   }
 }
 
+/**
+ * @private
+ */
 export function setupEvents(platform: Platform): Events {
   const events = new Events();
 
@@ -145,6 +148,9 @@ export function setupEvents(platform: Platform): Events {
   return events;
 }
 
+/**
+ * @private
+ */
 export function setupProvideEvents(platform: Platform) {
   return function() {
     return setupEvents(platform);


### PR DESCRIPTION
#### Short description of what this resolves:
With chnages to beta.12 they were implemented some tokens for factory platform should be privates and own factory:

[DocLangToken](http://ionic-site-staging.herokuapp.com/docs/v2/nightly/api/platform/DocLangToken/)
[DocumentDirToken](http://ionic-site-staging.herokuapp.com/docs/v2/nightly/api/platform/DocumentDirToken/)
[NavigatorPlatformToken](http://ionic-site-staging.herokuapp.com/docs/v2/nightly/api/platform/NavigatorPlatformToken/)
[UserAgentToken](http://ionic-site-staging.herokuapp.com/docs/v2/nightly/api/platform/UserAgentToken/)
[setupPlatform](http://ionic-site-staging.herokuapp.com/docs/v2/nightly/api/platform/setupPlatform/)

Thanks
Ramon

**Ionic Version**:  2.x
