### PR TITLE
chore(demos): delete examples Fab(old form) in component Button

### DIFF
--- a/demos/src/button/page.html
+++ b/demos/src/button/page.html
@@ -29,8 +29,6 @@
 
   <button ion-button round>Round Button</button>
 
-  <button ion-button fab style="position: relative;">FAB</button>
-
   <h4>Outlines</h4>
 
   <button ion-button color="secondary" full outline>Outline + Full</button>
@@ -38,8 +36,6 @@
   <button ion-button color="secondary" block outline>Outline + Block</button>
 
   <button ion-button color="secondary" round outline>Outline + Round</button>
-
-  <button ion-button color="secondary" fab outline style="position: relative;">FAB</button>
 
   <h4>Icons</h4>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Delete examples usage Fab (old) already exists in  [Fab Button](http://ionic-site-staging.herokuapp.com/docs/v2/components/#fabs)


**Ionic Version**: 2.0.0-rc.0

**Fixes**: #

