### PR TITLE
chore(ionicons): remove the import of ionicons css

### DIFF
--- a/scripts/demos/sass.config.js
+++ b/scripts/demos/sass.config.js
@@ -42,7 +42,6 @@ module.exports = {
    */
   includePaths: [
     'src/themes',
-    'node_modules/ionicons/dist/scss',
     'src/fonts'
   ],
 

--- a/scripts/e2e/sass.config.js
+++ b/scripts/e2e/sass.config.js
@@ -42,7 +42,6 @@ module.exports = {
    */
   includePaths: [
     'src/themes',
-    'node_modules/ionicons/dist/scss',
     'src/fonts'
   ],
 

--- a/src/fonts/ionicons.scss
+++ b/src/fonts/ionicons.scss
@@ -6,8 +6,8 @@
 
 $ionicons-font-path: $font-path !default;
 
-@import "ionicons-icons";
-@import "ionicons-variables";
+@import "node_modules/ionicons/dist/scss/ionicons-icons";
+@import "node_modules/ionicons/dist/scss/ionicons-variables";
 
 
 @font-face {


### PR DESCRIPTION
#### Short description of what this resolves:

Importing the [`ionicons.scss`](https://github.com/driftyco/ionicons/blob/3.0/dist/scss/ionicons.scss) file from [ionicons](https://github.com/driftyco/ionicons/tree/3.0) was adding css that is not desired. Specifically, the `.ion` class here: https://github.com/driftyco/ionicons/blob/3.0/dist/scss/ionicons.scss#L29-L41

The `.ion` class itself isn't added to our icons, but it is extended here: https://github.com/driftyco/ionicons/blob/3.0/dist/scss/ionicons-common.scss#L941

So because of this extend, each icon class was getting this css which caused issues all over the e2e tests and in Ionic apps as well. The rule that is causing the issues is `line-height: 1`. 

For example:

<img width="1230" alt="screen shot 2017-01-19 at 3 49 01 pm" src="https://cloud.githubusercontent.com/assets/6577830/22159416/cd25eee8-df0e-11e6-9f68-0861db7298c1.png">


#### Changes proposed in this pull request:

- Remove `node_modules/ionicons/dist/scss` from the sass config so that it won't import `ionicons.scss` from there and instead will import it from `src/fonts/`
- Change the import for `ionicons-icons` and `ionicons-variables` to include the full path with `node_modules`, because without `ionicons` in the `includePaths` it will throw errors that it can't find it

**Ionic Version**: 2.x
