### PR TITLE
Slides - add onInit EventEmitter

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -322,6 +322,11 @@ export class Slides extends Ion {
    */
   @Output() ionDrag: EventEmitter<any> = new EventEmitter();
 
+  /**
+   * @output {any} Expression to evaluate when the slider initializes.
+   */
+  @Output() onInit: EventEmitter<any> = new EventEmitter();
+
 
   constructor(config: Config, elementRef: ElementRef, renderer: Renderer) {
     super(config, elementRef, renderer, 'slides');
@@ -390,6 +395,10 @@ export class Slides extends Ion {
     options.onSliderMove = (swiper: any, e: any) => {
       this.ionDrag.emit(swiper);
       return this.options.onSliderMove && this.options.onSliderMove(swiper, e);
+    };
+    options.onInit = (swiper: any) => {
+      this.onInit.emit(swiper);
+      return this.options.onInit && this.options.onInit(swiper);
     };
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Until now its quite hard to get notified if a slider is fully initialized (to do something with the idangous swiper instance). 

http://idangero.us/swiper/api/#.WENF4KI19E4

#### Changes proposed in this pull request:
This PR adds an `onInit` eventemitter which emits when the `onInit` function of the idangerous swiper is called.

```
@ViewChild('pageSlider') pageSlider: Slides;
@ViewChild('headerSlider') headerSlider: Slides;
...

this.headerSlider.onInit.subscribe(swiper => {
// do stuff with the idangerous swiper...
});

...
combineLatest(this.headerSlider.onInit, this.pageSlider.onInit)
   .subscribe(([headerSlider, pageSlider]) => {
      if(!headerSlider || !pageSlider) return
      pageSlider.params.control = headerSlider;
      headerSlider.params.control = pageSlider;
   })
```

**Ionic Version**: 2.x

