### PR TITLE
documentation for getActiveNav()

### DIFF
--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -189,7 +189,7 @@ export class App {
   }
 
   /**
-   * @private
+   * @return {NavController} Returns the active NavController. Using this method is preferred when we need access to the top-level navigation controller while on the outside views and handlers like `registerBackButtonAction()` 
    */
   getActiveNav(): NavController {
     const portal = this._appRoot._getPortal(MODAL);


### PR DESCRIPTION
AppController.getActiveNav() doesn't need to be a private function. We really need this function when it comes to accessing an active NavController from the outside views/handlers like registerBackButtonAction().
getRootNav() won't work well when we have several NavControllers that are stacked into one single Tabs view.

#### Short description of what this resolves:
Add a new documentation for AppController.getActiveNav()

#### Changes proposed in this pull request:

- Brief comment changes

**Ionic Version**: 2.x
