### PR TITLE
docs(input): fix typo in documentation

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -321,7 +321,7 @@ export class TextArea extends InputBase {
   }
 
   /**
-   * @input {bool} Wheather the textara should be disabled or not
+   * @input {bool} Wheather the textarea should be disabled or not
    */
   @Input()
   get disabled() {


### PR DESCRIPTION
#### Short description of what this resolves:

fix typo in input's documentation

**Ionic Version**: 2.x