### PR TITLE
fix(searchbar): fix positionElements to assign input mode

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -239,7 +239,7 @@ export class Searchbar extends Ion {
     let shouldAlignLeft = (!isAnimated || (this._value && this._value.toString().trim() !== '') || this._sbHasFocus === true);
     this._shouldAlignLeft = shouldAlignLeft;
 
-    if (this._config.get('mode') !== 'ios') {
+    if (this._mode !== 'ios') {
       return;
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:

#### Changes proposed in this pull request:

**Ionic Version**: 1.x / 2.x

**Fixes**: #8855

