### PR TITLE
Add id attribute and value set from Input Options

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -50,7 +50,7 @@ import { ViewController } from '../../navigation/view-controller';
         '<template ngSwitchDefault>' +
           '<div class="alert-input-group">' +
             '<div *ngFor="let i of d.inputs" class="alert-input-wrapper">' +
-              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" class="alert-input">' +
+              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" [id]="i.id" class="alert-input">' +
             '</div>' +
           '</div>' +
         '</template>' +
@@ -153,7 +153,7 @@ export class AlertCmp {
         label: input.label,
         checked: !!input.checked,
         disabled: !!input.disabled,
-        id: `alert-input-${this.id}-${index}`,
+        id: `alert-input-${input.id}-${index}`,
         handler: isPresent(input.handler) ? input.handler : null,
       };
     });

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -126,7 +126,9 @@ export class Alert extends ViewController {
  * inputs. Do note however, different types of "text"" inputs can be mixed,
  * such as `url`, `email`, `text`, etc. If you require a complex form UI
  * which doesn't fit within the guidelines of an alert then we recommend
- * building the form within a modal instead.
+ * building the form within a modal instead. When using the `id` option, please 
+ * note the value of `id` will be written to the DOM as `alert-input-[id]-[index]`, 
+ * where index is the index of the input option.
  *
  *
  * @usage
@@ -231,7 +233,7 @@ export class Alert extends ViewController {
  *  | value       | `string`  | The input's value.                                              |
  *  | label       | `string`  | The input's label (only for radio/checkbox inputs)              |
  *  | checked     | `boolean` | Whether or not the input is checked.                            |
- *  | id          | `string`  | The input's id.                                                 |
+ *  | id          | `string`  | The input's id.(written to the DOM as alert-input-{id}-{index}) |
  *
  *  Button options
  *


### PR DESCRIPTION
#### Short description of what this resolves:
Adds ID attribute which was set in AlertOptions [inputs]

**Ionic Version**: 2.x

**Fixes**: #

https://github.com/driftyco/ionic/issues/9457