### PR TITLE
test(animations): fix memory check

### DIFF
--- a/src/components/app/test/animations/app-module.ts
+++ b/src/components/app/test/animations/app-module.ts
@@ -35,7 +35,7 @@ export class E2EPage {
 
       console.log('Play', count);
 
-      let a = new Animation(this.platform, '.green');
+      let a = new Animation(self.platform, '.green');
       a.fromTo('translateX', '0px', '200px');
       a.duration(parseInt(self.duration, 10));
       a.easing(self.easing);


### PR DESCRIPTION
#### Short description of what this resolves:
Originally this error was getting thrown when using the memory check button `EXCEPTION: Error in main.html:36:4 caused by: Cannot read property 'platform' of undefined`, this test fixes that issue so that platform is not undefined.

#### Changes proposed in this pull request:

- change `this` to `self`

**Ionic Version**: 2.x
