### PR TITLE
test(segment): ionSlideDidChange and _activeIndex

### DIFF
--- a/src/components/segment/test/swipe/app-module.ts
+++ b/src/components/segment/test/swipe/app-module.ts
@@ -40,7 +40,7 @@ export class SegmentPage {
   onSlideChanged(slider: any) {
     console.log('Slide changed', slider);
 
-    const currentSlide = this.slides[slider.activeIndex];
+    const currentSlide = this.slides[slider._activeIndex];
     this.selectedSegment = currentSlide.id;
   }
 }

--- a/src/components/segment/test/swipe/main.html
+++ b/src/components/segment/test/swipe/main.html
@@ -25,7 +25,7 @@
 
 <ion-content padding>
 
-  <ion-slides (ionDidChange)="onSlideChanged($event)" #loopSlider>
+  <ion-slides (ionSlideDidChange)="onSlideChanged($event)" #loopSlider>
     <ion-slide *ngFor="let slide of slides">
       <h1>{{ slide.title }}</h1>
     </ion-slide>


### PR DESCRIPTION
#### Short description of what this resolves:
`ionDidChange` was deprecated and changed to `ionSlideDidChange`, this updates the test to reflect that change. Also `activeIndex` does not exist and should be `_activeIndex`

#### Changes proposed in this pull request:

- change `ionDidChange` to `ionSlideDidChange`
- change `activeIndex` to `_activeIndex`

**Ionic Version**: 2.x
