### PR TITLE
change ionSlideDidChange to ionDidChange

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -76,10 +76,10 @@ import { ViewController } from '../../navigation/view-controller';
  * ```
  *
  * We can also add events to listen to on the `<ion-slides>` element.
- * Let's add the `ionSlideDidChange` event and call a method when the slide changes:
+ * Let's add the `ionDidChange` event and call a method when the slide changes:
  *
  * ```html
- * <ion-slides (ionSlideDidChange)="slideChanged()">
+ * <ion-slides (ionDidChange)="slideChanged()">
  * ```
  *
  * In our class, we add the `slideChanged()` method which gets the active


### PR DESCRIPTION
`ionSlideDidChange` didn't trigger an event, but `ionDidChange` did. change to `ionDidChange` event

#### Short description of what this resolves:
Documentation updates.

#### Changes proposed in this pull request:

- Update documentation for <ion-slides> element

**Ionic Version**: 1.x / 2.x

**Fixes**: #
