### PR TITLE
Improve documentation on setPages pages param

### DIFF
--- a/src/navigation/nav-controller.ts
+++ b/src/navigation/nav-controller.ts
@@ -514,7 +514,7 @@ export abstract class NavController {
    * by passing options to the navigation controller.You can also pass any
    * navigation params to the individual pages in the array.
    *
-   * @param {array<Page>} pages  An arry of page components and their params to load in the stack.
+   * @param {array} pages An array of objects, each with a `page` and optionally `params` property to load in the stack.
    * @param {object} [opts={}] Nav options to go with this transition.
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */


### PR DESCRIPTION
#### Short description of what this resolves:
Description of pages param for setPages function was confusing.

**Ionic Version**: 2.x

setPages pages param was described as an array of Page objects,
but such a type is not defined. Changed docs to better explain
what this param is, the same way as insertPages param is described