### PR TITLE
Improve IE support

### DIFF
--- a/src/components/fab/fab.scss
+++ b/src/components/fab/fab.scss
@@ -156,7 +156,7 @@ ion-fab-list[side=right] .fab-in-list {
 }
 
 ion-fab-list[side=top] {
-  top: initial;
+  top: auto;
   bottom: 0;
 
   flex-direction: column-reverse;

--- a/src/themes/util.scss
+++ b/src/themes/util.scss
@@ -57,8 +57,7 @@ ion-input :focus {
   display: block;
 
   opacity: 0;
-  transform: translate3d(0, -100%, 0);
-  transform: translate3d(0, calc(-100% + 1px), 0);
+  transform: translate3d(0, -100%, 0) translateY(1px);
 
   // background: red;
   // opacity: .3;


### PR DESCRIPTION
#### Short description of what this resolves:
1. IE does not support `calc` inside `transform` ([bug](https://connect.microsoft.com/IE/feedback/details/762719/css3-calc-bug-inside-transition-or-transform)). This causes the transform to fail and the `.click-block` to be active at all times, making Ionic apps unusable on IE. It looks there was a fallback in place without using `calc`, but that gets removed when building the Ionic source.

2. IE does not support the `initial` CSS value ([Can I Use](http://caniuse.com/css-initial-value)). This is used in [a few places](https://github.com/driftyco/ionic/search?l=SCSS&q=initial&utf8=%E2%9C%93), but in most cases it does not matter functionally (only visually). It *does* matter where it's used in the `ion-fab`, where a list that opens to the top is instead shown below.

I know IE is not officially supported by Ionic 2, but I certainly hope that this kind of small community-provided fixes will be merged! :)

I have another few visual fixes for IE, please let me know if you'd like to accept them as well.

#### Changes proposed in this pull request:

1. Use a `transform` with multiple `translate`'s in it. This achieves the same translation without using `calc`.

2. Use `top: auto;` instead of `top: initial;`, which *is* the initial value for `top` [source](https://developer.mozilla.org/en-US/docs/Web/CSS/top).

**Ionic Version**:
2.x

**Fixes**:
#8828 
#8669

