### PR TITLE
Virtual Scroll fix: this.approxItemHeight is undefined when update(true) is called first

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -343,6 +343,11 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
 
       this._init = true;
 
+      if (!this.approxItemHeight) {
+        this.approxItemHeight = '40px';
+        console.warn('Virtual Scroll: Please provide an "approxItemHeight" input to ensure proper virtual scroll rendering');
+      }
+
       this.update(true);
 
       this._platform.onResize(() => {
@@ -350,10 +355,6 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
         this.update(false);
       });
 
-      if (!this.approxItemHeight) {
-        this.approxItemHeight = '40px';
-        console.warn('Virtual Scroll: Please provide an "approxItemHeight" input to ensure proper virtual scroll rendering');
-      }
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
this.approxItemHeight is undefined when update(true) is called first
see https://github.com/driftyco/ionic/issues/8311

#### Changes proposed in this pull request:

- define this.approxItemHeight to default 40px before do this.update(true)

**Ionic Version**: 2.1.0

**Fixes**: https://github.com/driftyco/ionic/issues/8311
