### PR TITLE
docs(popover): add note about using setRoot()

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -132,6 +132,17 @@ export class Popover extends ViewController {
  *   }
  * }
  * ```
+ * > Note that if using a `NavController` method such as `push()` or `setRoot()` inside a popover
+ * you must first grab a reference to the root `NavController`. Below is an example of this.
+ * 
+ * ```ts
+ *  constructor(public app: App) {}
+ *  
+ *  setRootOnPage() {
+ *    this.app.getRootNav().push(SupportPage);
+ *  }
+ * ```
+ *
  * @advanced
  * Popover Options
  *


### PR DESCRIPTION
#### Short description of what this resolves:
A common pain point among our users with popover is how to use `NavController` methods from a popover. This note adds an example of how to do this.

#### Changes proposed in this pull request:

- Add note about using `NavController` methods from a popover

**Ionic Version**: 2.x

