### PR TITLE
Fixed a typo

### DIFF
--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -60,7 +60,7 @@ import { DomController } from '../../util/dom-controller';
  *
  * ```html
  * <ion-tabs>
- *  <ion-tab [root]="chatRoot" [rootParams]="chatParams" tabTitle="Chat" tabIcon="chat"><ion-tab>
+ *  <ion-tab [root]="chatRoot" [rootParams]="chatParams" tabTitle="Chat" tabIcon="chat"></ion-tab>
  * </ion-tabs>
  * ```
  *


### PR DESCRIPTION
#### Short description of what this resolves:

Missing closing brace in the documentation

**Ionic Version**: 2.x

**Fixes**: #

closing tag was wrong