### PR TITLE
fix(util): replace implicit any in dom-controller

### DIFF
--- a/src/util/dom-controller.ts
+++ b/src/util/dom-controller.ts
@@ -7,7 +7,7 @@ import { nativeRaf } from './dom';
 import { removeArrayItem } from './util';
 
 
-export type DomCallback = { (timeStamp: number) };
+export type DomCallback = { (timeStamp: number): any };
 
 export class DomDebouncer {
 

--- a/src/util/dom-controller.ts
+++ b/src/util/dom-controller.ts
@@ -7,7 +7,7 @@ import { nativeRaf } from './dom';
 import { removeArrayItem } from './util';
 
 
-export type DomCallback = { (timeStamp: number): any };
+export type DomCallback = { (timeStamp: number): void };
 
 export class DomDebouncer {
 


### PR DESCRIPTION
#### Short description of what this resolves:
Latest nightly throws me an error on serve.
```
[12:39:25]  typescript: node_modules/ionic-angular/util/dom-controller.d.ts, line: 2 
            Call signature, which lacks return-type annotation, implicitly has an 'any' return type. 

       L1:  export declare type DomCallback = {
       L2:      (timeStamp: number);
       L3:  };

[12:39:25]  transpile failed 
```

I'm using `"noImplicitAny": true` in my `tsconfig.json` `compilerOptions`, which some other developers will probably be using as well.

#### Changes proposed in this pull request:

- Add an explicit `any` return type

**Ionic Version**: 2.0.0-rc.3-201612021933

