### PR TITLE
refactor(bower): Using Angular 1.5.x instead of 1.5.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -48,9 +48,9 @@
     "js/ionic.js"
   ],
   "dependencies": {
-    "angular": "1.5.3",
-    "angular-animate": "1.5.3",
-    "angular-sanitize": "1.5.3",
+    "angular": "~1.5.3",
+    "angular-animate": "~1.5.3",
+    "angular-sanitize": "~1.5.3",
     "angular-ui-router": "0.2.13"
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Resolves the issue where a project may target Angular 1.5.4, while Ionic requires 1.5.3 specifically.
#### Changes proposed in this pull request:
- Updated bower.json to require Angular packages version ~1.5.

**Ionic Version**: 1.x

**Fixes**: #8863
