### PR TITLE
fix(sass): change default font path

### DIFF
--- a/src/themes/ionic.globals.scss
+++ b/src/themes/ionic.globals.scss
@@ -16,7 +16,7 @@ $include-rtl: true !default;
 
 
 // Global font path
-$font-path: "../fonts" !default;
+$font-path: "../assets/fonts" !default;
 
 
 // Hairline width


### PR DESCRIPTION
#### Short description of what this resolves:

This changes the default font path so that fonts can be loaded without having to have seperate variables in the users `variables.scss` file. This is a companion to https://github.com/driftyco/ionic-app-scripts/pull/152 and https://github.com/driftyco/ionic2-app-base/pull/92
#### Changes proposed in this pull request:
- change default font path from '../fonts' to '../assets/fonts'

**Ionic Version**: 2.x
