### PR TITLE
fix(ion-button): ion-button on a tag should be excluded

### DIFF
--- a/src/components/typography/typography.ts
+++ b/src/components/typography/typography.ts
@@ -9,7 +9,7 @@ import { Ion } from '../ion';
   * Select all of the HTML text elements with the color attribute to apply the text-color class.
  */
 @Directive({
-  selector: 'h1[color], h2[color], h3[color], h4[color], h5[color], h6[color], a[color], p[color], span[color], b[color], i[color], strong[color], em[color], small[color], sub[color], sup[color]'
+  selector: 'h1[color], h2[color], h3[color], h4[color], h5[color], h6[color], a[color]:not([ion-button]), p[color], span[color], b[color], i[color], strong[color], em[color], small[color], sub[color], sup[color]'
 })
 export class Typography extends Ion {
 


### PR DESCRIPTION
#### Short description of what this resolves:
The fore color of the button is being overwritten when it's applied on an a tag because of the 2 directives (text and button) that are setting the "color".

#### Changes proposed in this pull request:

- Exclude ion-button on a selector

**Ionic Version**: 2.x

**Fixes**: #8249

