### PR TITLE
fix(refresher): only animate transform property

### DIFF
--- a/src/components/refresher/refresher.scss
+++ b/src/components/refresher/refresher.scss
@@ -36,7 +36,7 @@ ion-refresher {
   margin-top: -1px;
 
   border-top: 1px solid $refresher-border-color;
-  transition: all 320ms cubic-bezier(.36, .66, .04, 1);
+  transition: transform 320ms cubic-bezier(.36, .66, .04, 1);
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
When using a Refresher, the content scroller gets a `transition: all;`. When using a header or footer on the same page, the content scroller's `margin-top` and/or `margin-bottom` are set. These margins are then animated in by the `transition` while they should render instantly. This margin animation is sometimes visible when a page gets loaded.

#### Changes proposed in this pull request:

- Change the `transition` to only animate `transform`, as this is the only property that requires animating for the refresher.

**Ionic Version**: 2.x