### PR TITLE
fixed create a duplicated view history and resetting backViewId for g…

### DIFF
--- a/js/angular/service/history.js
+++ b/js/angular/service/history.js
@@ -189,6 +189,11 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
       if (lastStateId !== currentStateId) {
         lastStateId = currentStateId;
         stateChangeCounter++;
+      } else {
+        if (currentView) {
+          viewId = currentView.viewId;
+          action = ACTION_INITIAL_VIEW;
+        }
       }
 
       if (forcedNav) {
@@ -251,6 +256,8 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
           historyId = forwardView.historyId;
         }
 
+        forwardView.backViewId = currentView.viewId ? currentView.viewId : null;
+
       } else if (currentView && currentView.historyId !== historyId &&
                 hist.cursor > -1 && hist.stack.length > 0 && hist.cursor < hist.stack.length &&
                 hist.stack[hist.cursor].stateId === currentStateId) {
@@ -290,7 +297,7 @@ function($rootScope, $state, $location, $window, $timeout, $ionicViewSwitcher, $
           hist.stack[hist.cursor].backViewId = currentView.viewId;
         }
 
-      } else {
+      } else if (!currentView || !action) {
 
         // create an element from the viewLocals template
         ele = $ionicViewSwitcher.createViewEle(viewLocals);


### PR DESCRIPTION
#### Short description of what this resolves:
* Sometimes duplicated view object are created. So back button will not disappear.
* I want to share a specific view (`Employee Detail`) without a tabs. But move to `Employee Detail` view, I can not move back('Search Employee') by following code. (js/angular/history.js (L: 54089))
```javascript
// the new view is being removed from it's old position in the history and being placed at the top,
// so we need to update any views that reference it as a backview, otherwise there will be infinitely loops
var viewIds = Object.keys(viewHistory.views);
viewIds.forEach(function(viewId) {
  var view = viewHistory.views[viewId];
  if ( view.backViewId === switchToView.viewId ) {
    view.backViewId = null;
  }
});
```

#### Changes proposed in this pull request:

- Prevent create a duplicated view object on histories.
- Reallocate a `forwardView.backViewId` when move to forward view.


#### Before fixed:
* Back button will not disappear on tab view.
![before0](https://cloud.githubusercontent.com/assets/8110371/20031275/2e7d84b8-a3b8-11e6-8fb0-06c39ca5dbed.gif)
  
* Tab -> SideMenu -> `Search Employee` -> `Employee Detail` -> `Search Employee` -> Tab -> SideMenu -> `Search Employee` -> `Employee Detail` -> can not move to `Search Employee`
![before](https://cloud.githubusercontent.com/assets/8110371/20030868/1b8b15d4-a3b1-11e6-9ec9-13a44233ee2f.gif)

#### After fixed:
* It works fine all tabs.
![after](https://cloud.githubusercontent.com/assets/8110371/20030873/38623174-a3b1-11e6-859b-986905e04d92.gif)

**Ionic Version**: 1.3

**Fixes**: #