### PR TITLE
Use performance.now() instead of Date.now() #9826

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -17,52 +17,52 @@ import { ViewController } from '../../navigation/view-controller';
 @Component({
   selector: 'ion-alert',
   template:
-    '<ion-backdrop (click)="bdClick()" [class.backdrop-no-tappable]="!d.enableBackdropDismiss"></ion-backdrop>' +
-    '<div class="alert-wrapper">' +
-      '<div class="alert-head">' +
-        '<h2 id="{{hdrId}}" class="alert-title" *ngIf="d.title" [innerHTML]="d.title"></h2>' +
-        '<h3 id="{{subHdrId}}" class="alert-sub-title" *ngIf="d.subTitle" [innerHTML]="d.subTitle"></h3>' +
-      '</div>' +
-      '<div id="{{msgId}}" class="alert-message" [innerHTML]="d.message"></div>' +
-      '<div *ngIf="d.inputs.length" [ngSwitch]="inputType">' +
+  '<ion-backdrop (click)="bdClick()" [class.backdrop-no-tappable]="!d.enableBackdropDismiss"></ion-backdrop>' +
+  '<div class="alert-wrapper">' +
+  '<div class="alert-head">' +
+  '<h2 id="{{hdrId}}" class="alert-title" *ngIf="d.title" [innerHTML]="d.title"></h2>' +
+  '<h3 id="{{subHdrId}}" class="alert-sub-title" *ngIf="d.subTitle" [innerHTML]="d.subTitle"></h3>' +
+  '</div>' +
+  '<div id="{{msgId}}" class="alert-message" [innerHTML]="d.message"></div>' +
+  '<div *ngIf="d.inputs.length" [ngSwitch]="inputType">' +
 
-        '<template ngSwitchCase="radio">' +
-          '<div class="alert-radio-group" role="radiogroup" [attr.aria-labelledby]="hdrId" [attr.aria-activedescendant]="activeId">' +
-            '<button ion-button="alert-radio-button" *ngFor="let i of d.inputs" (click)="rbClick(i)" [attr.aria-checked]="i.checked" [disabled]="i.disabled" [attr.id]="i.id" class="alert-tappable alert-radio" role="radio">' +
-              '<div class="alert-radio-icon"><div class="alert-radio-inner"></div></div>' +
-              '<div class="alert-radio-label">' +
-                '{{i.label}}' +
-              '</div>' +
-            '</button>' +
-          '</div>' +
-        '</template>' +
+  '<template ngSwitchCase="radio">' +
+  '<div class="alert-radio-group" role="radiogroup" [attr.aria-labelledby]="hdrId" [attr.aria-activedescendant]="activeId">' +
+  '<button ion-button="alert-radio-button" *ngFor="let i of d.inputs" (click)="rbClick(i)" [attr.aria-checked]="i.checked" [disabled]="i.disabled" [attr.id]="i.id" class="alert-tappable alert-radio" role="radio">' +
+  '<div class="alert-radio-icon"><div class="alert-radio-inner"></div></div>' +
+  '<div class="alert-radio-label">' +
+  '{{i.label}}' +
+  '</div>' +
+  '</button>' +
+  '</div>' +
+  '</template>' +
 
-        '<template ngSwitchCase="checkbox">' +
-          '<div class="alert-checkbox-group">' +
-            '<button ion-button="alert-checkbox-button" *ngFor="let i of d.inputs" (click)="cbClick(i)" [attr.aria-checked]="i.checked" [disabled]="i.disabled" class="alert-tappable alert-checkbox" role="checkbox">' +
-              '<div class="alert-checkbox-icon"><div class="alert-checkbox-inner"></div></div>' +
-              '<div class="alert-checkbox-label">' +
-                '{{i.label}}' +
-              '</div>' +
-            '</button>' +
-          '</div>' +
-        '</template>' +
+  '<template ngSwitchCase="checkbox">' +
+  '<div class="alert-checkbox-group">' +
+  '<button ion-button="alert-checkbox-button" *ngFor="let i of d.inputs" (click)="cbClick(i)" [attr.aria-checked]="i.checked" [disabled]="i.disabled" class="alert-tappable alert-checkbox" role="checkbox">' +
+  '<div class="alert-checkbox-icon"><div class="alert-checkbox-inner"></div></div>' +
+  '<div class="alert-checkbox-label">' +
+  '{{i.label}}' +
+  '</div>' +
+  '</button>' +
+  '</div>' +
+  '</template>' +
 
-        '<template ngSwitchDefault>' +
-          '<div class="alert-input-group">' +
-            '<div *ngFor="let i of d.inputs" class="alert-input-wrapper">' +
-              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" class="alert-input">' +
-            '</div>' +
-          '</div>' +
-        '</template>' +
+  '<template ngSwitchDefault>' +
+  '<div class="alert-input-group">' +
+  '<div *ngFor="let i of d.inputs" class="alert-input-wrapper">' +
+  '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" class="alert-input">' +
+  '</div>' +
+  '</div>' +
+  '</template>' +
 
-      '</div>' +
-      '<div class="alert-button-group" [ngClass]="{\'alert-button-group-vertical\':d.buttons.length>2}">' +
-        '<button ion-button="alert-button" *ngFor="let b of d.buttons" (click)="btnClick(b)" [ngClass]="b.cssClass">' +
-          '{{b.text}}' +
-        '</button>' +
-      '</div>' +
-    '</div>',
+  '</div>' +
+  '<div class="alert-button-group" [ngClass]="{\'alert-button-group-vertical\':d.buttons.length>2}">' +
+  '<button ion-button="alert-button" *ngFor="let b of d.buttons" (click)="btnClick(b)" [ngClass]="b.cssClass">' +
+  '{{b.text}}' +
+  '</button>' +
+  '</div>' +
+  '</div>',
   host: {
     'role': 'dialog',
     '[attr.aria-labelledby]': 'hdrId',
@@ -222,7 +222,7 @@ export class AlertCmp {
   keyUp(ev: KeyboardEvent) {
     if (this.enabled && this._viewCtrl.isLast()) {
       if (ev.keyCode === Key.ENTER) {
-        if (this.lastClick + 1000 < Date.now()) {
+        if (this.lastClick + 1000 < performance.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
           // key to click the button. However, both the click handler and
@@ -245,7 +245,7 @@ export class AlertCmp {
     }
 
     // keep the time of the most recent button click
-    this.lastClick = Date.now();
+    this.lastClick = performance.now();
 
     let shouldDismiss = true;
 
@@ -321,7 +321,7 @@ export class AlertCmp {
 
     // this is an alert with text inputs
     // return an object of all the values with the input name as the key
-    const values: {[k: string]: string} = {};
+    const values: { [k: string]: string } = {};
     this.d.inputs.forEach(i => {
       values[i.name] = i.value;
     });

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -120,12 +120,12 @@ export class App {
    * something goes wrong during a transition and the app wasn't re-enabled correctly.
    */
   setEnabled(isEnabled: boolean, duration: number = 700, minDuration: number = 0) {
-    this._disTime = (isEnabled ? 0 : Date.now() + duration);
+    this._disTime = (isEnabled ? 0 : performance.now() + duration);
 
     if (this._clickBlock) {
       if (isEnabled) {
         // disable the click block if it's enabled, or the duration is tiny
-        this._clickBlock.activate(false,  CLICK_BLOCK_BUFFER_IN_MILLIS, minDuration);
+        this._clickBlock.activate(false, CLICK_BLOCK_BUFFER_IN_MILLIS, minDuration);
 
       } else {
         // show the click block for duration + some number
@@ -156,14 +156,14 @@ export class App {
     if (disTime === 0) {
       return true;
     }
-    return (disTime < Date.now());
+    return (disTime < performance.now());
   }
 
   /**
    * @private
    */
   setScrolling() {
-    this._scrollTime = Date.now() + ACTIVE_SCROLLING_TIME;
+    this._scrollTime = performance.now() + ACTIVE_SCROLLING_TIME;
   }
 
   /**
@@ -175,7 +175,7 @@ export class App {
     if (scrollTime === 0) {
       return false;
     }
-    if (scrollTime < Date.now()) {
+    if (scrollTime < performance.now()) {
       this._scrollTime = 0;
       return false;
     }

--- a/src/components/infinite-scroll/test/infinite-scroll.spec.ts
+++ b/src/components/infinite-scroll/test/infinite-scroll.spec.ts
@@ -42,8 +42,8 @@ describe('Infinite Scroll', () => {
     });
 
     it('should not run again if ran less than 32ms ago', () => {
-      ev.timeStamp = Date.now();
-      inf._lastCheck = Date.now();
+      ev.timeStamp = performance.now();
+      inf._lastCheck = performance.now();
       var result = inf._onScroll(ev);
       expect(result).toEqual(2);
     });

--- a/src/components/item/item-sliding-gesture.ts
+++ b/src/components/item/item-sliding-gesture.ts
@@ -26,16 +26,16 @@ export class ItemSlidingGesture extends PanGesture {
     super(
       plt,
       list.getNativeElement(), {
-      maxAngle: 20,
-      threshold: 5,
-      zone: false,
-      domController: domCtrl,
-      gesture: gestureCtrl.createGesture({
-        name: GESTURE_ITEM_SWIPE,
-        priority: GesturePriority.SlidingItem,
-        disableScroll: true
-      })
-    });
+        maxAngle: 20,
+        threshold: 5,
+        zone: false,
+        domController: domCtrl,
+        gesture: gestureCtrl.createGesture({
+          name: GESTURE_ITEM_SWIPE,
+          priority: GesturePriority.SlidingItem,
+          disableScroll: true
+        })
+      });
   }
 
   canStart(ev: any): boolean {
@@ -56,7 +56,7 @@ export class ItemSlidingGesture extends PanGesture {
     let coord = pointerCoord(ev);
     this.preSelectedContainer = container;
     this.firstCoordX = coord.x;
-    this.firstTimestamp = Date.now();
+    this.firstTimestamp = performance.now();
     return true;
   }
 
@@ -79,7 +79,7 @@ export class ItemSlidingGesture extends PanGesture {
 
     let coordX = pointerCoord(ev).x;
     let deltaX = (coordX - this.firstCoordX);
-    let deltaT = (Date.now() - this.firstTimestamp);
+    let deltaT = (performance.now() - this.firstTimestamp);
     this.selectedContainer.endSliding(deltaX / deltaT);
     this.selectedContainer = null;
     this.preSelectedContainer = null;

--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -120,7 +120,7 @@ export class PickerColumnCmp {
     // reset everything
     this.velocity = 0;
     this.pos.length = 0;
-    this.pos.push(this.startY, Date.now());
+    this.pos.push(this.startY, performance.now());
 
     let options = this.col.options;
     let minY = (options.length - 1);
@@ -142,7 +142,7 @@ export class PickerColumnCmp {
     ev.stopPropagation();
 
     let currentY = pointerCoord(ev).y;
-    this.pos.push(currentY, Date.now());
+    this.pos.push(currentY, performance.now());
 
     this.debouncer.write(() => {
       if (this.startY === null) {
@@ -200,11 +200,11 @@ export class PickerColumnCmp {
 
     let endY = pointerCoord(ev).y;
 
-    this.pos.push(endY, Date.now());
+    this.pos.push(endY, performance.now());
 
     let endPos = (this.pos.length - 1);
     let startPos = endPos;
-    let timeRange = (Date.now() - 100);
+    let timeRange = (performance.now() - 100);
 
     // move pointer to position measured 100ms ago
     for (var i = endPos; i > 0 && this.pos[i] > timeRange; i -= 2) {
@@ -561,7 +561,7 @@ export class PickerCmp {
   _keyUp(ev: KeyboardEvent) {
     if (this.enabled && this._viewCtrl.isLast()) {
       if (ev.keyCode === Key.ENTER) {
-        if (this.lastClick + 1000 < Date.now()) {
+        if (this.lastClick + 1000 < performance.now()) {
           // do not fire this click if there recently was already a click
           // this can happen when the button has focus and used the enter
           // key to click the button. However, both the click handler and
@@ -594,7 +594,7 @@ export class PickerCmp {
     }
 
     // keep the time of the most recent button click
-    this.lastClick = Date.now();
+    this.lastClick = performance.now();
 
     let shouldDismiss = true;
 

--- a/src/components/refresher/refresher.ts
+++ b/src/components/refresher/refresher.ts
@@ -268,7 +268,7 @@ export class Refresher {
 
     // if we just updated stuff less than 16ms ago
     // then don't check again, just chillout plz
-    let now = Date.now();
+    let now = performance.now();
     if (this._lastCheck + 16 > now) {
       return 3;
     }

--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -273,7 +273,7 @@ var startTranslate: any;
 var allowThresholdMove: any;
 
 // Last click time
-var lastClickTime = Date.now();
+var lastClickTime = performance.now();
 var clickTimeout: any;
 
 // Velocities
@@ -326,7 +326,7 @@ function onTouchStart(s: Slides, plt: Platform, ev: SlideUIEvent) {
   s._touches.startX = startX;
   s._touches.startY = startY;
 
-  touchStartTime = Date.now();
+  touchStartTime = performance.now();
   s._allowClick = true;
 
   updateContainerSize(s, plt);
@@ -373,7 +373,7 @@ function onTouchMove(s: Slides, plt: Platform, ev: SlideUIEvent) {
     if (isTouched) {
       s._touches.startX = s._touches.currentX = ev.type === 'touchmove' ? ev.targetTouches[0].pageX : ev.pageX;
       s._touches.startY = s._touches.currentY = ev.type === 'touchmove' ? ev.targetTouches[0].pageY : ev.pageY;
-      touchStartTime = Date.now();
+      touchStartTime = performance.now();
     }
     return;
   }
@@ -553,7 +553,7 @@ function onTouchEnd(s: Slides, plt: Platform, ev: SlideUIEvent) {
   if (!isTouched) return;
 
   // Time diff
-  var touchEndTime = Date.now();
+  var touchEndTime = performance.now();
   var timeDiff = touchEndTime - touchStartTime;
 
   // Tap, doubleTap, Click
@@ -583,7 +583,7 @@ function onTouchEnd(s: Slides, plt: Platform, ev: SlideUIEvent) {
     });
   }
 
-  lastClickTime = Date.now();
+  lastClickTime = performance.now();
   plt.timeout(() => {
     if (s) {
       s._allowClick = true;

--- a/src/components/slides/swiper/swiper-zoom.ts
+++ b/src/components/slides/swiper/swiper-zoom.ts
@@ -265,17 +265,17 @@ function onTouchMove(s: Slides, plt: Platform, ev: TouchEvent) {
   // Velocity
   if (!z.velocity.prevPositionX) z.velocity.prevPositionX = z.image.touchesCurrent.x;
   if (!z.velocity.prevPositionY) z.velocity.prevPositionY = z.image.touchesCurrent.y;
-  if (!z.velocity.prevTime) z.velocity.prevTime = Date.now();
+  if (!z.velocity.prevTime) z.velocity.prevTime = performance.now();
 
-  z.velocity.x = (z.image.touchesCurrent.x - z.velocity.prevPositionX) / (Date.now() - z.velocity.prevTime) / 2;
-  z.velocity.y = (z.image.touchesCurrent.y - z.velocity.prevPositionY) / (Date.now() - z.velocity.prevTime) / 2;
+  z.velocity.x = (z.image.touchesCurrent.x - z.velocity.prevPositionX) / (performance.now() - z.velocity.prevTime) / 2;
+  z.velocity.y = (z.image.touchesCurrent.y - z.velocity.prevPositionY) / (performance.now() - z.velocity.prevTime) / 2;
 
   if (Math.abs(z.image.touchesCurrent.x - z.velocity.prevPositionX) < 2) z.velocity.x = 0;
   if (Math.abs(z.image.touchesCurrent.y - z.velocity.prevPositionY) < 2) z.velocity.y = 0;
 
   z.velocity.prevPositionX = z.image.touchesCurrent.x;
   z.velocity.prevPositionY = z.image.touchesCurrent.y;
-  z.velocity.prevTime = Date.now();
+  z.velocity.prevTime = performance.now();
 
   transform(z.gesture.imageWrap, 'translate3d(' + z.image.currentX + 'px, ' + z.image.currentY + 'px,0)');
 }

--- a/src/gestures/pointer-events.ts
+++ b/src/gestures/pointer-events.ts
@@ -44,7 +44,7 @@ export class PointerEvents {
     assert(this.ele, 'element can not be null');
     assert(this.pointerDown, 'pointerDown can not be null');
 
-    this.lastTouchEvent = Date.now() + this.mouseWait;
+    this.lastTouchEvent = performance.now() + this.mouseWait;
     this.lastEventType = PointerEventType.TOUCH;
     if (!this.pointerDown(ev, PointerEventType.TOUCH)) {
       return;
@@ -64,7 +64,7 @@ export class PointerEvents {
     assert(this.ele, 'element can not be null');
     assert(this.pointerDown, 'pointerDown can not be null');
 
-    if (this.lastTouchEvent > Date.now()) {
+    if (this.lastTouchEvent > performance.now()) {
       console.debug('mousedown event dropped because of previous touch');
       return;
     }

--- a/src/gestures/slide-gesture.ts
+++ b/src/gestures/slide-gesture.ts
@@ -43,7 +43,7 @@ export class SlideGesture extends PanGesture {
       max: 0,
       pointerStartPos: pos,
       pos: pos,
-      timestamp: Date.now(),
+      timestamp: performance.now(),
       elementStartPos: 0,
       started: true,
       delta: 0,
@@ -65,7 +65,7 @@ export class SlideGesture extends PanGesture {
 
     let coord = <any>pointerCoord(ev);
     let newPos = coord[this.direction];
-    let newTimestamp = Date.now();
+    let newTimestamp = performance.now();
     let velocity = (newPos - slide.pos) / (newTimestamp - slide.timestamp);
 
     slide.pos = newPos;

--- a/src/tap-click/tap-click.ts
+++ b/src/tap-click/tap-click.ts
@@ -92,7 +92,7 @@ export class TapClick {
   pointerEnd(ev: any, type: PointerEventType) {
     if (!this.dispatchClick) return;
 
-    runInDev(() => this.lastTouchEnd = Date.now());
+    runInDev(() => this.lastTouchEnd = performance.now());
 
     if (!this.startCoord) {
       return;
@@ -168,7 +168,7 @@ export class TapClick {
 
   private profileClickDelay(ev: any) {
     if (this.lastTouchEnd) {
-      let diff = Date.now() - this.lastTouchEnd;
+      let diff = performance.now() - this.lastTouchEnd;
       if (diff < 100) {
         console.debug(`FAST click dispatched. Delay(ms):`, diff);
       } else {
@@ -192,7 +192,7 @@ export class TapClick {
       return;
     }
     // prevent native mouse click events for XX amount of time
-    this.disableClick = Date.now() + DISABLE_NATIVE_CLICK_AMOUNT;
+    this.disableClick = performance.now() + DISABLE_NATIVE_CLICK_AMOUNT;
 
     if (this.app.isScrolling()) {
       // do not fire off a click event while the app was scrolling
@@ -210,7 +210,7 @@ export class TapClick {
   }
 
   isDisabledNativeClick() {
-    return this.disableClick > Date.now();
+    return this.disableClick > performance.now();
   }
 
 }
@@ -230,7 +230,7 @@ function getActivatableTarget(ele: HTMLElement) {
  * @private
  */
 export const isActivatable = function (ele: HTMLElement) {
-  if (ACTIVATABLE_ELEMENTS.indexOf(ele.tagName) > -1) {
+  if (ACTIVATABLE_ELEMENTS.indexOf(ele.tagName) > -1)  {
     return true;
   }
 
@@ -252,7 +252,7 @@ const DISABLE_NATIVE_CLICK_AMOUNT = 2500;
  * @private
  */
 export function setupTapClick(config: Config, plt: Platform, dom: DomController, app: App, zone: NgZone, gestureCtrl: GestureController) {
-  return function() {
+  return function () {
     return new TapClick(config, plt, dom, app, zone, gestureCtrl);
   };
 }

--- a/src/util/click-block.ts
+++ b/src/util/click-block.ts
@@ -38,7 +38,7 @@ export class ClickBlock {
       this.plt.cancelTimeout(this._tmr);
       if (shouldShow) {
         // remember when we started the click block
-        this._start = Date.now();
+        this._start = performance.now();
         // figure out the minimum time it should be showing until
         // this is useful for transitions that are less than 300ms
         this._minEnd = this._start + (minDuration || 0);
@@ -55,7 +55,7 @@ export class ClickBlock {
       if (!shouldShow) {
         // check if it was enabled before the minimum duration
         // this is useful for transitions that are less than 300ms
-        var now = Date.now();
+        var now = performance.now();
         if (now < this._minEnd) {
           this._tmr = this.plt.timeout(this._activate.bind(this, false), this._minEnd - now);
           return;

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -22,9 +22,9 @@ export function debounce(fn: Function, wait: number, immediate: boolean = false)
  return function() {
    context = this;
    args = arguments;
-   timestamp = Date.now();
+   timestamp = performance.now();
    var later: any = function() {
-     var last: any = Date.now() - timestamp;
+     var last: any = performance.now() - timestamp;
      if (last < wait) {
        timeout = setTimeout(later, wait - last);
      } else {


### PR DESCRIPTION
#### Short description of what this resolves:
I went through everything and replaced `performance.now()` with `Date.now()` where it is applicable, particularly where there are differences in timestamps (scroll events, etc.)

#### Changes proposed in this pull request:

- Use `performance.now()` because it is faster, newer, and more accurate.

**Ionic Version**: 2.x

**Fixes**: #9826 
