### PR TITLE
fix(toolbar): do not apply height for .statusbar-padding

### DIFF
--- a/src/platform/cordova.scss
+++ b/src/platform/cordova.scss
@@ -44,9 +44,6 @@ $cordova-statusbar-padding-modal-max-width:         767px !default;
 
   > .toolbar.statusbar-padding:first-child {
     padding-top: calc(#{$cordova-statusbar-padding} + #{$toolbar-padding});
-
-    height: calc(#{$toolbar-height} + #{$cordova-statusbar-padding});
-    min-height: calc(#{$toolbar-height} + #{$cordova-statusbar-padding});
   }
 
   > ion-content.statusbar-padding:first-child .scroll-content {

--- a/src/platform/cordova.scss
+++ b/src/platform/cordova.scss
@@ -44,6 +44,8 @@ $cordova-statusbar-padding-modal-max-width:         767px !default;
 
   > .toolbar.statusbar-padding:first-child {
     padding-top: calc(#{$cordova-statusbar-padding} + #{$toolbar-padding});
+
+    min-height: calc(#{$toolbar-height} + #{$cordova-statusbar-padding});
   }
 
   > ion-content.statusbar-padding:first-child .scroll-content {


### PR DESCRIPTION
#### Short description of what this resolves:
Related Issue
https://github.com/driftyco/ionic/issues/9395

#### Changes proposed in this pull request:

- The height and min-height is no longer applied to the toolbar when `.statusbar-padding` class is present.

**Ionic Version**:  2.x

**Fixes**: #

toolbar-statusbar-padding should only add padding-top