### PR TITLE
fix(toggle/checkbox): allow value to be updated when disabled

### DIFF
--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -158,7 +158,7 @@ export class Checkbox extends Ion implements IonicTapInput, AfterContentInit, Co
    * @private
    */
   _setChecked(isChecked: boolean) {
-    if (!this._disabled && isChecked !== this._checked) {
+    if (isChecked !== this._checked) {
       this._checked = isChecked;
       if (this._init) {
         this.ionChange.emit(this);

--- a/src/components/checkbox/test/basic/app.module.ts
+++ b/src/components/checkbox/test/basic/app.module.ts
@@ -27,6 +27,9 @@ export class E2EPage {
     'grape': this.grapeCtrl
   });
 
+  public checked: boolean = false;
+  public disabled: boolean = false;
+
   constructor() {
     this.grapeChecked = true;
     this.standAloneChecked = true;

--- a/src/components/checkbox/test/basic/main.html
+++ b/src/components/checkbox/test/basic/main.html
@@ -88,4 +88,20 @@
 
   <pre aria-hidden="true" padding>{{formResults}}</pre>
 
+  <ion-item>
+    <ion-label>Checkbox / Toggle</ion-label>
+    <ion-checkbox [(ngModel)]="checked" [disabled]="disabled"></ion-checkbox>
+    <ion-toggle [(ngModel)]="checked" [disabled]="disabled"></ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-label>checked</ion-label>
+    <ion-checkbox [(ngModel)]="checked"></ion-checkbox>
+    <ion-toggle [(ngModel)]="checked"></ion-toggle>
+  </ion-item>
+  <ion-item>
+    <ion-label>disabled</ion-label>
+    <ion-checkbox [(ngModel)]="disabled"></ion-checkbox>
+    <ion-toggle [(ngModel)]="disabled"></ion-toggle>
+  </ion-item>
+
 </ion-content>

--- a/src/components/toggle/toggle.ts
+++ b/src/components/toggle/toggle.ts
@@ -229,7 +229,7 @@ export class Toggle extends Ion implements IonicTapInput, AfterContentInit, Cont
    * @private
    */
   _setChecked(isChecked: boolean) {
-    if (!this._disabled && isChecked !== this._checked) {
+    if (isChecked !== this._checked) {
       this._checked = isChecked;
       if (this._init) {
         this.ionChange.emit(this);


### PR DESCRIPTION
fixes #9730

testing:
go to the `checkbox/basic` test, click on the `checked` item and watch the values update, click `disabled` and then click `checked` and make sure it still updates the value but not when clicking on the disabled item. 