### PR TITLE
perf(menu): avoiding change detection when unneeded

### DIFF
--- a/src/components/menu/menu-gestures.ts
+++ b/src/components/menu/menu-gestures.ts
@@ -21,6 +21,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
       threshold: 0,
       maxEdgeStart: menu.maxEdgeStart || 50,
       maxAngle: 40,
+      zone: false,
       debouncer: new NativeRafDebouncer(),
       gesture: gestureCtrl.create('menu-swipe', {
         priority: GesturePriority.MenuSwipe,
@@ -58,7 +59,6 @@ export class MenuContentGesture extends SlideEdgeGesture {
       'z', z,
       'stepValue', stepValue);
 
-    ev.preventDefault();
     this.menu.swipeProgress(stepValue);
   }
 

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -450,7 +450,11 @@ export class Menu {
       return;
     }
     this._getType().setProgessStep(stepValue);
-    this.ionDrag.emit(stepValue);
+
+    let ionDrag = this.ionDrag;
+    if (ionDrag.observers.length > 0) {
+      this._zone.run(ionDrag.emit.bind(ionDrag, stepValue));
+    }
   }
 
   /**


### PR DESCRIPTION
BEFORE:
<img width="539" alt="screen shot 2016-11-02 at 01 00 21" src="https://cloud.githubusercontent.com/assets/127379/19913327/ed1047fe-a0a1-11e6-9edb-f37eb5aa673b.png">


AFTER:
<img width="564" alt="screen shot 2016-11-02 at 00 58 56" src="https://cloud.githubusercontent.com/assets/127379/19913328/ed111d32-a0a1-11e6-8ba5-f574e1cf8bdc.png">

