### PR TITLE
fix(tabs): current tab still active if selected tab does not have a root

### DIFF
--- a/src/components/tabs/test/advanced/app-module.ts
+++ b/src/components/tabs/test/advanced/app-module.ts
@@ -1,5 +1,5 @@
 import { Component, NgModule, ViewChild } from '@angular/core';
-import { /*DeepLink,*/ DeepLinkConfig, IonicApp, IonicModule, App, NavController, NavParams, ModalController, ViewController, Tabs, Tab } from '../../../..';
+import { /*DeepLink,*/AlertController, DeepLinkConfig, IonicApp, IonicModule, App, NavController, NavParams, ModalController, ViewController, Tabs, Tab } from '../../../..';
 
 
 // @DeepLink({ name: 'sign-in' })
@@ -35,7 +35,12 @@ export class TabsPage {
 
   @ViewChild(Tabs) tabs: Tabs;
 
-  constructor(public modalCtrl: ModalController, public params: NavParams) {}
+  constructor(
+    public navCtrl: NavController,
+    public modalCtrl: ModalController,
+    public params: NavParams,
+    public alertCtrl: AlertController
+  ) { }
 
   ngAfterViewInit() {
     this.tabs.ionChange.subscribe((tab: Tab) => {
@@ -49,6 +54,39 @@ export class TabsPage {
     // wired up through the template
     // <ion-tabs (ionChange)="onTabChange()">
     console.log('onTabChange');
+  }
+
+  logout() {
+    this.navCtrl.pop().catch(() => {
+      console.log('Cannot go back.');
+    });
+  }
+
+  ionViewCanLeave() {
+    return new Promise((resolve, reject) => {
+      let alert = this.alertCtrl.create({
+        title: 'Log out',
+        subTitle: 'Are you sure you want to log out?',
+        buttons: [
+          {
+            text: 'No',
+            role: 'cancel',
+            handler: () => {
+              reject();
+            }
+          },
+          {
+            text: 'Yes',
+            handler: () => {
+              alert.dismiss().then(() => {
+                resolve();
+              });
+            }
+          }
+        ]
+      });
+      alert.present();
+    });
   }
 
   chat() {
@@ -104,7 +142,9 @@ export class Tab1Page1 {
   }
 
   logout() {
-    this.app.getRootNav().setRoot(SignIn, null, { animate: true, direction: 'back' });
+    this.app.getRootNav().setRoot(SignIn, null, { animate: true, direction: 'back' }).catch(() => {
+      console.debug('logout cancelled');
+    });
   }
 
   ionViewWillEnter() {

--- a/src/components/tabs/test/advanced/tab1page1.html
+++ b/src/components/tabs/test/advanced/tab1page1.html
@@ -13,6 +13,8 @@
   <p><button ion-button (click)="logout()">Logout</button></p>
   <p><button ion-button (click)="favoritesTab()">Favorites Tab</button></p>
   <p><button ion-button (click)="goBack()">Go Back</button></p>
+  <p><button ion-button (click)="color = !color" [color]="color ? 'primary':'secondary'">Change color</button></p>
+  <p>"Change color" should continue working after clicking Logout in the tabbar and cancelling (No in the alert)</p>
   <p>UserId: {{userId}}</p>
   <div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div>
   <div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div>

--- a/src/components/tabs/test/advanced/tabs.html
+++ b/src/components/tabs/test/advanced/tabs.html
@@ -4,4 +4,5 @@
   <ion-tab tabTitle="Favorites" tabIcon="star" root="Tab2Page1" tabsHideOnSubPages="false"></ion-tab>
   <ion-tab tabTitle="Settings" tabIcon="settings" root="Tab3Page1"></ion-tab>
   <ion-tab tabTitle="Chat" tabIcon="chatbubbles" (ionSelect)="chat()" [show]="showTab"></ion-tab>
+  <ion-tab tabTitle="Logout" tabIcon="exit" (ionSelect)="logout()"></ion-tab>
 </ion-tabs>


### PR DESCRIPTION
WIP , DO NOT MERGE!

The current selected tab should NOT be deselected (i.e. detached from change detection) if the selected tab does not have a root
ie. a tab that acts as a button to open a modal, logout etc.

Lifecycle events should not be dispatched either. Right now we are dispatching willLeave/willEnter always (this is a bug).

fixes #9392