### PR TITLE
fix(nav): catch errors on dismissPageChangeViews

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -1045,7 +1045,10 @@ export class NavControllerBase extends Ion implements NavController {
   dismissPageChangeViews() {
     for (let view of this._views) {
       if (view.data && view.data.dismissOnPageChange) {
-        view.dismiss();
+        view.dismiss().catch(() => {
+          // dismissing the view failed, probably because it had already been dismissed
+          // so we catch it to avoid an unhandled exception
+        });
       }
     }
   }


### PR DESCRIPTION
#### Short description of what this resolves:
Dismissing a `LoadingController` that has the `dismissOnPageChange` option is triggering a `App.viewDidLeave` which in turn [triggers the routine to dismiss any views that have the  `dismissOnPageChange` option](https://github.com/driftyco/ionic/blob/f599758db4c3162bc0bc5e36aba50321c152d827/src/components/nav/overlay-portal.ts#L40), including the one that was just dismissed.

Since at this point the `NavController` is trying to dismiss a view that has already been dismissed, an exception is thrown and it goes unhandled.

#### Changes proposed in this pull request:
Add a `.catch()` when dismissing views in `dismissOnPageChange()` to handle the exception. Nothing needs to be done inside the catch.

**Ionic Version**: 2.x

**Fixes**: #9589

