### PR TITLE
Changelog file RC3 section devDependencies missing typescript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,7 @@ Update the following dependencies in your `package.json` file:
 },
 "devDependencies": {
   "@ionic/app-scripts": "0.0.45",
+   "typescript": "2.0.6"
 }
 ```
 


### PR DESCRIPTION
 "devDependencies": {
    "@ionic/app-scripts": "0.0.48",
   
  }
should be
 "devDependencies": {
    "@ionic/app-scripts": "0.0.48",
    "typescript": "2.0.6"
  }

#### Short description of what this resolves:
Missing dependency 

#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #
