### PR TITLE
fix(input): don't allow focus when disabled is set

### DIFF
--- a/src/components/input/input.scss
+++ b/src/components/input/input.scss
@@ -94,7 +94,7 @@ input.text-input:-webkit-autofill {
   height: 100%;
 }
 
-ion-input[disabled] .input-cover {
+.input[disabled] .input-cover {
   pointer-events: none;
 }
 

--- a/src/components/input/input.ts
+++ b/src/components/input/input.ts
@@ -216,7 +216,7 @@ export class TextInput extends Ion implements IonicFormInput {
    */
   @Input()
   get disabled() {
-    return this.ngControl ? this.ngControl.disabled : this._disabled;
+    return this._disabled;
   }
   set disabled(val: boolean) {
     this.setDisabled(this._disabled = isTrueProperty(val));
@@ -226,8 +226,16 @@ export class TextInput extends Ion implements IonicFormInput {
    * @private
    */
   setDisabled(val: boolean) {
+    this._renderer.setElementAttribute(this._elementRef.nativeElement, 'disabled', val ? '' : null);
     this._item && this._item.setElementClass('item-input-disabled', val);
     this._native && this._native.isDisabled(val);
+  }
+
+  /**
+   * @private
+   */
+  setDisabledState(isDisabled: boolean) {
+    this.disabled = isDisabled;
   }
 
   /**


### PR DESCRIPTION
Adds the disabled attribute to the parent input/textarea, also fixes
where disabled textareas were focusable regardless of where disabled
was set.

Testing this:
- Use http://localhost:8000/dist/e2e/input/form-inputs/
- There are two disabled inputs via formControl under the "Form w/ disabled inputs" header
- There are two disabled via attribute (one toggle) at the bottom

fixes #10155