### PR TITLE
fix(ion-item-divider): apply z-index when sticky only

### DIFF
--- a/src/components/item/item.scss
+++ b/src/components/item/item.scss
@@ -76,7 +76,6 @@ ion-item-group {
 }
 
 ion-item-divider {
-  z-index: 1000;
   display: flex;
   overflow: hidden;
 
@@ -92,6 +91,7 @@ ion-item-divider {
 }
 
 ion-item-divider[sticky] {
+  z-index: 1000;
   position: sticky;
   top: 0;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
ion-item-divider has a z-index even when not sticky

#### Changes proposed in this pull request:

- Apply z-index only when the divider has the sticky attribute

**Ionic Version**: 2

**Fixes**: #8489

