### PR TITLE
chore(tests): fix failing tests

### DIFF
--- a/src/components/app/test/app.spec.ts
+++ b/src/components/app/test/app.spec.ts
@@ -389,7 +389,7 @@ describe('App', () => {
       app.setEnabled(false, 200);
 
       // assert
-      expect(mockClickBlock.activate).toHaveBeenCalledWith(true, 200 + 64);
+      expect(mockClickBlock.activate).toHaveBeenCalledWith(true, 200 + 64, 0);
     });
 
     it('should enable click block when false is passed w/o duration', () => {
@@ -407,7 +407,7 @@ describe('App', () => {
 
       // assert
       // 700 is the default
-      expect(mockClickBlock.activate).toHaveBeenCalledWith(true, 700 + 64);
+      expect(mockClickBlock.activate).toHaveBeenCalledWith(true, 700 + 64, 0);
     });
   });
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes two broken tests related to click block. The `setEnabled` method now takes a new parameter that defaults to 0, `minDuration`.

#### Changes proposed in this pull request:

- Change test to account for the new minDuration param

**Ionic Version**: 2.x
