### PR TITLE
fix(slides): deprecation notice typo's

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -1033,7 +1033,7 @@ export class Slides extends Ion {
    */
   getSlider(): void {
     // deprecated 2016-12-29
-    console.warn(`ion-slides, getSlide() has been removed. Please use the properties and methods on the instance of ion-slide instead.`);
+    console.warn(`ion-slides, getSlider() has been removed. Please use the properties and methods on the instance of ion-slides instead.`);
   }
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Small typo's in the deprecation notice for `getSlider()`.