### PR TITLE
fixed ion-footer transition problem  #9121

### DIFF
--- a/src/transitions/transition-ios.ts
+++ b/src/transitions/transition-ios.ts
@@ -36,7 +36,7 @@ export class IOSTransition extends PageTransition {
 
       // entering content
       const enteringContent = new Animation(enteringView.contentRef());
-      enteringContent.element(enteringPageEle.querySelectorAll('ion-header > *:not(ion-navbar),ion-footer > *'));
+      enteringContent.element(enteringPageEle.querySelectorAll('ion-header > *:not(ion-navbar),ion-footer'));
       this.add(enteringContent);
 
       if (backDirection) {
@@ -115,7 +115,7 @@ export class IOSTransition extends PageTransition {
       const leavingPageEle: Element = leavingView.pageRef().nativeElement;
 
       const leavingContent = new Animation(leavingView.contentRef());
-      leavingContent.element(leavingPageEle.querySelectorAll('ion-header > *:not(ion-navbar),ion-footer > *'));
+      leavingContent.element(leavingPageEle.querySelectorAll('ion-header > *:not(ion-navbar),ion-footer'));
       this.add(leavingContent);
 
       if (backDirection) {


### PR DESCRIPTION
#### Short description of what this resolves:
![](http://o93ntudss.bkt.clouddn.com/githubxcd_bug.gif)
fixed the problem

**Ionic Version**: 2.x

**Fixes**: #9121 

The ion-footer does not follow the move when the page is transitioning, but its children element are moved.