### PR TITLE
ionInfiniteScroll on-infinite is not called

### DIFF
--- a/js/angular/controller/infiniteScrollController.js
+++ b/js/angular/controller/infiniteScrollController.js
@@ -61,17 +61,17 @@ function($scope, $attrs, $element, $timeout) {
     if (self.jsScrolling) {
       maxScroll = self.getJSMaxScroll();
       var scrollValues = self.scrollView.getValues();
-      if ((maxScroll.left !== -1 && scrollValues.left >= maxScroll.left) ||
-        (maxScroll.top !== -1 && scrollValues.top >= maxScroll.top)) {
+      if ((maxScroll.left !== null && scrollValues.left >= maxScroll.left) ||
+        (maxScroll.top !== null && scrollValues.top >= maxScroll.top)) {
         onInfinite();
       }
     } else {
       maxScroll = self.getNativeMaxScroll();
       if ((
-        maxScroll.left !== -1 &&
+        maxScroll.left !== null &&
         self.scrollEl.scrollLeft >= maxScroll.left - self.scrollEl.clientWidth
         ) || (
-        maxScroll.top !== -1 &&
+        maxScroll.top !== null &&
         self.scrollEl.scrollTop >= maxScroll.top - self.scrollEl.clientHeight
         )) {
         onInfinite();
@@ -86,10 +86,10 @@ function($scope, $attrs, $element, $timeout) {
     return {
       left: self.scrollView.options.scrollingX ?
         calculateMaxValue(maxValues.left) :
-        -1,
+        null,
       top: self.scrollView.options.scrollingY ?
         calculateMaxValue(maxValues.top) :
-        -1
+        null
     };
   };
 
@@ -104,12 +104,12 @@ function($scope, $attrs, $element, $timeout) {
         (computedStyle.overflowX === 'scroll' ||
         computedStyle.overflowX === 'auto' ||
         self.scrollEl.style['overflow-x'] === 'scroll') ?
-        calculateMaxValue(maxValues.left) : -1,
+        calculateMaxValue(maxValues.left) : null,
       top: maxValues.top &&
         (computedStyle.overflowY === 'scroll' ||
         computedStyle.overflowY === 'auto' ||
         self.scrollEl.style['overflow-y'] === 'scroll' ) ?
-        calculateMaxValue(maxValues.top) : -1
+        calculateMaxValue(maxValues.top) : null
     };
   };
 

--- a/test/unit/angular/directive/infiniteScroll.unit.js
+++ b/test/unit/angular/directive/infiniteScroll.unit.js
@@ -158,16 +158,16 @@ describe('ionicInfiniteScroll directive', function() {
         it('should default to 2.5%', function() {
           setupJS('', {}, opts);
           expect(ctrl.getJSMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue * 0.975 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue * 0.975 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue * 0.975 : null,
+            top: opts.scrollingY ? scrollTopMaxValue * 0.975 : null
           });
 
           setupNative('', {}, opts);
           var tmp = window.getComputedStyle;
           window.getComputedStyle = function() {return {};};
           expect(ctrl.getNativeMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue * 0.975 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue * 0.975 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue * 0.975 : null,
+            top: opts.scrollingY ? scrollTopMaxValue * 0.975 : null
           });
           window.getComputedStyle = tmp;
         });
@@ -175,8 +175,8 @@ describe('ionicInfiniteScroll directive', function() {
         it('should use attr.distance as number', function() {
           setupJS('distance=3', {}, opts);
           expect(ctrl.getJSMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue - 3 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue - 3 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue - 3 : null,
+            top: opts.scrollingY ? scrollTopMaxValue - 3 : null
           });
 
           setupNative('distance=3', {}, opts);
@@ -184,8 +184,8 @@ describe('ionicInfiniteScroll directive', function() {
           var tmp = window.getComputedStyle;
           window.getComputedStyle = function() {return {};};
           expect(ctrl.getNativeMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue - 3 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue - 3 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue - 3 : null,
+            top: opts.scrollingY ? scrollTopMaxValue - 3 : null
           });
           window.getComputedStyle = tmp;
         });
@@ -193,8 +193,8 @@ describe('ionicInfiniteScroll directive', function() {
         it('should use attr.distance as percent', function() {
           setupJS('distance=5%', {}, opts);
           expect(ctrl.getJSMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue * 0.95 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue * 0.95 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue * 0.95 : null,
+            top: opts.scrollingY ? scrollTopMaxValue * 0.95 : null
           });
 
           setupNative('distance=5%', {}, opts);
@@ -202,8 +202,8 @@ describe('ionicInfiniteScroll directive', function() {
           var tmp = window.getComputedStyle;
           window.getComputedStyle = function() {return {};};
           expect(ctrl.getNativeMaxScroll()).toEqual({
-            left: opts.scrollingX ? scrollLeftMaxValue * 0.95 : -1,
-            top: opts.scrollingY ? scrollTopMaxValue * 0.95 : -1
+            left: opts.scrollingX ? scrollLeftMaxValue * 0.95 : null,
+            top: opts.scrollingY ? scrollTopMaxValue * 0.95 : null
           });
           window.getComputedStyle = tmp;
         });


### PR DESCRIPTION
#### Short description of what this resolves:
ion-infinite-scroll directive doesn't call on-infinite callback on some occasions.
CodePen example for bug: http://codepen.io/anon/pen/Roxrzz
CodePen example where everything works fine: http://codepen.io/anon/pen/aBENpQ
Second example shows the ion-infinite-scroll working as expected.
First example recreates the bug. note that the only change is the distance attribute of ion-infinite-scroll

#### Changes proposed in this pull request:

- Change special value from "-1" to "null"

**Ionic Version**: 1.x / 2.x
1.x

**Fixes**: #

When scroll container size differs from ionInfiniteScroll distance by -1 the on-infinite function won't be called.
"-1" was used as a special value, but "-1" might be a result of regular usage.