### PR TITLE
fix(spinner): add input mode fix #8598

### DIFF
--- a/src/components/spinner/spinner.ts
+++ b/src/components/spinner/spinner.ts
@@ -131,6 +131,14 @@ export class Spinner extends Ion {
   }
 
   /**
+   * @input {string} The mode to apply to this component.
+   */
+  @Input()
+  set mode(val: string) {
+    this._setMode('spinner', val);
+  }
+
+  /**
    * @input {string} SVG spinner name.
    */
   @Input()
@@ -163,6 +171,8 @@ export class Spinner extends Ion {
 
   constructor(config: Config, elementRef: ElementRef, renderer: Renderer) {
     super(config, elementRef, renderer);
+
+    this.mode = config.get('mode');
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
To assign color in ion-spinner
```<ion-spinner color="danger"></ion-spinner>```

Result in html
```
<ion-spinner color="danger" class="spinner-undefined-danger spinner-ios" ng-reflect-color="danger">
```
Expected
```
<ion-spinner color="danger" class="spinner-ios-danger spinner-ios" ng-reflect-color="danger">
```

See mode is how **undefined** in the concatenation of the **class**

**Ionic Version**: 2.0.0-rc.0

**Fixes**: #8598

