### PR TITLE
Added option to collection-repeat to use original scroll content size

### DIFF
--- a/js/angular/directive/collectionRepeat.js
+++ b/js/angular/directive/collectionRepeat.js
@@ -468,6 +468,10 @@ function RepeatManagerFactory($rootScope, $window, $$rAF) {
     var itemsShownMap = {};
     var nextItemId = 0;
 
+    var scrollViewSetDimensions = isVertical ?
+      function() { scrollView.setDimensions(null, null, null, getContentSize(), true); } :
+      function() { scrollView.setDimensions(null, null, getContentSize(), null, true); };
+
     // view is a mix of list/grid methods + static/dynamic methods.
     // See bottom for implementations. Available methods:
     //
@@ -485,10 +489,6 @@ function RepeatManagerFactory($rootScope, $window, $$rAF) {
       angular.bind(view, view.getContentSize);
 
     scrollView.options[contentSizeStr] = getContentSize;
-
-    var scrollViewSetDimensions = isVertical ?
-      function() { scrollView.setDimensions(null, null, null, getContentSize(), true); } :
-      function() { scrollView.setDimensions(null, null, getContentSize(), null, true); };
 
     scrollView.__$callback = scrollView.__callback;
     scrollView.__callback = function(transformLeft, transformTop, zoom, wasResize) {


### PR DESCRIPTION
#### Short description of what this resolves:

Combining the `collection-repeat` directive with the pull-to-search pattern cause issues as the scroll view size is forced to the list size and ignore the original scroll view content size.

#### Changes proposed in this pull request:

This patch adds a `use-content-size="true"` option to the directive to fix this behavior.
When enabled, you can use css to apply a minimum width or height to the scroll view content, and it will be used instead of overriding it with the list size.

**Ionic Version**: 1.x

**Fixes**: https://forum.ionicframework.com/t/collection-repeat-and-pull-to-search/71603

