### PR TITLE
chore(release): add prompt for release to select release type

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "gulp-util": "3.0.7",
     "gulp-watch": "4.3.9",
     "html-entities": "1.2.0",
+    "inquirer": "3.0.1",
     "ionic-cz-conventional-changelog": "1.0.0",
     "ionic-native": "^2.2.6",
     "jasmine-core": "2.5.2",

--- a/scripts/gulp/declarations.d.ts
+++ b/scripts/gulp/declarations.d.ts
@@ -14,6 +14,7 @@ declare module 'gulp-server-livereload';
 declare module 'gulp-tslint';
 declare module 'gulp-typescript';
 declare module 'html-entities';
+declare module 'inquirer';
 declare module 'path';
 declare module 'rollup';
 declare module 'rollup-plugin-commonjs';


### PR DESCRIPTION
**IMPORTANT:**
You need to comment out the code in the following tasks and replace them with a log for testing: https://github.com/driftyco/ionic/blob/chore-release-prompt/scripts/gulp/tasks/release.ts#L72-L113

Testing this:
1. Run `gulp release`, select any release type, select either yes or abort release

    - if yes:
      - verify the changelog and package.json updated
      - verify the tasks to publish npm and github were called

    - if no:
      - verify nothing was updated and the tasks to publish weren't called

2. Run `gulp release.test`, select any release type, select either yes or abort release

    - if yes:
      - verify the changelog and package.json updated
      - verify the tasks to publish npm and github were **NOT** called

    - if no:
      - verify nothing was updated and the tasks to publish weren't called

Closes #10169