### PR TITLE
fix(scroll): handling low duration in scrollTo

### DIFF
--- a/src/util/scroll-view.ts
+++ b/src/util/scroll-view.ts
@@ -421,6 +421,13 @@ export class ScrollView {
       return promise;
     }
 
+    if (duration < 32) {
+      self.setTop(y);
+      self.setLeft(x);
+      done();
+      return promise;
+    }
+
     x = x || 0;
     y = y || 0;
 


### PR DESCRIPTION
#### Short description of what this resolves:
If the duration for scrollTo is 0, then the scroll never happens. The logic is scroll-view will produce `NaN`

#### Changes proposed in this pull request:

- Check if the duration is less than 32
- If so, set the position right away and return the promise


**Ionic Version**: 1.x / 2.x
2x
**Fixes**: #9864