### PR TITLE
chore(clickblock): add minClickBlockDuration to components

### DIFF
--- a/src/components/action-sheet/action-sheet-component.ts
+++ b/src/components/action-sheet/action-sheet-component.ts
@@ -6,6 +6,7 @@ import { Config } from '../../config/config';
 import { Key } from '../../platform/key';
 import { Platform } from '../../platform/platform';
 import { NavParams } from '../../navigation/nav-params';
+import { NavOptions } from '../../navigation/nav-util';
 import { ViewController } from '../../navigation/view-controller';
 
 /**
@@ -174,7 +175,10 @@ export class ActionSheetCmp {
   }
 
   dismiss(role: any): Promise<any> {
-    return this._viewCtrl.dismiss(null, role);
+    const opts: NavOptions = {
+      minClickBlockDuration: 400
+    };
+    return this._viewCtrl.dismiss(null, role, opts);
   }
 
   ngOnDestroy() {

--- a/src/components/action-sheet/action-sheet.ts
+++ b/src/components/action-sheet/action-sheet.ts
@@ -58,6 +58,7 @@ export class ActionSheet extends ViewController {
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */
   present(navOptions: NavOptions = {}) {
+    navOptions.minClickBlockDuration = navOptions.minClickBlockDuration || 400;
     return this._app.present(this, navOptions);
   }
 

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -300,7 +300,7 @@ export class AlertCmp {
 
   dismiss(role: any): Promise<any> {
     const opts: NavOptions = {
-      minClickBlockDuration: 3500
+      minClickBlockDuration: 400
     };
     return this._viewCtrl.dismiss(this.getValues(), role, opts);
   }

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -81,7 +81,7 @@ export class Alert extends ViewController {
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */
   present(navOptions: NavOptions = {}) {
-    navOptions.minClickBlockDuration = navOptions.minClickBlockDuration || 3500;
+    navOptions.minClickBlockDuration = navOptions.minClickBlockDuration || 400;
     return this._app.present(this, navOptions);
   }
 

--- a/src/components/modal/modal-component.ts
+++ b/src/components/modal/modal-component.ts
@@ -2,6 +2,7 @@ import { Component, ComponentFactoryResolver, HostListener, Renderer, ViewChild,
 
 import { Key } from '../../platform/key';
 import { NavParams } from '../../navigation/nav-params';
+import { NavOptions } from '../../navigation/nav-util';
 import { ViewController } from '../../navigation/view-controller';
 import { GestureController, BlockerDelegate, GESTURE_MENU_SWIPE, GESTURE_GO_BACK_SWIPE } from '../../gestures/gesture-controller';
 import { assert } from '../../util/util';
@@ -78,7 +79,10 @@ export class ModalCmp {
 
   _bdClick() {
     if (this._enabled && this._bdDismiss) {
-      return this._viewCtrl.dismiss(null, 'backdrop').catch(() => {
+      const opts: NavOptions = {
+        minClickBlockDuration: 400
+      };
+      return this._viewCtrl.dismiss(null, 'backdrop', opts).catch(() => {
         console.debug('Dismiss modal by clicking backdrop was cancelled');
       });
     }

--- a/src/components/modal/modal.ts
+++ b/src/components/modal/modal.ts
@@ -58,6 +58,7 @@ export class Modal extends ViewController {
    * @returns {Promise} Returns a promise which is resolved when the transition has completed.
    */
   present(navOptions: NavOptions = {}) {
+    navOptions.minClickBlockDuration = navOptions.minClickBlockDuration || 400;
     return this._app.present(this, navOptions, AppPortal.MODAL);
   }
 

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -167,6 +167,12 @@ export class ViewController {
     if (!this._nav) {
       return Promise.resolve(false);
     }
+    if (this.isOverlay && !navOptions.minClickBlockDuration) {
+      // This is a Modal being dismissed so we need
+      // to add the minClickBlockDuration option
+      // for UIWebView
+      navOptions.minClickBlockDuration = 400;
+    }
     this._dismissData = data;
     this._dismissRole = role;
 


### PR DESCRIPTION
#### Short description of what this resolves:
This adds the minClickBlockDuration nav option to the action sheet and modal. It also tweaks the duration to 400ms which from my testing with the emulator and an iPhone 5 running iOS 10 seems to be the magic number.

#### Changes proposed in this pull request:

- change minClickBlockDuration to 400ms default
- add minClickBlockDuration to action sheet and modal

**Ionic Version**: 2.x
