### PR TITLE
fix(virtual-scroll): replace implicit any's

### DIFF
--- a/src/components/virtual-scroll/virtual-util.ts
+++ b/src/components/virtual-scroll/virtual-util.ts
@@ -620,10 +620,10 @@ export interface VirtualHtmlElement {
   offsetHeight: number;
   style: any;
   classList: {
-    add: {(name: string)};
-    remove: {(name: string)};
+    add: {(name: string): void};
+    remove: {(name: string): void};
   };
-  setAttribute: {(name: string, value: any)};
+  setAttribute: {(name: string, value: any): void};
   parentElement: VirtualHtmlElement;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Same idea as #9511 from yesterday. Is it possible to have the tests for Ionic run with `noImplicitAny` to prevent this in the future?

Latest nightly throws me some errors on serve.
```
[10:01:32]  typescript: node_modules/ionic-angular/components/virtual-scroll/virtual-util.d.ts, line: 22 
[10:01:32]  typescript: node_modules/ionic-angular/components/virtual-scroll/virtual-util.d.ts, line: 25 
            Call signature, which lacks return-type annotation, implicitly has an 'any' return type. 

      L21:  add: {
      L22:      (name: string);
      L23:  };

            Call signature, which lacks return-type annotation, implicitly has an 'any' return type. 

      L24:  remove: {
      L25:      (name: string);
      L26:  };

            Call signature, which lacks return-type annotation, implicitly has an 'any' return type. 

      L28:  setAttribute: {
      L29:      (name: string, value: any);
      L30:  };

[10:01:32]  typescript: node_modules/ionic-angular/components/virtual-scroll/virtual-util.d.ts, line: 29 
```

I'm using `"noImplicitAny": true` in my `tsconfig.json` `compilerOptions`, which some other developers will probably be using as well.

#### Changes proposed in this pull request:

- Add an explicit `void` return type

**Ionic Version**: 2.0.0-rc.3-201612062256

