### PR TITLE
Prevents z-index from switching while animating causing the right sid…

### DIFF
--- a/js/angular/controller/sideMenuController.js
+++ b/js/angular/controller/sideMenuController.js
@@ -212,7 +212,7 @@ function($scope, $attrs, $ionicSideMenuDelegate, $ionicPlatform, $ionicBody, $io
       self.right && self.right.pushDown && self.right.pushDown();
       // Bring the z-index of the left menu up
       self.left && self.left.bringUp && self.left.bringUp();
-    } else {
+    } else if (amount < 0) {
       // Bring the z-index of the right menu up
       self.right && self.right.bringUp && self.right.bringUp();
       // Push the z-index of the left menu down


### PR DESCRIPTION
#### Short description of what this resolves:
Prevents z-index from switching while animating causing the right side menu to flash when closing the left side menu.

#### Changes proposed in this pull request:

- Prevents z-index change when side menu content is at 0 position.

**Ionic Version**: 1.3.2

**Fixes**: #9517 

…e menu to flash when closing left.