### PR TITLE
fix(variable): correctly use enter and leave popup animation variables

### DIFF
--- a/scss/_popup.scss
+++ b/scss/_popup.scss
@@ -25,14 +25,14 @@
   }
 
   &.popup-hidden .popup {
-    @include animation-name(scaleOut);
+    @include animation-name($popup-leave-animation);
     @include animation-duration($popup-leave-animation-duration);
     @include animation-timing-function(ease-in-out);
     @include animation-fill-mode(both);
   }
 
   &.active .popup {
-    @include animation-name(superScaleIn);
+    @include animation-name($popup-enter-animation);
     @include animation-duration($popup-enter-animation-duration);
     @include animation-timing-function(ease-in-out);
     @include animation-fill-mode(both);

--- a/scss/_variables.scss
+++ b/scss/_variables.scss
@@ -621,6 +621,7 @@ $sheet-options-border-color:      #d1d3d6 !default;
 
 $popup-width:                     250px !default;
 $popup-enter-animation:           superScaleIn !default;
+$popup-leave-animation:           scaleOut !default;
 $popup-enter-animation-duration:  0.2s !default;
 $popup-leave-animation-duration:  0.1s !default;
 


### PR DESCRIPTION
#### Short description of what this resolves:

This commit allow to edit popup enter and leave animation :wink:
#### Changes proposed in this pull request:
- Use $popup-enter-animation variable (It wasn't use before).
- Create variable $popup-leave-animation with scaleOut as default value

**Ionic Version**: 1.3.1
