### PR TITLE
fix(tabs): pass null to popToRoot

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -512,7 +512,7 @@ export class Tabs extends Ion implements AfterViewInit {
 
       } else if (tab.length() > 1) {
         // if we're a few pages deep, pop to root
-        tab.popToRoot();
+        tab.popToRoot(null, null);
 
       } else if (getComponent(this._linker, tab.root) !== active.component) {
         // Otherwise, if the page we're on is not our real root, reset it to our

--- a/src/components/tabs/test/advanced/app.module.ts
+++ b/src/components/tabs/test/advanced/app.module.ts
@@ -301,6 +301,11 @@ export class Tab2Page2 {
   ionViewWillUnload() {
     console.log('Tab2Page2, ionViewWillUnload');
   }
+
+  ionViewCanLeave() {
+    console.log('Tab2Page2, ionViewCanLeave', false);
+    return false;
+  }
 }
 
 
@@ -334,6 +339,11 @@ export class Tab2Page3 {
   ionViewWillUnload() {
     console.log('Tab2Page3, ionViewWillUnload');
   }
+
+  ionViewCanLeave() {
+    console.log('Tab2Page3, ionViewCanLeave', false);
+    return false;
+  }
 }
 
 
@@ -345,6 +355,8 @@ export class Tab2Page3 {
   templateUrl: './tab3page1.html'
 })
 export class Tab3Page1 {
+
+  constructor(public navCtrl: NavController) {}
 
   ionViewWillEnter() {
     console.log('Tab3Page1, ionViewWillEnter');
@@ -364,6 +376,14 @@ export class Tab3Page1 {
 
   ionViewWillUnload() {
     console.log('Tab3Page1, ionViewWillUnload');
+  }
+
+  navigateTab2Page2() {
+    this.navCtrl.push(Tab2Page2);
+  }
+
+  navigateTab2Page3() {
+    this.navCtrl.push(Tab2Page3);
   }
 }
 

--- a/src/components/tabs/test/advanced/tab2page2.html
+++ b/src/components/tabs/test/advanced/tab2page2.html
@@ -10,7 +10,7 @@
 <ion-content padding>
 
   <p><button ion-button [navPush]="tab2Page3">Go to Tab 2, Page 3 (no navbar)</button></p>
-  <p><button ion-button navPop>Back to Tab 2, Page 1</button></p>
+  <p><button ion-button navPop>Go Back</button></p>
   <div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div>
   <div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div><div f></div>
 

--- a/src/components/tabs/test/advanced/tab3page1.html
+++ b/src/components/tabs/test/advanced/tab3page1.html
@@ -3,6 +3,9 @@
 
   <h2>Tabs 3, Page 1</h2>
 
+  <p><button ion-button (click)="navigateTab2Page2()">Navigate to Tab2Page2</button></p>
+  <p><button ion-button (click)="navigateTab2Page3()">Navigate to Tab2Page3</button></p>
+
   <p>No header.</p>
 
 </ion-content>


### PR DESCRIPTION
#### Short description of what this resolves:
This passes `null` to `popToRoot()` which means that it will work with `ionViewCanLeave` just like when the page is closed from the back button in the `navbar` https://github.com/driftyco/ionic/blob/master/src/components/navbar/navbar.ts#L138. 

#### Changes proposed in this pull request:

- pass `null` to `popToRoot()`

**Ionic Version**: 2.x

**Fixes**: #10194 
