### PR TITLE
fix(content): unsubscribe from viewCtrl observables after content ins…

### DIFF
--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -167,6 +167,10 @@ export class Content extends Ion implements OnDestroy, OnInit {
   _fixedEle: HTMLElement;
   /** @internal */
   _imgs: Img[] = [];
+  /** @internal */
+  _viewCtrlReadSub: any;
+  /** @internal */
+  _viewCtrlWriteSub: any;
 
   private _imgReqBfr: number;
   private _imgRndBfr: number;
@@ -334,13 +338,13 @@ export class Content extends Ion implements OnDestroy, OnInit {
       viewCtrl._setIONContent(this);
       viewCtrl._setIONContentRef(elementRef);
 
-      var readSub = viewCtrl.readReady.subscribe(() => {
-        readSub.unsubscribe();
+      this._viewCtrlReadSub = viewCtrl.readReady.subscribe(() => {
+        this._viewCtrlReadSub.unsubscribe();
         this._readDimensions();
       });
 
-      var writeSub = viewCtrl.writeReady.subscribe(() => {
-        writeSub.unsubscribe();
+      this._viewCtrlWriteSub = viewCtrl.writeReady.subscribe(() => {
+        this._viewCtrlWriteSub.unsubscribe();
         this._writeDimensions();
       });
 
@@ -400,6 +404,8 @@ export class Content extends Ion implements OnDestroy, OnInit {
    */
   ngOnDestroy() {
     this._scLsn && this._scLsn();
+    this._viewCtrlReadSub && this._viewCtrlReadSub.unsubscribe();
+    this._viewCtrlWriteSub && this._viewCtrlWriteSub.unsubscribe();
     this._scroll && this._scroll.destroy();
     this._scrollEle = this._fixedEle = this._footerEle = this._scLsn = this._scroll = null;
   }

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -406,6 +406,7 @@ export class Content extends Ion implements OnDestroy, OnInit {
     this._scLsn && this._scLsn();
     this._viewCtrlReadSub && this._viewCtrlReadSub.unsubscribe();
     this._viewCtrlWriteSub && this._viewCtrlWriteSub.unsubscribe();
+    this._viewCtrlReadSub = this._viewCtrlWriteSub = null;
     this._scroll && this._scroll.destroy();
     this._scrollEle = this._fixedEle = this._footerEle = this._scLsn = this._scroll = null;
   }

--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -333,6 +333,9 @@ export class Slides extends Ion {
 
   // Slides grid
 
+  /**
+   * @input {number}  Distance between slides in px. Default: `0`.
+   */
   @Input()
   get spaceBetween() {
     return this._spaceBetween;
@@ -342,6 +345,9 @@ export class Slides extends Ion {
   }
   private _spaceBetween = 0;
 
+  /**
+   * @input {number}  Slides per view. Slides visible at the same time. Default: `1`.
+   */
   @Input()
   get slidesPerView() {
     return this._slidesPerView;


### PR DESCRIPTION
…tance destroyed

#### Short description of what this resolves:
Resolves error `Uncaught TypeError: Cannot read property 'ev' of null` when user switches views too quickly

#### Changes proposed in this pull request:
The subscribers on the viewCtrl observables can resolve after the Content instance has been destroyed. This results in the _scroll property being undefined at the time the subscriber resolves, causing this error. This may also be related to #9593 

**Ionic Version**: 2.x

**Fixes**: #10045 
