### PR TITLE
Fix ion-content height after first keyboard show

### DIFF
--- a/js/views/scrollViewNative.js
+++ b/js/views/scrollViewNative.js
@@ -22,6 +22,8 @@
 
       if(options.startY >= 0 || options.startX >= 0) {
         ionic.requestAnimationFrame(function() {
+          self.__originalContainerHeight = self.el.getBoundingClientRect().height;
+
           self.el.scrollTop = options.startY || 0;
           self.el.scrollLeft = options.startX || 0;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Incorrect ion-content height when the native keyboard appears for the first time. It happens to other users as well, as you can see in the related issue.

#### Changes proposed in this pull request:

- Adjust the __originalContainerHeight in ionic.views.ScrollNative after first keyboard show in ionic.requestAnimationFrame callback.

**Ionic Version**: 1.x

**Fixes**: #6715 

