### PR TITLE
docs(navController): add note about overlay components

### DIFF
--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -18,7 +18,7 @@ import { ViewController } from './view-controller';
  * arbitrary locations in history.
  *
  * The current page is the last one in the array, or the top of the stack if we
- * think of it that way.  [Pushing](#push) a new page onto the top of the
+ * think of it that way. [Pushing](#push) a new page onto the top of the
  * navigation stack causes the new page to be animated in, while [popping](#pop)
  * the current page will navigate to the previous page in the stack.
  *
@@ -33,7 +33,6 @@ import { ViewController } from './view-controller';
  *
  * ```typescript
  * import { Component } from `@angular/core`;
- * import { ionicBootstrap } from 'ionic-angular';
  * import { StartPage } from './start-page';
  *
  * @Component(
@@ -47,7 +46,6 @@ import { ViewController } from './view-controller';
  *   }
  * }
  *
- * ionicBootstrap(MyApp);
  * ```
  *
  * ### Injecting NavController
@@ -85,10 +83,10 @@ import { ViewController } from './view-controller';
  *
  * ```typescript
  *
- * import { App, ViewChild } from '@angular/core';
+ * import { Component, ViewChild } from '@angular/core';
  * import { NavController } from 'ionic-angular';
  *
- * @App({
+ * @Component({
  *    template: '<ion-nav #myNav [root]="rootPage"></ion-nav>'
  * })
  * export class MyApp {
@@ -103,6 +101,36 @@ import { ViewController } from './view-controller';
  *    }
  * }
  * ```
+ *
+ * ### Navigating from an Overlay Component
+ * What if you wanted to navigate from an overlay component (popover, modal, alert, etc)?
+ * For this, you need to have access to the root `NavController`.
+ *
+ * ```typescript
+ * import { Component } from '@angular/core';
+ * import { App, ViewController } from 'ionic-angular';
+ *
+ * @Component({
+ *     template: `
+ *     <ion-content>
+ *       <h1>My PopoverPage</h1>
+ *       <button ion-button (click)="pusPage()">Call pushPage</button>
+ *      </ion-content>
+ *     `
+ *   })
+ *   class PopoverPage {
+ *     constructor(
+ *       public viewCtrl: ViewController
+ *       public appCtrl: App
+ *     ) {}
+ *
+ *     pushPage() {
+ *       this.viewCtrl.dismiss();
+ *       this.appCtrl.getRootNav().push(SecondPage);
+ *     }
+ *   }
+ *```
+ *
  *
  * ## View creation
  * Views are created when they are added to the navigation stack.  For methods

--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -94,7 +94,7 @@ import { ViewController } from './view-controller';
  *    public rootPage = TabsPage;
  *
  *    // Wait for the components in MyApp's template to be initialized
- *    // In this case, we are waiting for the Nav with refernce varialbe of "#myNa"
+ *    // In this case, we are waiting for the Nav with reference variable of "#myNav"
  *    ngOnInit() {
  *       // Let's navigate from TabsPage to Page1
  *       this.nav.push(Page1);

--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -40,7 +40,7 @@ import { ViewController } from './view-controller';
  * })
  * class MyApp {
  *   // set the rootPage to the first page we want displayed
- *   private rootPage: any = StartPage;
+ *   public rootPage: any = StartPage;
  *
  *   constructor(){
  *   }
@@ -91,11 +91,11 @@ import { ViewController } from './view-controller';
  * })
  * export class MyApp {
  *    @ViewChild('myNav') nav: NavController
- *    private rootPage = TabsPage;
+ *    public rootPage = TabsPage;
  *
  *    // Wait for the components in MyApp's template to be initialized
- *    // In this case, we are waiting for the Nav with id="my-nav"
- *    ngAfterViewInit() {
+ *    // In this case, we are waiting for the Nav with refernce varialbe of "#myNa"
+ *    ngOnInit() {
  *       // Let's navigate from TabsPage to Page1
  *       this.nav.push(Page1);
  *    }
@@ -223,7 +223,7 @@ import { ViewController } from './view-controller';
  *   <ion-content>I'm the other page!</ion-content>`
  * })
  * class OtherPage {
- *    constructor(private navCtrl: NavController ){
+ *    constructor(public navCtrl: NavController ){
  *    }
  *
  *    popView(){

--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -104,7 +104,9 @@ import { ViewController } from './view-controller';
  *
  * ### Navigating from an Overlay Component
  * What if you wanted to navigate from an overlay component (popover, modal, alert, etc)?
- * For this, you need to have access to the root `NavController`.
+ * In this example, we've displayed a popover in our app. From the popover, we'll get a
+ * reference of the root `NavController` in our app, using the `getRootNav()` method.
+ *
  *
  * ```typescript
  * import { Component } from '@angular/core';
@@ -114,7 +116,7 @@ import { ViewController } from './view-controller';
  *     template: `
  *     <ion-content>
  *       <h1>My PopoverPage</h1>
- *       <button ion-button (click)="pusPage()">Call pushPage</button>
+ *       <button ion-button (click)="pushPage()">Call pushPage</button>
  *      </ion-content>
  *     `
  *   })


### PR DESCRIPTION
#### Short description of what this resolves:
A common feature is when people display an overlay component, they want to navigate from that.
But we don't document how to do that.

#### Changes proposed in this pull request:

- Add note in NavController docs about overlay components

**Ionic Version**: 1.x / 2.x
2.x


