### PR TITLE
fix(util): replace implicit any

### DIFF
--- a/src/util/scroll-view.ts
+++ b/src/util/scroll-view.ts
@@ -35,7 +35,7 @@ export class ScrollView {
       velocityX: 0,
       directionY: 'down',
       directionX: null,
-      domWrite: function(fn: DomCallback, ctx?: any) {
+      domWrite: function(fn: DomCallback, ctx?: any): void {
         _dom.write(fn, ctx);
       },
       contentElement: null,


### PR DESCRIPTION
#### Short description of what this resolves:
Same as #9511 and #9530. Replaces an implicit any type with the correct type.

Is it possible to have the tests run with the `noImplicitAny` `tsconfig` option to prevent this in the future?

**Ionic Version**: 2.0.0-rc.3-201612080433

