### PR TITLE
fix #3915: ion-tab can't work with ng-repeat

### DIFF
--- a/js/angular/directive/tab.js
+++ b/js/angular/directive/tab.js
@@ -154,7 +154,7 @@ function($compile, $ionicConfig, $ionicBind, $ionicViewSwitcher) {
               // tab should be selected and is NOT in the DOM
               // create a new scope and append it
               childScope = $scope.$new();
-              childElement = jqLite(tabContentEle);
+              childElement = jqLite(tabContentEle.cloneNode(true));
               $ionicViewSwitcher.viewEleIsActive(childElement, true);
               tabsCtrl.$element.append(childElement);
               $compile(childElement)(childScope);


### PR DESCRIPTION
BUG reason: ng-repeat is terminal directive, $transclude trigger lazy compile, but compile just execute once, in a word, ion-tab's compile function just execute once, but ion-tab cached ion-tab children which append into ion-tabs when click tab, but the same children can't append to parent duplicate.

https://github.com/driftyco/ionic/issues/3915

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x

**Fixes**: #1892
