### PR TITLE
fix(content): check for this._scroll

### DIFF
--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -605,7 +605,7 @@ export class Content extends Ion implements OnDestroy, OnInit {
     let cacheHeaderHeight = this._hdrHeight;
     let cacheFooterHeight = this._ftrHeight;
     let cacheTabsPlacement = this._tabsPlacement;
-    let scrollEvent: any;
+    let scrollEvent: ScrollEvent;
     let tabsTop = 0;
     this._pTop = 0;
     this._pRight = 0;
@@ -620,11 +620,9 @@ export class Content extends Ion implements OnDestroy, OnInit {
 
     // In certain cases this._scroll is undefined
     // if that is the case then we should just return
-    if (this._scroll) {
-      scrollEvent = this._scroll.ev;
-    } else {
-      return;
-    }
+    if (!this._scroll) return;
+
+    scrollEvent = this._scroll.ev;
 
     let ele: HTMLElement = this._elementRef.nativeElement;
     if (!ele) {

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -605,6 +605,7 @@ export class Content extends Ion implements OnDestroy, OnInit {
     let cacheHeaderHeight = this._hdrHeight;
     let cacheFooterHeight = this._ftrHeight;
     let cacheTabsPlacement = this._tabsPlacement;
+    let scrollEvent;
     let tabsTop = 0;
     this._pTop = 0;
     this._pRight = 0;
@@ -617,7 +618,13 @@ export class Content extends Ion implements OnDestroy, OnInit {
     this._fTop = 0;
     this._fBottom = 0;
 
-    const scrollEvent = this._scroll.ev;
+    // In certain cases this._scroll is undefined
+    // if that is the case then we should just return
+    if (this._scroll) {
+      scrollEvent = this._scroll.ev;
+    } else {
+      return;
+    }
 
     let ele: HTMLElement = this._elementRef.nativeElement;
     if (!ele) {

--- a/src/components/content/content.ts
+++ b/src/components/content/content.ts
@@ -605,7 +605,7 @@ export class Content extends Ion implements OnDestroy, OnInit {
     let cacheHeaderHeight = this._hdrHeight;
     let cacheFooterHeight = this._ftrHeight;
     let cacheTabsPlacement = this._tabsPlacement;
-    let scrollEvent;
+    let scrollEvent: any;
     let tabsTop = 0;
     this._pTop = 0;
     this._pRight = 0;


### PR DESCRIPTION
#### Short description of what this resolves:
This checks for a use case where `this._scroll` may be undefined in certain cases. If it is undefined we simply return and if it is not undefined then we set `scrollEvent` and continue on.

Also, scrollEvent is now a `let` instead of a `const` as `const`s have to be initialized upon declaration as per the ES2015 spec.

#### Changes proposed in this pull request:

- check for `this._scroll`

**Ionic Version**: 2.x

**Fixes**: #10186 
