### PR TITLE
docs(tabs): fix description of tabsHideOnSubPages

### DIFF
--- a/src/components/tabs/tab.ts
+++ b/src/components/tabs/tab.ts
@@ -246,7 +246,7 @@ export class Tab extends NavControllerBase {
   }
 
   /**
-   * @input {boolean} Whether it's possible to swipe-to-go-back on this tab or not.
+   * @input {boolean} Whether to hide the tabs on child pages or not. If `true` it will not show the tabs on child pages.
    */
   @Input()
   get tabsHideOnSubPages(): boolean {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes the description for tabsHideOnSubPages (copy paste error).

#### Changes proposed in this pull request:

I copied the correct string from here: https://ionicframework.com/docs/v2/api/config/Config/

**Ionic Version**: 2.x

**Fixes**: 
