### PR TITLE
docs(range)

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -216,7 +216,7 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   }
 
   /**
-   * @input {number} If true, the knob snaps to tick marks evenly spaced based
+   * @input {boolean} If true, the knob snaps to tick marks evenly spaced based
    * on the step property value. Defaults to `false`.
    */
   @Input()
@@ -228,7 +228,7 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   }
 
   /**
-   * @input {number} If true, a pin with integer value is shown when the knob
+   * @input {boolean} If true, a pin with integer value is shown when the knob
    * is pressed. Defaults to `false`.
    */
   @Input()


### PR DESCRIPTION
#### Short description of what this resolves:
Corrects the type of two input properties in the documentation of the range component.

#### Changes proposed in this pull request:

- change type of 'snaps' from number to boolean
- change type of 'pin' from number to boolean

**Ionic Version**: 2.0.0