### PR TITLE
Update tabs.ts documentation

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -137,7 +137,7 @@ import { ViewController } from '../../navigation/view-controller';
  *
  *```ts
  * switchTabs() {
- *   this.navCtrl.parent.switch(2);
+ *   this.navCtrl.parent.select(2);
  * }
  *```
  * @demo /docs/v2/demos/src/tabs/


### PR DESCRIPTION
#### Short description of what this resolves:
There is an error in the documentation concerning the tabs. In order to change the active tab from a child tab component 
```
this.navCtrl.parent.select(2)
``` 
has to be called instead of 
```
this.navCtrl.parent.switch(2)
```
 that is stated
