### PR TITLE
fix:(tabs/view-controller) keep changedetector

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -414,7 +414,8 @@ export class Tabs extends Ion implements AfterViewInit {
       }
 
       selectedPage && selectedPage._didEnter();
-      deselectedPage && deselectedPage._didLeave();
+      const keepChangeDetectorAttached = !selectedTab.root;
+      deselectedPage && deselectedPage._didLeave(keepChangeDetectorAttached);
 
       // track the order of which tabs have been selected, by their index
       // do not track if the tab index is the same as the previous

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -464,13 +464,13 @@ export class ViewController {
    * The view has finished leaving and is no longer the active view. This
    * will fire, whether it is cached or unloaded.
    */
-  _didLeave() {
+  _didLeave(keepChangeDetectorAttached?: boolean) {
     this.didLeave.emit(null);
     this._lifecycle('DidLeave');
 
     // when this is not the active page
     // we no longer need to detect changes
-    if (!this._detached && this._cmp) {
+    if (!this._detached && this._cmp && !keepChangeDetectorAttached) {
       this._cmp.changeDetectorRef.detach();
       this._detached = true;
     }


### PR DESCRIPTION
#### Short description of what this resolves:

Keeps the change detector attached when selecting a tab wich has not [root] page set.

related Issue
https://github.com/driftyco/ionic/issues/9577

#### Changes proposed in this pull request:

- added an optional parameter (`keepChangeDetectorAttached`) to `viewcontroller._didLeave()`
- didLeave with parameter is called in tabs.ts when selecting a tab
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

keep the change detector when selecting a tab without a [root]