### PR TITLE
fix(fab): center fab list for larger buttons

### DIFF
--- a/src/components/fab/fab.scss
+++ b/src/components/fab/fab.scss
@@ -128,7 +128,7 @@ ion-fab-list {
 }
 
 ion-fab-list .fab-in-list {
-  margin: 8px;
+  margin: 8px 0;
 
   width: $fab-mini-size;
   height: $fab-mini-size;
@@ -145,6 +145,11 @@ ion-fab-list .fab-in-list.show {
   opacity: 1;
   visibility: visible;
   transform: scale(1);
+}
+
+ion-fab-list[side=left] .fab-in-list,
+ion-fab-list[side=right] .fab-in-list {
+  margin: 0 8px;
 }
 
 ion-fab-list[side=top] {


### PR DESCRIPTION
#### Short description of what this resolves:
When setting the `$fab-mini-size` to be larger than normal, the buttons inside the `ion-fab-list` are not positioned correctly.

#### Changes proposed in this pull request:

- Remove the horizontal margin from fab buttons in a top or bottom list
- Remove the vertical margin from fab buttons in a left or right list

##### Before => After
![screen shot 2016-10-12 at 14 49 36](https://cloud.githubusercontent.com/assets/2545042/19310613/3d0c5030-908b-11e6-818c-b763b74e6f4b.png)
##### After
![screen shot 2016-10-12 at 14 49 10](https://cloud.githubusercontent.com/assets/2545042/19310614/3d0cd55a-908b-11e6-8874-4edd10153519.png)


**Ionic Version**: 2.x
