### PR TITLE
fix(loading): dismiss loading w/ dismissOnPageChange when modal closes

### DIFF
--- a/src/components/loading/test/basic/app-module.ts
+++ b/src/components/loading/test/basic/app-module.ts
@@ -1,6 +1,36 @@
 import { Component, ViewEncapsulation, NgModule } from '@angular/core';
-import { App, IonicApp, IonicModule, LoadingController, NavController } from '../../../..';
+import { App, IonicApp, IonicModule, LoadingController, ModalController, NavController, ViewController } from '../../../..';
 
+
+@Component({
+  template: `
+  <ion-header>
+    <ion-toolbar>
+      <ion-title>Modal w/ Loading</ion-title>
+    </ion-toolbar>
+  </ion-header>
+  <ion-content padding>
+    This is a modal to close
+  </ion-content>
+  `
+})
+export class MyModal {
+  constructor(public loadingCtrl: LoadingController, public viewCtrl: ViewController) {}
+
+  ionViewDidEnter() {
+    this.loadingCtrl.create({
+      spinner: 'hide',
+      content: 'Loading 1 Please Wait...',
+      dismissOnPageChange: true
+    }).present().then(() => {
+      setTimeout(() => {
+        this.viewCtrl.dismiss().then(() => {
+          // => Modal and Loading should close
+        });
+      }, 1000);
+    });
+  }
+}
 
 @Component({
   templateUrl: 'main.html',
@@ -80,7 +110,7 @@ import { App, IonicApp, IonicModule, LoadingController, NavController } from '..
   ]
 })
 export class E2EPage {
-  constructor(public loadingCtrl: LoadingController, public navCtrl: NavController) {}
+  constructor(public loadingCtrl: LoadingController, public modalCtrl: ModalController, public navCtrl: NavController, public viewCtrl: ViewController) {}
 
   presentLoadingIos() {
     let loading = this.loadingCtrl.create({
@@ -254,6 +284,10 @@ export class E2EPage {
       this.navCtrl.push(Page2);
     }, 500);
   }
+
+  presentLoadingDismissModal() {
+    this.modalCtrl.create(MyModal).present();
+  }
 }
 
 @Component({
@@ -321,7 +355,8 @@ export class E2EApp {
     E2EApp,
     E2EPage,
     Page2,
-    Page3
+    Page3,
+    MyModal
   ],
   imports: [
     IonicModule.forRoot(E2EApp)
@@ -331,7 +366,8 @@ export class E2EApp {
     E2EApp,
     E2EPage,
     Page2,
-    Page3
+    Page3,
+    MyModal
   ]
 })
 export class AppModule {}

--- a/src/components/loading/test/basic/main.html
+++ b/src/components/loading/test/basic/main.html
@@ -22,6 +22,7 @@
   <button ion-button block (click)="presentLoadingMultiple()" color="danger">Multiple Loading</button>
   <button ion-button block (click)="presentLoadingMultipleNav()" color="danger">Multiple Nav Loading</button>
   <button ion-button block (click)="presentLoadingDismissNav()">Dismiss Page Change</button>
+  <button ion-button block (click)="presentLoadingDismissModal()">Dismiss From Modal</button>
 
 </ion-content>
 

--- a/src/components/nav/overlay-portal.ts
+++ b/src/components/nav/overlay-portal.ts
@@ -6,6 +6,7 @@ import { DeepLinker } from '../../navigation/deep-linker';
 import { DomController } from '../../platform/dom-controller';
 import { GestureController } from '../../gestures/gesture-controller';
 import { Keyboard } from '../../platform/keyboard';
+import { Modal } from '../modal/modal';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
 import { Platform } from '../../platform/platform';
 import { TransitionController } from '../../transitions/transition-controller';
@@ -40,7 +41,7 @@ export class OverlayPortal extends NavControllerBase {
     // on every page change make sure the portal has
     // dismissed any views that should be auto dismissed on page change
     app.viewDidLeave.subscribe((ev) => {
-      !ev.isOverlay && this.dismissPageChangeViews();
+      (!ev.isOverlay || ev instanceof Modal) && this.dismissPageChangeViews();
     });
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Dismiss all components with dismissOnPageChange when a modal is dismissed

#### Changes proposed in this pull request:

- adds test for loading component
- checks instance of to see if it's a modal

**Fixes**: #9907

This is up for discussion on how it should work. 
