### PR TITLE
fix(navbar): make ios content transparent. Fixes #8060

### DIFF
--- a/src/components/content/content.ios.scss
+++ b/src/components/content/content.ios.scss
@@ -9,6 +9,10 @@ $content-ios-transition-background:     #000 !default;
 
 .content-ios {
   color: $text-ios-color;
+  background-color: rgba(255,255,255,0);
+}
+
+.fixed-content {
   background-color: $background-ios-color;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:

The navbar transition on ios causes a white flash when animating between bars, most noticeable when the navbar colors are dark. This is due to the opacity animation that briefly shows the white background of ion-content since ion-content is now fullscreen.

This PR makes ion-content background transparent, while making the actual fixed content part the ios background color.

Needs review!

**Fixes**: #8060

