### PR TITLE
docs(FabContainer): fix typo of ion-fab placement in comment

### DIFF
--- a/src/components/fab/fab.ts
+++ b/src/components/fab/fab.ts
@@ -208,7 +208,7 @@ export class FabList {
   *
   * ```html
   * <ion-content>
-  *  <!-- this fab is placed at top right -->
+  *  <!-- this fab is placed at bottom right -->
   *  <ion-fab bottom right >
   *    <button ion-fab>Share</button>
   *    <ion-fab-list side="top">


### PR DESCRIPTION
#### Short description of what this resolves:
there's a typo about fab button placement

#### Changes proposed in this pull request:

- change description from ```top``` to ```bottom``` to match the code
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

