### PR TITLE
fix(nav): ionViewCanLeave does not break navigation

### DIFF
--- a/src/navigation/nav-util.ts
+++ b/src/navigation/nav-util.ts
@@ -170,6 +170,8 @@ export interface TransitionInstruction {
   removeCount?: number;
   resolve?: TransitionResolveFn;
   reject?: TransitionRejectFn;
+  leavingRequiresTransition?: boolean;
+  enteringRequiresTransition?: boolean;
 }
 
 export enum ViewState {

--- a/src/navigation/test/nav-controller.spec.ts
+++ b/src/navigation/test/nav-controller.spec.ts
@@ -231,6 +231,53 @@ describe('NavController', () => {
       expect(nav.last().component).toEqual(MockView1);
     });
 
+    it('should not insert any view in the stack if canLeave returns false', () => {
+      let view1 = mockView(MockView1);
+      let view2 = mockView(MockView2);
+      let view3 = mockView(MockView3);
+      mockViews(nav, [view1, view2]);
+
+      let instance2 = spyOnLifecycles(view2);
+
+      let count = 0;
+      instance2.ionViewCanLeave = function () {
+        count++;
+        return (count === 3);
+      };
+
+      nav.push(view3);
+      expect(nav.length()).toEqual(2);
+
+      nav.push(view3);
+      expect(nav.length()).toEqual(2);
+
+      nav.push(view3);
+      expect(nav.length()).toEqual(3);
+    });
+
+    it('should not remove any view from the stack if canLeave returns false', () => {
+      let view1 = mockView(MockView1);
+      let view2 = mockView(MockView2);
+      mockViews(nav, [view1, view2]);
+
+      let instance2 = spyOnLifecycles(view2);
+
+      let count = 0;
+      instance2.ionViewCanLeave = function () {
+        count++;
+        return (count === 3);
+      };
+
+      nav.pop();
+      expect(nav.length()).toEqual(2);
+
+      nav.pop();
+      expect(nav.length()).toEqual(2);
+
+      nav.pop();
+      expect(nav.length()).toEqual(1);
+    });
+
   });
 
   describe('insertPages', () => {
@@ -550,14 +597,16 @@ describe('NavController', () => {
       let view2 = mockView(MockView2);
       let view3 = mockView(MockView3);
       let view4 = mockView(MockView4);
-      mockViews(nav, [view1, view2, view3, view4]);
+      let view5 = mockView(MockView5);
+      mockViews(nav, [view1, view2, view3, view4, view5]);
 
       let instance1 = spyOnLifecycles(view1);
       let instance2 = spyOnLifecycles(view2);
       let instance3 = spyOnLifecycles(view3);
       let instance4 = spyOnLifecycles(view4);
+      let instance5 = spyOnLifecycles(view5);
 
-      nav.remove(1, 2, null, trnsDone);
+      nav.remove(2, 2, null, trnsDone);
 
       expect(instance1.ionViewDidLoad).not.toHaveBeenCalled();
       expect(instance1.ionViewCanEnter).not.toHaveBeenCalled();
@@ -573,9 +622,9 @@ describe('NavController', () => {
       expect(instance2.ionViewWillEnter).not.toHaveBeenCalled();
       expect(instance2.ionViewDidEnter).not.toHaveBeenCalled();
       expect(instance2.ionViewCanLeave).not.toHaveBeenCalled();
-      expect(instance2.ionViewWillLeave).toHaveBeenCalled();
-      expect(instance2.ionViewDidLeave).toHaveBeenCalled();
-      expect(instance2.ionViewWillUnload).toHaveBeenCalled();
+      expect(instance2.ionViewWillLeave).not.toHaveBeenCalled();
+      expect(instance2.ionViewDidLeave).not.toHaveBeenCalled();
+      expect(instance2.ionViewWillUnload).not.toHaveBeenCalled();
 
       expect(instance3.ionViewDidLoad).not.toHaveBeenCalled();
       expect(instance3.ionViewCanEnter).not.toHaveBeenCalled();
@@ -591,18 +640,28 @@ describe('NavController', () => {
       expect(instance4.ionViewWillEnter).not.toHaveBeenCalled();
       expect(instance4.ionViewDidEnter).not.toHaveBeenCalled();
       expect(instance4.ionViewCanLeave).not.toHaveBeenCalled();
-      expect(instance4.ionViewWillLeave).not.toHaveBeenCalled();
-      expect(instance4.ionViewDidLeave).not.toHaveBeenCalled();
-      expect(instance4.ionViewWillUnload).not.toHaveBeenCalled();
+      expect(instance4.ionViewWillLeave).toHaveBeenCalled();
+      expect(instance4.ionViewDidLeave).toHaveBeenCalled();
+      expect(instance4.ionViewWillUnload).toHaveBeenCalled();
+
+      expect(instance5.ionViewDidLoad).not.toHaveBeenCalled();
+      expect(instance5.ionViewCanEnter).not.toHaveBeenCalled();
+      expect(instance5.ionViewWillEnter).not.toHaveBeenCalled();
+      expect(instance5.ionViewDidEnter).not.toHaveBeenCalled();
+      expect(instance5.ionViewCanLeave).not.toHaveBeenCalled();
+      expect(instance5.ionViewWillLeave).not.toHaveBeenCalled();
+      expect(instance5.ionViewDidLeave).not.toHaveBeenCalled();
+      expect(instance5.ionViewWillUnload).not.toHaveBeenCalled();
 
       let hasCompleted = true;
       let requiresTransition = false;
       expect(trnsDone).toHaveBeenCalledWith(
         hasCompleted, requiresTransition, undefined, undefined, undefined
       );
-      expect(nav.length()).toEqual(2);
+      expect(nav.length()).toEqual(3);
       expect(nav.getByIndex(0).component).toEqual(MockView1);
-      expect(nav.getByIndex(1).component).toEqual(MockView4);
+      expect(nav.getByIndex(1).component).toEqual(MockView2);
+      expect(nav.getByIndex(2).component).toEqual(MockView5);
     });
 
     it('should remove the last two views at the end', () => {

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -532,18 +532,18 @@ export class ViewController {
    * @private
    */
   _lifecycleTest(lifecycle: string): boolean | string | Promise<any> {
-    let result: any = true;
-
-    if (this.instance && this.instance['ionViewCan' + lifecycle]) {
+    let instance = this.instance;
+    let methodName = 'ionViewCan' + lifecycle;
+    if (instance && instance[methodName]) {
       try {
-        result = this.instance['ionViewCan' + lifecycle]();
+        return instance[methodName]();
 
       } catch (e) {
         console.error(`${this.name} ionViewCan${lifecycle} error: ${e}`);
-        result = false;
+        return false;
       }
     }
-    return result;
+    return true;
   }
 
 }

--- a/src/transitions/transition.ts
+++ b/src/transitions/transition.ts
@@ -21,7 +21,7 @@ export class Transition extends Animation {
   _trnsStart: Function;
 
   parent: Transition;
-  hasChildTrns: boolean;
+  hasChildTrns: boolean = false;
   trnsId: number;
 
 

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -10,14 +10,13 @@ import { Form } from './form';
 import { GestureController } from '../gestures/gesture-controller';
 import { Keyboard } from './keyboard';
 import { Menu } from '../components/menu/menu';
-import { NavOptions, ViewState, DeepLinkConfig } from '../navigation/nav-util';
+import { ViewState, DeepLinkConfig } from '../navigation/nav-util';
 import { OverlayPortal } from '../components/nav/overlay-portal';
 import { PageTransition } from '../transitions/page-transition';
 import { Platform } from '../platform/platform';
 import { QueryParams } from '../platform/query-params';
 import { Tab }  from '../components/tabs/tab';
 import { Tabs }  from '../components/tabs/tabs';
-import { Transition } from '../transitions/transition';
 import { TransitionController } from '../transitions/transition-controller';
 import { UrlSerializer } from '../navigation/url-serializer';
 import { ViewController } from '../navigation/view-controller';
@@ -271,7 +270,7 @@ export const mockNavController = function(): NavControllerBase {
     linker
   );
 
-  nav._viewInit = function(trns: Transition, enteringView: ViewController, opts: NavOptions) {
+  nav._viewInit = function(enteringView: ViewController) {
     enteringView.init(mockComponentRef());
     enteringView._state = ViewState.INITIALIZED;
   };


### PR DESCRIPTION
Right now, the NavController does the canLeave/canEnter challenge only when the navigation change requires a transition.

1. Remove from stack
2. Evaluate if a transition is required
 - if yes: canLeave/canEnter challenge -> continue transition
 - if no: we are done

This logic leads to an important bug when canLeave or canEnter returns `false` (i.e. the transition has been cancelled) but the pages have been already removed from the stack.

This PR introduces a new logic (that of course passes all the current unit tests):

1. Evaluate if a transition is required
 - if yes: canLeave/canEnter challenge -> continue
 - if no: continue
2. Remove from stack
3. Evaluate if a transition is required (cached value from step one)
 - if yes: transition -> done!
 - if no: done

This way if canLeave returns false, we have not touched the stack yet.


This bug can be reproduced with the following code, the simulates returning false a couple of times, then return true:

```ts
    public trys = 0;
    ionViewCanLeave(): any {
        if (this.trys++ < 2) {
            return false;
        } else return true;
    }
```
It breaks the navigation 100% of the times

fixes #8408