### PR TITLE
fix(scroll): cancel scrollEnd timer before unsubscribing (#9751)

### DIFF
--- a/src/util/scroll-view.ts
+++ b/src/util/scroll-view.ts
@@ -501,11 +501,11 @@ export class ScrollView {
    * @private
    */
   destroy() {
+    this._endTmr && this._endTmr();
     this.scrollStart.unsubscribe();
     this.scroll.unsubscribe();
     this.scrollEnd.unsubscribe();
     this.stop();
-    this._endTmr && this._endTmr();
     this._lsn && this._lsn();
     let ev = this.ev;
     ev.domWrite = ev.contentElement = ev.fixedElement = ev.scrollElement = ev.headerElement = null;


### PR DESCRIPTION
#### Short description of what this resolves:
While a ScrollView is being scrolled, a timeout is set ([via rafFrames](https://github.com/driftyco/ionic/blob/5bbbfb2b0057836ae2bfd57a73ae75b9e31cb6bb/src/util/scroll-view.ts#L141-L152)) and cleared/reset until it finally triggers when scrolling has ended, at which point it emits on the scrollEnd Subject.

If at some point the view is destroyed then the `destroy()` method gets called to do the necessary cleanup, which includes unsubscribing from the scroll-related Observables. The problem comes if ~~scrolling hasn't yet finished and~~ the timer is still active, as when it finally triggers [it tries to emit on  self.scrollEnd](https://github.com/driftyco/ionic/blob/5bbbfb2b0057836ae2bfd57a73ae75b9e31cb6bb/src/util/scroll-view.ts#L151) but that Subject is already closed since its Subscriber [has already unsubscribed inside `destroy()`](https://github.com/driftyco/ionic/blob/5bbbfb2b0057836ae2bfd57a73ae75b9e31cb6bb/src/util/scroll-view.ts#L506).

#### Changes proposed in this pull request:
~~Make sure the Subject is still open before calling `.next()` on it.~~
Cancel the scrollEnd timer before unsubscribing from the Subject, ensuring it will always still be open when emiting on it.

**Ionic Version**:  2.x

**Fixes**: #9751
