### PR TITLE
Fix for slidesPerView 'auto'

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -343,7 +343,7 @@ export class Slides extends Ion {
     return this._slidesPerView;
   }
   set slidesPerView(val: any) {
-    this._slidesPerView = parseInt(val, 10);
+    this._slidesPerView = val === 'auto' ? 'auto' : parseInt(val, 10);
   }
   private _slidesPerView = 1;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes slidesPerView value 'auto'

#### Changes proposed in this pull request:

the option 'auto' could not be set in slidesPerView because of the parseInt
line 346

**Ionic Version**: 2.x
