### PR TITLE
Fix - Update spelling in toolbar-title.ts docs

### DIFF
--- a/src/components/toolbar/toolbar-title.ts
+++ b/src/components/toolbar/toolbar-title.ts
@@ -29,7 +29,7 @@ import { Toolbar } from './toolbar';
  * <ion-header>
  *
  *   <ion-navbar>
- *     <ion-title>Main Heder</ion-title>
+ *     <ion-title>Main Header</ion-title>
  *   </ion-navbar>
  *
  *   <ion-toolbar>


### PR DESCRIPTION
#### Short description of what this resolves:

This resolves a spelling mistake in the toolbar-title.ts docs
#### Changes proposed in this pull request:

- Spelling mistake

**Ionic Version**: 2.x

**Fixes**: #

A basic spelling change in the toolbar-title.ts documentation (heder to header)