### PR TITLE
1.x

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -159,13 +159,7 @@ ionic.tap = {
   },
 
   isContentEditable: function(ele) {
-    while (ele && ele.tagName === 'DIV') {
-        if(ele.contentEditable) {
-          return true;
-        }
-        ele = ele.parentElement;
-    }
-    return false;
+    return e.contentEditable || (e.parentElement && e.parentElement.contentEditable);
   },
 
   isTextInput: function(ele) {

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -159,7 +159,7 @@ ionic.tap = {
   },
 
   isContentEditable: function(ele) {
-    return ele.contentEditable || (ele.parentElement && ele.parentElement.contentEditable);
+    return ele.contentEditable === 'true'|| (ele.parentElement && ele.parentElement.contentEditable === 'true');
   },
 
   isTextInput: function(ele) {

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -158,10 +158,20 @@ ionic.tap = {
            ionic.tap.isElementTapDisabled(e.target); // check if this element, or an ancestor, has `data-tap-disabled` attribute
   },
 
+  isContentEditable: function(ele) {
+    while (ele && ele.tagName === 'DIV') {
+        if(ele.contentEditable) {
+          return true;
+        }
+        ele = ele.parentElement;
+    }
+    return false;
+  },
+
   isTextInput: function(ele) {
     return !!ele &&
            (ele.tagName == 'TEXTAREA' ||
-            ele.contentEditable === 'true' ||
+            ionic.tap.isContentEditable(ele) ||
             (ele.tagName == 'INPUT' && !(/^(radio|checkbox|range|file|submit|reset|color|image|button)$/i).test(ele.type)));
   },
 

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -159,7 +159,7 @@ ionic.tap = {
   },
 
   isContentEditable: function(ele) {
-    return e.contentEditable || (e.parentElement && e.parentElement.contentEditable);
+    return ele.contentEditable || (ele.parentElement && ele.parentElement.contentEditable);
   },
 
   isTextInput: function(ele) {

--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -159,7 +159,7 @@ ionic.tap = {
   },
 
   isContentEditable: function(ele) {
-    return ele.contentEditable === 'true'|| (ele.parentElement && ele.parentElement.contentEditable === 'true');
+    return ele.contentEditable === 'true' || (ele.parentElement && ele.parentElement.contentEditable === 'true');
   },
 
   isTextInput: function(ele) {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixing bug. When div has some content it wasn't possible to check on it. Only the current select note was checked when the contentEditable could be in it's parent once content is added. That was making contentEditable not compatible with ionic.

Impact: user was not able to click on a contentEditable div with more than a row. He would have to click the first div or the click will be ignored.
#### Changes proposed in this pull request:
## \- Checking that the div or it's first parent has this attribute

**Ionic Version**: 1.x

**Fixes**: #
