### PR TITLE
fix(chip): Icon alignment fix

### DIFF
--- a/src/components/chip/chip.scss
+++ b/src/components/chip/chip.scss
@@ -53,7 +53,8 @@ ion-chip ion-icon {
   height: $chip-icon-size;
 
   border-radius: $chip-icon-border-radius;
-
+  
+  text-align: center;
   font-size: $chip-icon-font-size;
   line-height: $chip-icon-size;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

UI fixes for `<ion-chip>` component (icon in chip alignment).

**Ionic Version**: 2.x

**Fixes**: #5386 
