### PR TITLE
Add import of PopoverController to example code

### DIFF
--- a/src/components/popover/popover.ts
+++ b/src/components/popover/popover.ts
@@ -95,6 +95,8 @@ export class Popover extends ViewController {
  * ```
  *
  * ```ts
+ * import { PopoverController } from 'ionic-angular';
+ *
  * @Component({})
  * class MyPage {
  *   constructor(public popoverCtrl: PopoverController) {}


### PR DESCRIPTION
#### Short description of what this resolves:
There was no explicit use of the import in the example usage code.

#### Changes proposed in this pull request:
Add import of PopoverController to example code.
