### PR TITLE
chore: fix incorrect execution of node binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *.sw[mnpcod]
 *.log
+*.lock
 *.tmp
 *.tmp.*
 log.txt

--- a/scripts/gulp/util.ts
+++ b/scripts/gulp/util.ts
@@ -11,6 +11,9 @@ import * as through from 'through2';
 import * as uglifyPlugin from 'rollup-plugin-uglify';
 import { argv } from 'yargs';
 
+// These packages lack of types.
+const resolveBin = require('resolve-bin');
+
 export function mergeObjects(obj1: any, obj2: any ) {
   if (! obj1) {
     obj1 = {};
@@ -140,7 +143,8 @@ export function copyFile(srcPath: string, destPath: string) {
 
 export function runNgc(pathToConfigFile: string, done: Function) {
   let exec = require('child_process').exec;
-  var shellCommand = `node --max_old_space_size=8096 ${PROJECT_ROOT}/node_modules/.bin/ngc -p ${pathToConfigFile}`;
+  let ngcPath = getBinaryPath('@angular/compiler-cli', 'ngc');
+  let shellCommand = `node --max_old_space_size=8096 ${ngcPath} -p ${pathToConfigFile}`;
 
   exec(shellCommand, function(err, stdout, stderr) {
     console.log(stdout);
@@ -151,7 +155,8 @@ export function runNgc(pathToConfigFile: string, done: Function) {
 
 export function runTsc(pathToConfigFile: string, done: Function) {
   let exec = require('child_process').exec;
-  var shellCommand = `node --max_old_space_size=8096 ${PROJECT_ROOT}/node_modules/.bin/tsc -p ${pathToConfigFile}`;
+  let tscPath = getBinaryPath('typescript', 'tsc');
+  let shellCommand = `node --max_old_space_size=8096 ${tscPath} -p ${pathToConfigFile}`;
 
   exec(shellCommand, function(err, stdout, stderr) {
     console.log(stdout);
@@ -162,13 +167,19 @@ export function runTsc(pathToConfigFile: string, done: Function) {
 
 export function runWebpack(pathToWebpackConfig: string, done: Function) {
   let exec = require('child_process').exec;
-  let shellCommand = `node --max_old_space_size=8096 ./node_modules/.bin/webpack --config ${pathToWebpackConfig} --display-error-details`;
+  let webpackPath = getBinaryPath('webpack');
+  let shellCommand = `node --max_old_space_size=8096 ${webpackPath} --config ${pathToWebpackConfig} --display-error-details`;
 
   exec(shellCommand, function(err, stdout, stderr) {
     console.log(stdout);
     console.log(stderr);
     done(err);
   });
+}
+
+/** Resolves the path for a node package executable. */
+export function getBinaryPath(packageName: string, executable = packageName): string {
+  return resolveBin.sync(packageName, {executable});
 }
 
 export function deleteFiles(glob: string[], done: Function) {
@@ -277,3 +288,4 @@ export function getFolderInfo() {
     componentTest: componentTest
   };
 }
+

--- a/scripts/gulp/util.ts
+++ b/scripts/gulp/util.ts
@@ -288,4 +288,3 @@ export function getFolderInfo() {
     componentTest: componentTest
   };
 }
-


### PR DESCRIPTION
* Currently gulp runs the `ngc` by manually calling the `./node_modules/.bin/ngc` file (by assuming it's a node script)

  This is not always correct, because often package managers like (npm or yarn) create bash files for the package binaries.

  >  Using `resolve-bin` to properly determine the path to the *real* node script and then we can assume it's a node file.

* Also excluded the `yarn.lock` files in the repository. (Decided to use the wildcard, because `.lock` is very uncommon)

**Small Summary**
> This PR fixes the weird build issues on Windows machines (using Git Bash)

![](https://i.gyazo.com/5d8081913367fcdc8f6db0d34e5364e8.png)


**Ionic Version**: V2

Fixes #8341