### PR TITLE
chore(demos): use full polyfills

### DIFF
--- a/scripts/demos/demos.template.dev.html
+++ b/scripts/demos/demos.template.dev.html
@@ -36,7 +36,7 @@
       }
     });
   </script>
-	<script src="../polyfills/polyfills.ng.js"></script>
+	<script src="../polyfills/polyfills.js"></script>
 	<script src="../../bundles/ionic.system.js"></script>
 </head>
 

--- a/scripts/demos/demos.template.prod.html
+++ b/scripts/demos/demos.template.prod.html
@@ -13,7 +13,7 @@
 
   <ion-app></ion-app>
 
-  <script src="../polyfills/polyfills.ng.js"></script>
+  <script src="../polyfills/polyfills.js"></script>
   <script src="./build/main.js"></script>
 </body>
 </html>


### PR DESCRIPTION
#### Short description of what this resolves:
We should use our full polyfills instead of just the ng polyfills for browsers like edge and safari. With just the ng polyfills edge breaks on the demos because it does not support the `closest` dom method.

#### Changes proposed in this pull request:
- use full polyfills instead of just ng polyfills

**Ionic Version**: 2.x

**Fixes**: #9861 
