### PR TITLE
fix(clickBlock): add clickblock to ngModule declarations

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -33,7 +33,7 @@ import { registerTransitions } from './transitions/transition-registry';
 import { TransitionController } from './transitions/transition-controller';
 import { AppRootToken } from './components/app/app-root';
 import { UrlSerializer, setupUrlSerializer, DeepLinkConfigToken } from './navigation/url-serializer';
-
+import { ClickBlock } from './util/click-block';
 /**
  * Import Overlay Entry Components
  */
@@ -107,7 +107,8 @@ export { ViewController } from './navigation/view-controller';
     ModalCmp,
     PickerCmp,
     PopoverCmp,
-    ToastCmp
+    ToastCmp,
+    ClickBlock
   ],
   entryComponents: [
     ActionSheetCmp,


### PR DESCRIPTION
#### Short description of what this resolves:
With 2.1.2 compiler, ngc will fail if click block is not added to declarations

#### Changes proposed in this pull request:

- add click block to ngModule declarations
-
-

**Ionic Version**: 1.x / 2.x
2.x rc4

