### PR TITLE
fix(searchbar-md-cancel): fix always hide button

### DIFF
--- a/src/components/searchbar/searchbar.md.scss
+++ b/src/components/searchbar/searchbar.md.scss
@@ -130,11 +130,11 @@ $searchbar-md-input-clear-icon-size:     22px !default;
 // Searchbar Focused
 // -----------------------------------------
 
-.searchbar-md .searchbar-has-focus.searchbar-show-cancel .searchbar-search-icon {
+.searchbar-md.searchbar-has-focus.searchbar-show-cancel .searchbar-search-icon {
   display: none;
 }
 
-.searchbar-md .searchbar-has-focus.searchbar-show-cancel .searchbar-md-cancel {
+.searchbar-md.searchbar-has-focus.searchbar-show-cancel .searchbar-md-cancel {
   display: inline-flex;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Search bar don't show the cancel button for android.

#### Changes proposed in this pull request:
Update css selector to match with searchbar html 


**Ionic Version**: 1.x / 2.x
2.0.0-rc.1

**Fixes**: #
#8403
