### PR TITLE
chore(swiper): make touchmove listener not passive

### DIFF
--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -58,7 +58,7 @@ export function initEvents(s: Slides, plt: Platform): Function {
     // touchmove
     plt.registerListener(touchEventsTarget, s._touchEvents.move, (ev: SlideUIEvent) => {
       onTouchMove(s, plt, ev);
-    }, { passive: true, zone: false }, unregs);
+    }, { zone: false }, unregs);
 
     // touchend
     plt.registerListener(touchEventsTarget, s._touchEvents.end, (ev: SlideUIEvent) => {


### PR DESCRIPTION
#### Short description of what this resolves:
This fixes an issue where `Unable to preventDefault inside passive event listener invocation.` was getting thrown because we were using preventDefault inside a passive event listener. According to the current dom events spec passive events cannot use preventDefault. The fix for this was to make the touchmove listener not passive.

#### Changes proposed in this pull request:

- make touchmove listener not passive

**Ionic Version**: 2.x
