### PR TITLE
Disabled input fix

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -23,6 +23,10 @@ ion-textarea {
   width: 100%;
 }
 
+ion-input[disabled] .input-cover {
+  pointer-events: none;
+}
+
 
 .item-input ion-input,
 .item-input ion-textarea {
@@ -63,7 +67,6 @@ textarea.text-input {
 .text-input[disabled] {
   opacity: .4;
 }
-
 
 input.text-input:-webkit-autofill {
   background-color: transparent;

--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -23,15 +23,11 @@ ion-textarea {
   width: 100%;
 }
 
-ion-input[disabled] .input-cover {
-  pointer-events: none;
-}
-
-
 .item-input ion-input,
 .item-input ion-textarea {
   position: static;
 }
+
 
 // Textarea Within An Item
 // --------------------------------------------------
@@ -84,6 +80,7 @@ input.text-input:-webkit-autofill {
 // This make it so the native input element is not clickable.
 // This will only show when the scroll assist is configured
 // otherwise the .input-cover will not be rendered at all
+// The input cover is not clickable when the input is disabled
 
 .input-cover {
   position: absolute;
@@ -92,6 +89,10 @@ input.text-input:-webkit-autofill {
 
   width: 100%;
   height: 100%;
+}
+
+ion-input[disabled] .input-cover {
+  pointer-events: none;
 }
 
 

--- a/src/components/input/test/input-focus/main.html
+++ b/src/components/input/test/input-focus/main.html
@@ -214,6 +214,11 @@
       <ion-input value="inline input 1"></ion-input>
     </ion-item>
 
+    <ion-item>
+      <ion-label>Disabled Input:</ion-label>
+      <ion-input disabled value="disabled input 1"></ion-input>
+    </ion-item>
+
   </ion-list>
 
 </ion-content>


### PR DESCRIPTION
#### Short description of what this resolves:
Stops disabled inputs from acting like they have been focused

#### Changes proposed in this pull request:

- add a css rule to prevent `.input-cover` from being focused
- add a disabled input to the input focus test

**Ionic Version**: 2

**Fixes**: #9070 
