### PR TITLE
fix(datetime): onChange without formControlName sets input-has-value …

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -837,6 +837,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     console.debug('datetime, onChange w/out formControlName', val);
     this.setValue(val);
     this.updateText();
+    this.checkHasValue(val);
     this.onTouched();
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:

When using an `<ion-datetime>` component outside of a form, `checkHasValue()` is not called during `onChange()`, which results in the `.input-has-value` missing from the `<ion-item>`
#### Changes proposed in this pull request:

Changes the default `onChange()` function to match `registerOnChange()` and invoke `this.checkHasValue(val);` after setting the value and updating the text.

**Ionic Version**: 2.0.0-rc.1
