### PR TITLE
Fix url is not correct after selecting tabs

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -405,10 +405,10 @@ export class Tabs extends Ion implements AfterViewInit {
     // Let's start the transition
     opts.animate = false;
     selectedTab.load(opts, () => {
+      this._tabSwitchEnd(selectedTab, selectedPage, currentPage);
       if (opts.updateUrl !== false) {
         this._linker.navChange(DIRECTION_SWITCH);
       }
-      this._tabSwitchEnd(selectedTab, selectedPage, currentPage);
     });
   }
 


### PR DESCRIPTION
Update deeplinker's updateNav after tabSwitchEnd so deeplinker gets the
right active navchild.

#### Short description of what this resolves:
Url is not correct after selecting tabs.

**Ionic Version**: 2.x

**Fixes**: #10032
