### PR TITLE
Reduce a lot latency on iOS Safari

### DIFF
--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -215,7 +215,7 @@ export class Refresher {
       return false;
     }
 
-    let scrollHostScrollTop = this._content.getContentDimensions().scrollTop;
+    let scrollHostScrollTop = this._content.getScrollTop();
     // if the scrollTop is greater than zero then it's
     // not possible to pull the content down yet
     if (scrollHostScrollTop > 0) {


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #

In case of complex content (i.e. a Instagram like flow) computing the whole content dimensions takes a lot of time.
getScrollTop is a lot faster because it doesn't need to compute the other dimensions.
I'm on an UIWebView on iOS 10.2
Thank you