### PR TITLE
fix(ion-datetime): remove log on deceleration

### DIFF
--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -230,8 +230,6 @@ export class PickerColumnCmp {
         this.velocity = 0;
       }
 
-      console.log(`decelerate y: ${y}, velocity: ${this.velocity}, optHeight: ${this.optHeight}`);
-
       var notLockedIn = (y % this.optHeight !== 0 || Math.abs(this.velocity) > 1);
 
       this.update(y, 0, true, !notLockedIn);


### PR DESCRIPTION
#### Short description of what this resolves:
DateTime is very slow on mobile devices, especially Android

#### Changes proposed in this pull request:
- Do not log on each deceleration

**Ionic Version**: 2.x

**Fixes**: #8515 

