### PR TITLE
chore(): move ionic's dependencies into peerDependencies.

### DIFF
--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -10,10 +10,9 @@
   "license": "MIT",
   "main": "umd/index.js",
   "module": "index.js",
-  "dependencies": {
+  "peerDependencies": {
     "@angular/common": "",
     "@angular/compiler": "",
-    "@angular/compiler-cli": "",
     "@angular/core": "",
     "@angular/forms": "",
     "@angular/http": "",

--- a/scripts/npm/package.json
+++ b/scripts/npm/package.json
@@ -13,6 +13,7 @@
   "peerDependencies": {
     "@angular/common": "",
     "@angular/compiler": "",
+    "@angular/compiler-cli": "",
     "@angular/core": "",
     "@angular/forms": "",
     "@angular/http": "",


### PR DESCRIPTION
#### Short description of what this resolves:
This change will move all of Ionic's dependencies into peer dependencies.

Ionic acts as a plugin for Angular. Both Ionic and Angular are direct dependencies of the source project. According to the definition of when to use peerDependencies from NPM our code fits into this.

https://nodejs.org/en/blog/npm/peer-dependencies/

#### Changes proposed in this pull request:

- Move Ionic's dependencies to peerDependencies in the package.json file

**Ionic Version**: 2.x
