### PR TITLE
fix(gesture): pass type to hammer.get() so pinch and rotate can be en…

### DIFF
--- a/src/gestures/gesture.ts
+++ b/src/gestures/gesture.ts
@@ -38,7 +38,7 @@ export class Gesture {
 
   on(type: string, cb: Function) {
     if (type === 'pinch' || type === 'rotate') {
-      this._hammer.get('pinch').set({enable: true});
+      this._hammer.get(type).set({enable: true});
     }
     this._hammer.on(type, cb);
     (this._callbacks[type] || (this._callbacks[type] = [])).push(cb);


### PR DESCRIPTION
#### Short description of what this resolves:

only 'pinch' was being enabled in Gesture.on()

#### Changes proposed in this pull request:

- pass type to this._hammer.get() instead of 'pinch'

**Ionic Version**: 2.x

**Fixes**: #
