### PR TITLE
feat(menu): more options for swipeEnabled

### DIFF
--- a/src/components/menu/menu-gestures.ts
+++ b/src/components/menu/menu-gestures.ts
@@ -1,7 +1,7 @@
 import { Menu } from './menu';
 import { SlideEdgeGesture } from '../../gestures/slide-edge-gesture';
 import { SlideData } from '../../gestures/slide-gesture';
-import { assign } from '../../util/util';
+import { assign, assert } from '../../util/util';
 import { GestureController, GesturePriority } from '../../gestures/gesture-controller';
 
 /**
@@ -28,7 +28,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
 
   canStart(ev: any): boolean {
     let menu = this.menu;
-    if (!menu.canSwipe()) {
+    if (!menu.canSwipe() || menu.isAnimating) {
       return false;
     }
     if (menu.isOpen) {
@@ -84,11 +84,11 @@ export class MenuContentGesture extends SlideEdgeGesture {
     this.menu.swipeEnd(shouldCompleteLeft, shouldCompleteRight, currentStepValue);
   }
 
-  getElementStartPos(slide: SlideData, ev: any) {
+  getElementStartPos(slide: SlideData, ev: any): number {
     if (this.menu.side === 'right') {
       return this.menu.isOpen ? slide.min : slide.max;
     }
-    // left menu
+    assert(this.menu.side === 'left', 'menu side should be left');
     return this.menu.isOpen ? slide.max : slide.min;
   }
 
@@ -99,7 +99,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
         max: 0
       };
     }
-    // left menu
+    assert(this.menu.side === 'left', 'menu side should be left');
     return {
       min: 0,
       max: this.menu.width()

--- a/src/components/menu/menu.scss
+++ b/src/components/menu/menu.scss
@@ -51,7 +51,7 @@ ion-menu ion-backdrop {
   z-index: -1;
   display: none;
 
-  opacity: .1;
+  opacity: .01;
 }
 
 .menu-content {

--- a/src/components/menu/test/basic/app-module.ts
+++ b/src/components/menu/test/basic/app-module.ts
@@ -6,7 +6,18 @@ import { IonicApp, IonicModule, MenuController, NavController, AlertController, 
   templateUrl: 'page1.html'
 })
 export class Page1 {
-  constructor(public navCtrl: NavController, public alertCtrl: AlertController) {}
+  constructor(public navCtrl: NavController, public menuCtrl: MenuController, public alertCtrl: AlertController) {}
+
+  get swipeMenuMode() {
+    return this.menuCtrl.get().swipeEnabled;
+  }
+
+  set swipeMenuMode(value: any) {
+    console.log('swipeMenuMode', value);
+    this.menuCtrl.getMenus().forEach(menu => {
+      menu.swipeEnable(value);
+    });
+  }
 
   presentAlert() {
     let alert = this.alertCtrl.create({

--- a/src/components/menu/test/basic/page1.html
+++ b/src/components/menu/test/basic/page1.html
@@ -68,6 +68,28 @@
     <button ion-button (click)="goToPage2()">Go to Page 2</button>
   </p>
 
+  <ion-list radio-group [(ngModel)]="swipeMenuMode">
+    <ion-list-header>
+      Menu Swipe Mode
+    </ion-list-header>
+    <ion-item>
+      <ion-label>True</ion-label>
+      <ion-radio value="true"></ion-radio>
+    </ion-item>
+    <ion-item>
+      <ion-label>False</ion-label>
+      <ion-radio value="false"></ion-radio>
+    </ion-item>
+    <ion-item>
+      <ion-label>Open</ion-label>
+      <ion-radio value="open"></ion-radio>
+    </ion-item>
+    <ion-item>
+      <ion-label>Close</ion-label>
+      <ion-radio value="close"></ion-radio>
+    </ion-item>
+  </ion-list>
+
   <div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div>
 
 </ion-content>

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -108,7 +108,7 @@ import { isObject, isDefined, isFunction, isArray } from '../util/util';
  * | `menuType`               | `string`            | Type of menu to display. Available options: `"overlay"`, `"reveal"`, `"push"`.                                                                   |
  * | `modalEnter`             | `string`            | The name of the transition to use while a modal is presented.                                                                                    |
  * | `modalLeave`             | `string`            | The name of the transition to use while a modal is dismiss.                                                                                      |
- * | `mode`                   | `string`            | The mode to use throughout the application.                                                                                     |
+ * | `mode`                   | `string`            | The mode to use throughout the application.                                                                                                      |
  * | `pageTransition`         | `string`            | The name of the transition to use while changing pages.                                                                                          |
  * | `pageTransitionDelay`    | `number`            | The delay in milliseconds before the transition starts while changing pages.                                                                     |
  * | `pickerEnter`            | `string`            | The name of the transition to use while a picker is presented.                                                                                   |
@@ -116,7 +116,8 @@ import { isObject, isDefined, isFunction, isArray } from '../util/util';
  * | `popoverEnter`           | `string`            | The name of the transition to use while a popover is presented.                                                                                  |
  * | `popoverLeave`           | `string`            | The name of the transition to use while a popover is dismissed.                                                                                  |
  * | `spinner`                | `string`            | The default spinner to use when a name is not defined.                                                                                           |
- * | `swipeBackEnabled`       | `boolean`           | Whether native iOS swipe to go back functionality is enabled.
+ * | `swipeBackEnabled`       | `boolean`           | Whether native iOS swipe to go back functionality is enabled.                                                                                    |
+ * | `swipeMenuEnabled`       | `boolean|string`    | Sets the default value for the sidemenu swipe. Available options: true, false, "open" and "close".                                               |
  * | `tabsHighlight`          | `boolean`           | Whether to show a highlight line under the tab when it is selected.                                                                              |
  * | `tabsLayout`             | `string`            | The layout to use for all tabs. Available options: `"icon-top"`, `"icon-left"`, `"icon-right"`, `"icon-bottom"`, `"icon-hide"`, `"title-hide"`.  |
  * | `tabsPlacement`          | `string`            | The position of the tabs relative to the content. Available options: `"top"`, `"bottom"`                                                         |


### PR DESCRIPTION
DO NOT MERGE!
#### Changes proposed in this pull request:

New options for swipeEnabled:

```
  /**
   * @input {boolean|string} Whether or not swiping the menu should be enabled.
   * It accepts `true`, `false`, `"open"` and `"close"`. Default `true`.
   * - `true`: menu can be opened and closed with a finger swipe
   * - `false`: swipe gesture is completely disabled. Menu can only be opened programatically or using a button.
   * - `"open"`: menu can be opened with a swipe, but it can't be closed.
   * - `"close": menu can be closed with a swipe, but it can't be opened, you would still need a button to open it.
   */
```

This would allow ionic to match the side menu behavior of apps like netflix.

ping @bensperry @brandyscarney @adamdbradley 

This probably should be merged after releasing 2.0 final though
