### PR TITLE
[navPush] Check if the NavPush page exists onClick

### DIFF
--- a/src/components/nav/nav-push.ts
+++ b/src/components/nav/nav-push.ts
@@ -71,7 +71,7 @@ export class NavPush {
  */
   @HostListener('click')
   onClick(): boolean {
-    if (this._nav) {
+    if (this._nav && this.navPush) {
       this._nav.push(this.navPush, this.navParams, null);
       return false;
     }


### PR DESCRIPTION
#### Short description of what this resolves:

When using the NavPush directive there isn't a way to disable the nav. For example, while using a ion-card I was using `[navPush]` to go to the card detail page, and on the detail page I use the same card component, but don't want to push to anything. Not setting a page to the directive works, but there is an error thrown. 

Currently happening on click:

```
invalid page component: null
```

**Usage Example:**
So when `PushPage` is explicity set to a falsey value, nothing will happen.

``` typescript

@Input() isDetailPage;

PushPage: any = null

constructor() {
  if (!this.isDeatilPage) {
    this.PushPage = CardDetailPage
  }
}
```
#### Changes proposed in this pull request:
- Check for a page to push to before pushing.

**Ionic Version**: 1.x / 2.x
2.x
**Fixes**: #
