### PR TITLE
fix(tabs): applying badge style with mode

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -145,7 +145,7 @@ import { ViewController } from '../../navigation/view-controller';
       '<a *ngFor="let t of _tabs" [tab]="t" class="tab-button" [class.tab-disabled]="!t.enabled" [class.tab-hidden]="!t.show" role="tab" href="#" (ionSelect)="select($event)">' +
         '<ion-icon *ngIf="t.tabIcon" [name]="t.tabIcon" [isActive]="t.isSelected" class="tab-button-icon"></ion-icon>' +
         '<span *ngIf="t.tabTitle" class="tab-button-text">{{t.tabTitle}}</span>' +
-        '<ion-badge *ngIf="t.tabBadge" class="tab-badge" [ngClass]="\'badge-\' + t.tabBadgeStyle">{{t.tabBadge}}</ion-badge>' +
+        '<ion-badge *ngIf="t.tabBadge" class="tab-badge" [ngClass]="\'badge-\' + _mode + \'-\' + t.tabBadgeStyle">{{t.tabBadge}}</ion-badge>' +
         '<div class="button-effect"></div>' +
       '</a>' +
       '<div class="tab-highlight"></div>' +


### PR DESCRIPTION
#### Short description of what this resolves:
Applying `tabBadgeStyle` style to a tab does not work.

For example, 
` <ion-tab [root]="tab3Root"  tabIcon="person" tabBadge="2" tabBadgeStyle="danger" ></ion-tab>`
would not get `danger` color styling.

#### Changes proposed in this pull request:

It seems that a style for badge is generated in `badge-mode-style` manner (eg. `badge-ios-danger`) therefore adding `_mode` in the badge template.

**Ionic Version**: 2 RC0