### PR TITLE
fix(tabs) ion-badge not being given the proper color

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -145,7 +145,7 @@ import { ViewController } from '../../navigation/view-controller';
       '<a *ngFor="let t of _tabs" [tab]="t" class="tab-button" [class.tab-disabled]="!t.enabled" [class.tab-hidden]="!t.show" role="tab" href="#" (ionSelect)="select($event)">' +
         '<ion-icon *ngIf="t.tabIcon" [name]="t.tabIcon" [isActive]="t.isSelected" class="tab-button-icon"></ion-icon>' +
         '<span *ngIf="t.tabTitle" class="tab-button-text">{{t.tabTitle}}</span>' +
-        '<ion-badge *ngIf="t.tabBadge" class="tab-badge" [ngClass]="\'badge-\' + t.tabBadgeStyle">{{t.tabBadge}}</ion-badge>' +
+        '<ion-badge *ngIf="t.tabBadge" class="tab-badge" [color]="t.tabBadgeStyle">{{t.tabBadge}}</ion-badge>' +
         '<div class="button-effect"></div>' +
       '</a>' +
       '<div class="tab-highlight"></div>' +


### PR DESCRIPTION
#### Short description of what this resolves:
tabBadgeStyle input is not setting the correct class on the ion-badge. It is adding `badge-danger` rather than `badge-ios-danger`

#### Changes proposed in this pull request:
- remove ngClss and use color input instead

**Ionic Version**: 2

**Fixes**: #8317

