### PR TITLE
docs(item component) fix typo

### DIFF
--- a/src/components/item/item.ts
+++ b/src/components/item/item.ts
@@ -69,7 +69,7 @@ import { Label } from '../label/label';
  * ## Detail Arrows
  * By default, `<button>` and `<a>` elements with the `ion-item` attribute will display a right arrow icon
  * on `ios` mode. To hide the right arrow icon on either of these elements, add the `detail-none` attribute
- * to the item. To show the right arrow icon on an element that doesn't display is naturally, add the
+ * to the item. To show the right arrow icon on an element that doesn't display it naturally, add the
  * `detail-push` attribute to the item.
  *
  * ```html


### PR DESCRIPTION
#### Short description of what this resolves:
A simple typo that made me stare at it for a while to realise it was a typo!

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

Should be "display it naturally", not "display is naturally" ?