### PR TITLE
Add more information about device() object returned

### DIFF
--- a/js/utils/platform.js
+++ b/js/utils/platform.js
@@ -22,6 +22,22 @@
    * A set of utility methods that can be used to retrieve the device ready state and
    * various other information such as what kind of platform the app is currently installed on.
    *
+   * ionic.Platform.device() will return the following object with the example from calling on iOS device,
+   *
+   * {
+   *    available: true,
+   *    platform: iOS,
+   *    version: 10.1,
+   *    uuid: XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX,
+   *    cordova: 4.2.1,
+   *    model: iPhone8.1,
+   *    manufacturer: Apple,
+   *    isVirtual: false,
+   *    serial: unknown
+   * }
+   *
+   * So you can get particular information out of ionic.Platform.device().
+   *
    * @usage
    * ```js
    * angular.module('PlatformApp', ['ionic'])


### PR DESCRIPTION
#### Short description of what this resolves:
Added more information about device() object.

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

More information about ionic.Platform.device() should be added as developers can know right away which piece of information they need. Those properties are available only on real device, thus it's not so convenient to test it on browsers. This will help them.