### PR TITLE
fix(input): show clearInput on inputs with ngModel/formControlName

### DIFF
--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -301,6 +301,7 @@ export class TextInput extends Ion implements IonicFormInput {
 
     nativeInput.valueChange.subscribe((inputValue: any) => {
       this.onChange(inputValue);
+      this.checkHasValue(inputValue);
     });
 
     nativeInput.keydown.subscribe((inputValue: any) => {

--- a/src/components/input/test/clear-input/app.module.ts
+++ b/src/components/input/test/clear-input/app.module.ts
@@ -1,4 +1,6 @@
 import { Component, NgModule } from '@angular/core';
+import { FormBuilder, Validators } from '@angular/forms';
+
 import { IonicApp, IonicModule } from '../../../../../ionic-angular';
 
 
@@ -6,7 +8,15 @@ import { IonicApp, IonicModule } from '../../../../../ionic-angular';
   templateUrl: 'main.html'
 })
 export class E2EPage {
+  userForm: any;
   myValue = 'really long value that overflows to show padding';
+
+  constructor(fb: FormBuilder) {
+    this.userForm = fb.group({
+      username: [{value: '', disabled: false}, Validators.required],
+      password: [{value: '', disabled: false}, Validators.required],
+    });
+  }
 
   clicked() {
     console.log('clicked button');

--- a/src/components/input/test/clear-input/main.html
+++ b/src/components/input/test/clear-input/main.html
@@ -17,6 +17,11 @@
     </ion-item>
 
     <ion-item>
+      <ion-label>Input Clear No ngModel:</ion-label>
+      <ion-input clearInput></ion-input>
+    </ion-item>
+
+    <ion-item>
       <ion-label>Input Clear:</ion-label>
       <ion-input class="e2eClearInput" [(ngModel)]="myValue" clearInput></ion-input>
     </ion-item>
@@ -32,5 +37,21 @@
       <button ion-button item-right (click)="clicked()">Button</button>
     </ion-item>
   </ion-list>
+
+  <form [formGroup]="userForm">
+    <ion-list>
+      <ion-list-header>
+        Form w/ clearInput
+      </ion-list-header>
+      <ion-item>
+        <ion-label floating>Username</ion-label>
+        <ion-input formControlName="username" clearInput></ion-input>
+      </ion-item>
+      <ion-item>
+        <ion-label floating>Password</ion-label>
+        <ion-input type="password" formControlName="password" clearInput></ion-input>
+      </ion-item>
+    </ion-list>
+  </form>
 
 </ion-content>


### PR DESCRIPTION
If the input has a `formControlName` or `ngModel` on it then `onChange` is not called so `checkHasValue` doesn't get called. This PR calls `checkHasValue` so that the clear input will work.

Also adds an input without ngModel/formControlName and inputs with formControlName to the clear-input test

Fixes #9077
