### PR TITLE
fix(errorhandler): class should implements ErrorHandler

### DIFF
--- a/src/util/ionic-error-handler.ts
+++ b/src/util/ionic-error-handler.ts
@@ -1,11 +1,13 @@
+import { ErrorHandler } from '@angular/core';
+
 /**
  * This class is an internal error handler for Ionic. We can often add
  * some nice goodies to the dev/debugging process by reporting to our
  * dev server. To use this class, call `IonicErrorHandler.handleError(err)` from
  * inside a custom `ErrorHandler` as described here: https://angular.io/docs/ts/latest/api/core/index/ErrorHandler-class.html
  */
-export class IonicErrorHandler {
-  static handleError(err: any): void {
+export class IonicErrorHandler implements ErrorHandler {
+  handleError(err: any): void {
     let server = window['IonicDevServer'];
     if (server) {
       server.handleError(err);


### PR DESCRIPTION
#### Short description of what this resolves:
Register ErrorHandler ```IonicErrorHandler```
```
...
{ provide: ErrorHandler, useClass: IonicErrorHandler }
...
```

Problem in ionic-app-scripts with command ```ionic-app-scripts serve``` return
```
polyfills.js:3 Unhandled Promise rejection: errorHandler.handleError is not a function ; Zone: <root> ; Task: Promise.then ; Value: TypeError: errorHandler.handleError is not a function(…) TypeError: errorHandler.handleError is not a function
    at http://localhost:8100/build/main.js:7929:30
    at t.invoke (http://localhost:8100/build/polyfills.js:3:13422)
    at Object.onInvoke (http://localhost:8100/build/main.js:7545:37)
    at t.invoke (http://localhost:8100/build/polyfills.js:3:13373)
    at e.run (http://localhost:8100/build/polyfills.js:3:10809)
    at http://localhost:8100/build/polyfills.js:3:8911
    at t.invokeTask (http://localhost:8100/build/polyfills.js:3:14051)
    at Object.onInvokeTask (http://localhost:8100/build/main.js:7536:37)
    at t.invokeTask (http://localhost:8100/build/polyfills.js:3:13987)
    at e.runTask (http://localhost:8100/build/polyfills.js:3:11411)o @ polyfills.js:3r @ polyfills.js:3i @ polyfills.js:3
polyfills.js:3 Error: Uncaught (in promise): TypeError: errorHandler.handleError is not a function(…)
```

**Ionic Version**: rc2

**Fixes**: #

