### PR TITLE
refactor(events): call event handlers by passing all arguments as dif…

### DIFF
--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -100,7 +100,7 @@ export class Events {
 
     let responses: any[] = [];
     t.forEach((handler: any) => {
-      responses.push(handler(args));
+      responses.push(handler(...args));
     });
     return responses;
   }

--- a/src/util/test/events.spec.ts
+++ b/src/util/test/events.spec.ts
@@ -1,0 +1,39 @@
+import { Events } from '../events';
+
+fdescribe('Events service', () => {
+  let events: Events;
+  let listener: jasmine.Spy;
+
+  beforeEach(() => {
+    events = new Events();
+  });
+
+  it('should call listener when event is published', () => {
+    const eventParams = [{}, {}, {}];
+
+    listener = jasmine.createSpy('listener');
+    events.subscribe('test', listener);
+    events.publish('test', ...eventParams);
+
+    expect(listener).toHaveBeenCalledWith(...eventParams);
+  });
+
+  it('should unsubscribe listener', () => {
+    listener = jasmine.createSpy('listener');
+    events.subscribe('test', listener);
+    events.unsubscribe('test', listener);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should return an array of responses when event is published', () => {
+    const [response, anotherResponse] = [{}, {}];
+    const listener = jasmine.createSpy('listener').and.returnValue(response);
+    const anotherListener = jasmine.createSpy('anotherListener').and.returnValue(anotherResponse);
+
+    events.subscribe('test', listener, anotherListener);
+    const responses = events.publish('test');
+
+    expect(responses).toEqual([response, anotherResponse]);
+  });
+});


### PR DESCRIPTION
#### Short description of what this resolves:
This resolves #7314

#### Changes proposed in this pull request:
- pass all arguments as separate arguments instead of single array argument

**Ionic Version**: 2.x

**Fixes**: #7314

Also adds tests for Events service