### PR TITLE
perf(item): improves performance of sliding item

### DIFF
--- a/src/components/item/item-sliding-gesture.ts
+++ b/src/components/item/item-sliding-gesture.ts
@@ -4,6 +4,7 @@ import { List } from '../list/list';
 import { GesturePriority } from '../../gestures/gesture-controller';
 import { PanGesture } from '../../gestures/drag-gesture';
 import { pointerCoord } from '../../util/dom';
+import { NativeRafDebouncer } from '../../util/debouncer';
 
 const DRAG_THRESHOLD = 10;
 const MAX_ATTACK_ANGLE = 20;
@@ -19,6 +20,8 @@ export class ItemSlidingGesture extends PanGesture {
     super(list.getNativeElement(), {
       maxAngle: MAX_ATTACK_ANGLE,
       threshold: DRAG_THRESHOLD,
+      zone: false,
+      debouncer: new NativeRafDebouncer(),
       gesture: list._gestureCtrl.create('item-sliding', {
         priority: GesturePriority.SlidingItem,
       })

--- a/src/components/item/item-sliding.ts
+++ b/src/components/item/item-sliding.ts
@@ -402,7 +402,10 @@ export class ItemSliding {
     }
 
     this.item.setElementStyle(CSS.transform, `translate3d(${-openAmount}px,0,0)`);
-    this._zone.run(() => this.ionDrag.emit(this));
+    let ionDrag = this.ionDrag;
+    if (ionDrag.observers.length > 0) {
+      this._zone.run(ionDrag.emit.bind(ionDrag, this));
+    }
   }
 
   private _setState(state: SlidingState) {


### PR DESCRIPTION
Same technique used in this PR: https://github.com/driftyco/ionic/pull/8986

This PR should improves dramatically the performance in low end devices:

BEFORE:
<img width="143" alt="screen shot 2016-11-03 at 01 00 41" src="https://cloud.githubusercontent.com/assets/127379/19959394/c70c4188-a1a6-11e6-89c9-59d6ac268567.png">

AFTER:
<img width="167" alt="screen shot 2016-11-03 at 09 22 27" src="https://cloud.githubusercontent.com/assets/127379/19959438/2264c442-a1a7-11e6-9e16-e57ab468fef0.png">


**Fixes**: #

- Using new NativeRafDebouncer
- Events are not zone wrapped unless strictly necessary