### PR TITLE
fix(popover): flipped arrow on iOS

### DIFF
--- a/src/components/popover/popover.ios.scss
+++ b/src/components/popover/popover.ios.scss
@@ -66,11 +66,11 @@ $popover-ios-arrow-background:          $popover-ios-background !default;
   transform: rotate(45deg);
 }
 
-.popover-ios .popover-bottom .popover-arrow {
+.popover-ios.popover-bottom .popover-arrow {
   top: auto;
   bottom: -10px;
 }
 
-.popover-ios .popover-bottom .popover-arrow::after {
+.popover-ios.popover-bottom .popover-arrow::after {
   top: -6px;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the flipped arrow on iOS, when the popover opens above an element.

#### Changes proposed in this pull request:

- Fixed class selector for popover-bottom

**Ionic Version**: 2.0.0-rc.0

**Fixes**: #8419 