### PR TITLE
[WIP] fix(tabs): return correct tab from previousTab()

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -448,8 +448,8 @@ export class Tabs extends Ion implements AfterViewInit {
     // walk backwards through the tab selection history
     // and find the first previous tab that is enabled and shown
     console.debug('run previousTab', this._selectHistory);
-    for (var i = this._selectHistory.length - 2; i >= 0; i--) {
-      var tab = this._tabs.find(t => t.id === this._selectHistory[i]);
+    for (let i = this._selectHistory.length - 1; i >= 0; i--) {
+      const tab = this._tabs.find(t => t.id === this._selectHistory[i]);
       if (tab && tab.enabled && tab.show) {
         if (trimHistory) {
           this._selectHistory.splice(i + 1);


### PR DESCRIPTION
### Work in progress, do not merge yet (needs tests)

#### Short description of what this resolves:
Fixes the `previousTab()` method from the `Tabs` component to return the correct `Tab`.

#### Changes proposed in this pull request:
- Start looping the history array from its last element, not the previous one

**Ionic Version**: 2.x

**Fixes**: #9999
