### PR TITLE
fix(platform): enable scrollAssist on Android

### DIFF
--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -76,6 +76,7 @@ export const PLATFORM_CONFIGS: {[key: string]: PlatformConfig} = {
         return 'ripple';
       },
       autoFocusAssist: 'immediate',
+      scrollAssist: true,
       hoverCSS: false,
       keyboardHeight: 300,
       mode: 'md',


### PR DESCRIPTION
#### Short description of what this resolves:

This fixes an issue where in Ionic 2 apps the native chrome functionality of auto scrolling when an input is focused does not currently work. This is a shorter term fix as the ultimate fix is to find what is causing the native chrome auto-scroll to not work in Ionic 2 apps. I have tested this on Android 5.1.1, 6.0.1 and 7.0. cc @mlynch @manucorporat 
#### Changes proposed in this pull request:
- set `scrollAssist` on Android

**Ionic Version**: 2.x

**Fixes**: #6228 
