### PR TITLE
Exclude contentEditable from preventDefault on tapMouseDown()

### DIFF
--- a/js/utils/tap.js
+++ b/js/utils/tap.js
@@ -362,7 +362,7 @@ function tapMouseDown(e) {
     e.stopPropagation();
 
     if (!ionic.Platform.isEdge() && (!ionic.tap.isTextInput(e.target) || tapLastTouchTarget !== e.target) &&
-      !isSelectOrOption(e.target.tagName) && !ionic.tap.isVideo(e.target)) {
+      !isSelectOrOption(e.target.tagName) && !e.target.isContentEditable && !ionic.tap.isVideo(e.target)) {
       // If you preventDefault on a text input then you cannot move its text caret/cursor.
       // Allow through only the text input default. However, without preventDefault on an
       // input the 300ms delay can change focus on inputs after the keyboard shows up.


### PR DESCRIPTION
#### Short description of what this resolves:

When selecting the contentEditable element, the first tap does not focus the element.
#### Changes proposed in this pull request:

Add additional clause to the if statement to exclude contentEditable from the `preventDefault()`

**Ionic Version**: 1.x / 2.x
1.3.1

**Fixes**: #8741 
