### PR TITLE
fix(menu): menu's content is resized properly

### DIFF
--- a/src/components/backdrop/backdrop.ts
+++ b/src/components/backdrop/backdrop.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, Input } from '@angular/core';
+import { Directive, ElementRef, Input, Renderer } from '@angular/core';
 
 import { GestureController } from '../../gestures/gesture-controller';
 import { isTrueProperty } from '../../util/util';
@@ -19,7 +19,10 @@ export class Backdrop {
   private _gestureID: number = null;
   @Input() disableScroll = true;
 
-  constructor(private _gestureCtrl: GestureController, private _elementRef: ElementRef) {}
+  constructor(
+    private _gestureCtrl: GestureController,
+    private _elementRef: ElementRef,
+    private _renderer: Renderer) { }
 
   ngOnInit() {
     if (isTrueProperty(this.disableScroll)) {
@@ -36,6 +39,10 @@ export class Backdrop {
 
   getNativeElement(): HTMLElement {
     return this._elementRef.nativeElement;
+  }
+
+  setElementClass(className: string, add: boolean) {
+    this._renderer.setElementClass(this._elementRef.nativeElement, className, add);
   }
 
 }

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -488,7 +488,9 @@ export class Content extends Ion {
     this._tabsPlacement = null;
 
     let ele: HTMLElement = this._elementRef.nativeElement;
-    if (!ele) return;
+    if (!ele) {
+      return;
+    }
 
     let parentEle: HTMLElement = ele.parentElement;
     let computedStyle: any;

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -29,9 +29,7 @@ ion-menu.show-menu {
   bottom: 0;
   left: 0;
 
-  display: flex;
-
-  flex-direction: column;
+  display: block;
 
   width: $menu-width;
 
@@ -41,7 +39,7 @@ ion-menu.show-menu {
 .menu-inner > ion-header,
 .menu-inner > ion-content,
 .menu-inner > ion-footer {
-  position: relative;
+  position: absolute;
 }
 
 ion-menu[side=right] > .menu-inner {

--- a/src/components/menu/test/push/main.html
+++ b/src/components/menu/test/push/main.html
@@ -7,7 +7,6 @@
   </ion-header>
 
   <ion-content>
-
     <ion-list>
 
       <button ion-item menuToggle="left" detail-none>
@@ -18,6 +17,13 @@
       </button>
 
     </ion-list>
+    <p>Close Left Menu and Show alert buttons</p>
+
+    <div f></div>
+    <div f></div>
+    <div f></div>
+    <div f></div>
+
   </ion-content>
 
 </ion-menu>
@@ -31,7 +37,6 @@
   </ion-header>
 
   <ion-content>
-
     <ion-list>
 
       <button ion-item menuToggle="right" detail-none>
@@ -39,6 +44,13 @@
       </button>
 
     </ion-list>
+    <p>Only one close button</p>
+
+    <div f></div>
+    <div f></div>
+    <div f></div>
+    <div f></div>
+
   </ion-content>
 
 </ion-menu>

--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -6,7 +6,6 @@ import { Content } from '../content/content';
 import { DeepLinker } from '../../navigation/deep-linker';
 import { Ion } from '../ion';
 import { isBlank } from '../../util/util';
-import { nativeRaf } from '../../util/dom';
 import { NavController } from '../../navigation/nav-controller';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
 import { NavOptions, DIRECTION_SWITCH } from '../../navigation/nav-util';
@@ -476,10 +475,7 @@ export class Tabs extends Ion implements AfterViewInit {
       if (alreadyLoaded && selectedPage) {
         let content = <Content>selectedPage.getContent();
         if (content && content instanceof Content) {
-          nativeRaf(() => {
-            content.readDimensions();
-            content.writeDimensions();
-          });
+          content.resize();
         }
       }
     });

--- a/src/transitions/page-transition.ts
+++ b/src/transitions/page-transition.ts
@@ -14,6 +14,7 @@ export class PageTransition extends Transition {
       this.enteringPage = new Animation(this.enteringView.pageRef());
       this.add(this.enteringPage.beforeAddClass('show-page'));
 
+      // Resize content before transition starts
       this.beforeAddRead(this.readDimensions.bind(this));
       this.beforeAddWrite(this.writeDimensions.bind(this));
     }


### PR DESCRIPTION
### Short description of what this resolves:

Before fix:
![screen shot 2016-10-05 at 21 22 24](https://cloud.githubusercontent.com/assets/127379/19128052/eaf622f6-8b41-11e6-8627-7ec4ba3efcbf.png)
![screen shot 2016-10-05 at 21 22 34](https://cloud.githubusercontent.com/assets/127379/19128053/eb1be6c6-8b41-11e6-9876-8bbae9d329e2.png)

footer and part of the content is hidden.

After:
![screen shot 2016-10-05 at 19 40 28](https://cloud.githubusercontent.com/assets/127379/19128072/fb5e873c-8b41-11e6-90ee-ca1192fb571f.png)
![screen shot 2016-10-05 at 19 40 36](https://cloud.githubusercontent.com/assets/127379/19128071/fb5b3546-8b41-11e6-8d10-2ae7252a6a24.png)




fixes #8504