### PR TITLE
test(platform): new user agent tests

### DIFF
--- a/src/platform/test/platform.spec.ts
+++ b/src/platform/test/platform.spec.ts
@@ -318,6 +318,7 @@ describe('Platform', () => {
     expect(plt.is('android')).toEqual(false);
     expect(plt.is('ios')).toEqual(true);
     expect(plt.is('iphone')).toEqual(true);
+    expect(plt.is('ipad')).toEqual(false);
     expect(plt.is('tablet')).toEqual(false);
 
     plt.setQueryParams('');
@@ -330,6 +331,7 @@ describe('Platform', () => {
     expect(plt.is('android')).toEqual(false);
     expect(plt.is('ios')).toEqual(true);
     expect(plt.is('iphone')).toEqual(true);
+    expect(plt.is('ipad')).toEqual(false);
     expect(plt.is('tablet')).toEqual(false);
   });
 
@@ -344,6 +346,7 @@ describe('Platform', () => {
     expect(plt.is('android')).toEqual(false);
     expect(plt.is('ios')).toEqual(true);
     expect(plt.is('ipad')).toEqual(true);
+    expect(plt.is('iphone')).toEqual(false);
     expect(plt.is('tablet')).toEqual(true);
 
     plt.setQueryParams('');
@@ -356,6 +359,7 @@ describe('Platform', () => {
     expect(plt.is('android')).toEqual(false);
     expect(plt.is('ios')).toEqual(true);
     expect(plt.is('ipad')).toEqual(true);
+    expect(plt.is('iphone')).toEqual(false);
     expect(plt.is('tablet')).toEqual(true);
   });
 

--- a/src/platform/test/platform.spec.ts
+++ b/src/platform/test/platform.spec.ts
@@ -297,7 +297,7 @@ describe('Platform', () => {
     expect(plt.is('ios')).toEqual(false);
 
     plt.setQueryParams('');
-    plt.setUserAgent(NEW_ANDROID_UA);
+    plt.setUserAgent(ANDROID_7_1_1_UA);
     plt.init();
 
     expect(plt.is('core')).toEqual(false);
@@ -321,7 +321,7 @@ describe('Platform', () => {
     expect(plt.is('tablet')).toEqual(false);
 
     plt.setQueryParams('');
-    plt.setUserAgent(NEW_IPHONE_UA);
+    plt.setUserAgent(IPHONE_10_2_UA);
     plt.init();
 
     expect(plt.is('core')).toEqual(false);
@@ -347,7 +347,7 @@ describe('Platform', () => {
     expect(plt.is('tablet')).toEqual(true);
 
     plt.setQueryParams('');
-    plt.setUserAgent(NEW_IPAD_UA);
+    plt.setUserAgent(IPAD_10_2_UA);
     plt.init();
 
     expect(plt.is('core')).toEqual(false);
@@ -474,9 +474,9 @@ const WINDOWS8_PHONE_UA = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0
 const WINDOWS7_PHONE_UA = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; LG; GW910)';
 
 const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.20 Mobile Safari/537.36';
-const NEW_ANDROID_UA = 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36';
+const ANDROID_7_1_1_UA = 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36';
 
 const IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4';
-const NEW_IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140564782665216)';
+const IPHONE_10_2_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140564782665216)';
 const IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53';
-const NEW_IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140342232906320)';
+const IPAD_10_2_UA = 'Mozilla/5.0 (iPad; CPU OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140342232906320)';

--- a/src/platform/test/platform.spec.ts
+++ b/src/platform/test/platform.spec.ts
@@ -295,6 +295,16 @@ describe('Platform', () => {
     expect(plt.is('windows')).toEqual(false);
     expect(plt.is('android')).toEqual(true);
     expect(plt.is('ios')).toEqual(false);
+
+    plt.setQueryParams('');
+    plt.setUserAgent(NEW_ANDROID_UA);
+    plt.init();
+
+    expect(plt.is('core')).toEqual(false);
+    expect(plt.is('mobile')).toEqual(true);
+    expect(plt.is('windows')).toEqual(false);
+    expect(plt.is('android')).toEqual(true);
+    expect(plt.is('ios')).toEqual(false);
   });
 
   it('should set iphone via user agent', () => {
@@ -309,11 +319,35 @@ describe('Platform', () => {
     expect(plt.is('ios')).toEqual(true);
     expect(plt.is('iphone')).toEqual(true);
     expect(plt.is('tablet')).toEqual(false);
+
+    plt.setQueryParams('');
+    plt.setUserAgent(NEW_IPHONE_UA);
+    plt.init();
+
+    expect(plt.is('core')).toEqual(false);
+    expect(plt.is('mobile')).toEqual(true);
+    expect(plt.is('windows')).toEqual(false);
+    expect(plt.is('android')).toEqual(false);
+    expect(plt.is('ios')).toEqual(true);
+    expect(plt.is('iphone')).toEqual(true);
+    expect(plt.is('tablet')).toEqual(false);
   });
 
   it('should set ipad via user agent', () => {
     plt.setQueryParams('');
     plt.setUserAgent(IPAD_UA);
+    plt.init();
+
+    expect(plt.is('core')).toEqual(false);
+    expect(plt.is('mobile')).toEqual(true);
+    expect(plt.is('windows')).toEqual(false);
+    expect(plt.is('android')).toEqual(false);
+    expect(plt.is('ios')).toEqual(true);
+    expect(plt.is('ipad')).toEqual(true);
+    expect(plt.is('tablet')).toEqual(true);
+
+    plt.setQueryParams('');
+    plt.setUserAgent(NEW_IPAD_UA);
     plt.init();
 
     expect(plt.is('core')).toEqual(false);
@@ -440,5 +474,9 @@ const WINDOWS8_PHONE_UA = 'Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0
 const WINDOWS7_PHONE_UA = 'Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; LG; GW910)';
 
 const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 5.1.1; Nexus 6 Build/LYZ28E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.20 Mobile Safari/537.36';
+const NEW_ANDROID_UA = 'Mozilla/5.0 (Linux; Android 7.1.1; Nexus 6 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36';
+
 const IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/600.1.3 (KHTML, like Gecko) Version/8.0 Mobile/12A4345d Safari/600.1.4';
+const NEW_IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140564782665216)';
 const IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53';
+const NEW_IPAD_UA = 'Mozilla/5.0 (iPad; CPU OS 10_2 like Mac OS X) AppleWebKit/602.3.12 (KHTML, like Gecko) Mobile/14C89 (140342232906320)';


### PR DESCRIPTION
#### Short description of what this resolves:
This PR modifies unit tests around `platform.is()`. This is related to https://github.com/driftyco/ionic/issues/10209. I am not able to reproduce this issue, but just to cover our bases more I have modified our unit tests to be a little more thorough as the user agent, especially in iOS, has changed a good bit recently.

#### Changes proposed in this pull request:

- modify unit tests in platform to test newer user agents

**Ionic Version**: 2.x
