### PR TITLE
add void return value for some callback signatures

### DIFF
--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -414,7 +414,7 @@ export class Content extends Ion implements OnDestroy, OnInit {
   /**
    * @private
    */
-  onScrollElementTransitionEnd(callback: {(ev: TransitionEvent)}) {
+  onScrollElementTransitionEnd(callback: {(ev: TransitionEvent): void}) {
     this._plt.transitionEnd(this._scrollEle, callback);
   }
 

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -638,7 +638,7 @@ export class Platform {
    * If options are not supported, then just return a boolean which
    * represents "capture". Returns a method to remove the listener.
    */
-  registerListener(ele: any, eventName: string, callback: {(ev?: UIEvent)}, opts: EventListenerOptions, unregisterListenersCollection?: Function[]): Function {
+  registerListener(ele: any, eventName: string, callback: {(ev?: UIEvent): void}, opts: EventListenerOptions, unregisterListenersCollection?: Function[]): Function {
     // use event listener options when supported
     // otherwise it's just a boolean for the "capture" arg
     const listenerOpts: any = this._uiEvtOpts ? {
@@ -673,7 +673,7 @@ export class Platform {
   /**
    * @private
    */
-  transitionEnd(el: HTMLElement, callback: {(ev?: TransitionEvent)}, zone = true) {
+  transitionEnd(el: HTMLElement, callback: {(ev?: TransitionEvent): void}, zone = true) {
     const unRegs: Function[] = [];
 
     function unregister() {


### PR DESCRIPTION
#### Short description of what this resolves:

Build breaks if `noImplicitAny` is declared in `tsconfig.json`.

#### Changes proposed in this pull request:

- add `void` return value to call signature of a few callbacks

**Ionic Version**: 2.0rc5