### PR TITLE
InAppBrowser add hide() function

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "lib": ["dom", "es2015"],
     "module": "commonjs",
     "moduleResolution": "node",
-    "noImplicitAny": false,
+    "noImplicitAny": true,
     "removeComments": false,
     "sourceMap": true,
     "target": "es5",


### PR DESCRIPTION
#### Short description of what this resolves:
the implementation of cordova-plugin-inappbrowser
dose not used inappbrowser.hide()

#### Changes proposed in this pull request:

ionic _native/dist/es5/inappbrowser.js
ionic _native/dist/es5/inappbrowser.d.ts
add hide method implementation

ionic _native/dist/esm/inappbrowser.js
ionic _native/dist/esm/inappbrowser.d.ts
add hide method implementation 
also in ionic.native.js

**Ionic Version**:   2.x

