### PR TITLE
Fix infinite loop (hang) in viewcontroller dismiss

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -1,7 +1,7 @@
 import { ComponentRef, ElementRef, EventEmitter, Output, Renderer } from '@angular/core';
 
 import { Footer, Header } from '../components/toolbar/toolbar';
-import { isPresent, merge } from '../util/util';
+import { isPresent, assign } from '../util/util';
 import { Navbar } from '../components/navbar/navbar';
 import { NavControllerBase } from './nav-controller-base';
 import { NavOptions, ViewState } from './nav-util';
@@ -184,7 +184,7 @@ export class ViewController {
       return Promise.resolve(false);
     }
 
-    let options = merge({}, this._leavingOpts, navOptions);
+    let options = assign({}, this._leavingOpts, navOptions);
     this._onWillDismiss && this._onWillDismiss(data, role);
     return this._nav.remove(this._nav.indexOf(this), 1, options).then(() => {
       this._onDidDismiss && this._onDidDismiss(data, role);


### PR DESCRIPTION
#### Short description of what this resolves:

Fix an  infinite loop on ViewController.dismiss(): on an android device (Nexus 7, android 5.1.1) dismissing a PopOver without this patch causes an infinite loop.

#### Changes proposed in this pull request:

- replace deep copy with shallow copy, avoiding the possibility of an infinite loop due to recursive data structures

**Ionic Version**: 2.0.0-rc.0
