### PR TITLE
fix(show-hide-when): remove whitespaces from conditions before check …

### DIFF
--- a/src/components/show-hide-when/show-hide-when.ts
+++ b/src/components/show-hide-when/show-hide-when.ts
@@ -15,7 +15,7 @@ export class DisplayWhen {
 
     if (!conditions) return;
 
-    this.conditions = conditions.split(',');
+    this.conditions = conditions.replace(/\s/g, '').split(',');
 
     // check if its one of the matching platforms first
     // a platform does not change during the life of an app


### PR DESCRIPTION
When `showWhen` is used with whitespace like this...

```html
<div showWhen="android, ios"></div>
```
... it doesn't work properly, the component just is not shown. This makes it difficult to debug and may cause misunderstandings because no error is reported (the developer may think that the problem may be elsewhere). And the whitespace may have been accidentally written by intuition.

So, to ensure this doesn't happen I just remove all whitespaces from conditions string before check phase. 😬