### PR TITLE
docs(navbar): fix a typo

### DIFF
--- a/src/components/navbar/navbar.ts
+++ b/src/components/navbar/navbar.ts
@@ -15,7 +15,7 @@ import { ViewController } from '../../navigation/view-controller';
  * button. A navbar can contain a `ion-title`, any number of buttons,
  * a segment, or a searchbar. Navbars must be placed within an
  * `<ion-header>` in order for them to be placed above the content.
- * It's important to note that navbar's are part of the dynamica navigation
+ * It's important to note that navbar's are part of the dynamic navigation
  * stack. If you need a static toolbar, use ion-toolbar.
  *
  * @usage


### PR DESCRIPTION
#### Short description of what this resolves:
This adjusts the text of the navbar documentation to fix a typo.

#### Changes proposed in this pull request:

- fix a typo

**Ionic Version**: 2.x
