### PR TITLE
fix rtl text align

### DIFF
--- a/src/components/alert/alert.scss
+++ b/src/components/alert/alert.scss
@@ -111,3 +111,7 @@ ion-alert input {
   text-align: left;
   background: transparent;
 }
+
+ html[dir="rtl"] .alert-tappable {
+  text-align: right;
+}


### PR DESCRIPTION
we have to use this or not to use text-align:left ;
prefer to inherit style from parent
fix isseu
https://github.com/driftyco/ionic/issues/9815

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #
