### PR TITLE
fix(nav): swipe back after getRootNav().push

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -973,7 +973,7 @@ export class NavControllerBase extends Ion implements NavController {
   canSwipeBack(): boolean {
     return (this._sbEnabled &&
             !this._isPortal &&
-            !this._children.length &&
+            this._children.length <= 1 &&
             !this.isTransitioning() &&
             this._app.isEnabled() &&
             this.canGoBack());


### PR DESCRIPTION
#### Short description of what this resolves:

When pushing a page using `app.getRootNav().push(CoolPage)` you can now swipe this page back. Before this fix when pushing a page from the rootNav you could not swipe this page back.

#### Changes proposed in this pull request:

- check that the length of `this._children` (the array of navs) is <= to 1

**Ionic Version**: 2.x

**Fixes**: #9558
