### PR TITLE
feat(alert): add sass variables for checkbox and radio button text color

### DIFF
--- a/src/components/alert/alert.ios.scss
+++ b/src/components/alert/alert.ios.scss
@@ -120,6 +120,9 @@ $alert-ios-list-border-top:                     $alert-ios-button-border-width $
 /// @prop - Padding on the label for the radio alert
 $alert-ios-radio-label-padding:                 13px !default;
 
+/// @prop - Text color of the label for the radio alert
+$alert-ios-radio-label-text-color:              null !default;
+
 /// @prop - Text color of the label for the checked radio alert
 $alert-ios-radio-label-text-color-checked:      $alert-ios-button-text-color !default;
 
@@ -152,6 +155,9 @@ $alert-ios-radio-icon-transform:                rotate(45deg) !default;
 
 /// @prop - Padding of the label for the checkbox in the alert
 $alert-ios-checkbox-label-padding:              13px !default;
+
+/// @prop - Text color of the label for the checkbox in the alert
+$alert-ios-checkbox-label-text-color:           null !default;
 
 /// @prop - Text color of the label for the checked checkbox in the alert
 $alert-ios-checkbox-label-text-color-checked:   initial !default;
@@ -314,6 +320,8 @@ $alert-ios-checkbox-icon-transform:             rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  color: $alert-ios-radio-label-text;
 }
 
 
@@ -369,6 +377,8 @@ $alert-ios-checkbox-icon-transform:             rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  color: $alert-ios-checkbox-label-text;
 }
 
 .alert-ios [aria-checked=true] .alert-checkbox-label {

--- a/src/components/alert/alert.ios.scss
+++ b/src/components/alert/alert.ios.scss
@@ -321,7 +321,7 @@ $alert-ios-checkbox-icon-transform:             rotate(45deg) !default;
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  color: $alert-ios-radio-label-text;
+  color: $alert-ios-radio-label-text-color;
 }
 
 
@@ -378,7 +378,7 @@ $alert-ios-checkbox-icon-transform:             rotate(45deg) !default;
   text-overflow: ellipsis;
   white-space: nowrap;
 
-  color: $alert-ios-checkbox-label-text;
+  color: $alert-ios-checkbox-label-text-color;
 }
 
 .alert-ios [aria-checked=true] .alert-checkbox-label {

--- a/src/components/alert/alert.ios.scss
+++ b/src/components/alert/alert.ios.scss
@@ -121,7 +121,7 @@ $alert-ios-list-border-top:                     $alert-ios-button-border-width $
 $alert-ios-radio-label-padding:                 13px !default;
 
 /// @prop - Text color of the label for the radio alert
-$alert-ios-radio-label-text-color:              null !default;
+$alert-ios-radio-label-text-color:              initial !default;
 
 /// @prop - Text color of the label for the checked radio alert
 $alert-ios-radio-label-text-color-checked:      $alert-ios-button-text-color !default;
@@ -157,7 +157,7 @@ $alert-ios-radio-icon-transform:                rotate(45deg) !default;
 $alert-ios-checkbox-label-padding:              13px !default;
 
 /// @prop - Text color of the label for the checkbox in the alert
-$alert-ios-checkbox-label-text-color:           null !default;
+$alert-ios-checkbox-label-text-color:           initial !default;
 
 /// @prop - Text color of the label for the checked checkbox in the alert
 $alert-ios-checkbox-label-text-color-checked:   initial !default;

--- a/src/components/alert/alert.md.scss
+++ b/src/components/alert/alert.md.scss
@@ -124,6 +124,9 @@ $alert-md-list-border-bottom:                 $alert-md-list-border-top !default
 /// @prop - Padding on the label for the radio alert
 $alert-md-radio-label-padding:                13px 26px !default;
 
+/// @prop - Text color of the label for the radio alert
+$alert-md-radio-label-text-color:             null !default;
+
 /// @prop - Text color of the label for the checked radio alert
 $alert-md-radio-label-text-color-checked:     $alert-md-button-text-color !default;
 
@@ -180,6 +183,9 @@ $alert-md-radio-icon-transition:              transform 280ms cubic-bezier(.4, 0
 
 /// @prop - Padding of the label for the checkbox in the alert
 $alert-md-checkbox-label-padding:             13px 26px !default;
+
+/// @prop - Text color of the label for the checkbox in the  alert
+$alert-md-checkbox-label-text-color:          null !default;
 
 /// @prop - Text color of the label for the checked checkbox in the  alert
 $alert-md-checkbox-label-text-color-checked:  initial !default;
@@ -339,6 +345,8 @@ $alert-md-checkbox-icon-transform:            rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  color: $alert-md-radio-label-text-color;
 }
 
 // Material Design Alert Radio Unchecked Circle
@@ -405,6 +413,8 @@ $alert-md-checkbox-icon-transform:            rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  color: $alert-md-checkbox-label-text-color;
 }
 
 .alert-md [aria-checked=true] .alert-checkbox-label {

--- a/src/components/alert/alert.md.scss
+++ b/src/components/alert/alert.md.scss
@@ -184,10 +184,10 @@ $alert-md-radio-icon-transition:              transform 280ms cubic-bezier(.4, 0
 /// @prop - Padding of the label for the checkbox in the alert
 $alert-md-checkbox-label-padding:             13px 26px !default;
 
-/// @prop - Text color of the label for the checkbox in the  alert
+/// @prop - Text color of the label for the checkbox in the alert
 $alert-md-checkbox-label-text-color:          null !default;
 
-/// @prop - Text color of the label for the checked checkbox in the  alert
+/// @prop - Text color of the label for the checked checkbox in the alert
 $alert-md-checkbox-label-text-color-checked:  initial !default;
 
 

--- a/src/components/alert/alert.md.scss
+++ b/src/components/alert/alert.md.scss
@@ -125,7 +125,7 @@ $alert-md-list-border-bottom:                 $alert-md-list-border-top !default
 $alert-md-radio-label-padding:                13px 26px !default;
 
 /// @prop - Text color of the label for the radio alert
-$alert-md-radio-label-text-color:             null !default;
+$alert-md-radio-label-text-color:             initial !default;
 
 /// @prop - Text color of the label for the checked radio alert
 $alert-md-radio-label-text-color-checked:     $alert-md-button-text-color !default;
@@ -185,7 +185,7 @@ $alert-md-radio-icon-transition:              transform 280ms cubic-bezier(.4, 0
 $alert-md-checkbox-label-padding:             13px 26px !default;
 
 /// @prop - Text color of the label for the checkbox in the alert
-$alert-md-checkbox-label-text-color:          null !default;
+$alert-md-checkbox-label-text-color:          initial !default;
 
 /// @prop - Text color of the label for the checked checkbox in the alert
 $alert-md-checkbox-label-text-color-checked:  initial !default;

--- a/src/components/alert/alert.wp.scss
+++ b/src/components/alert/alert.wp.scss
@@ -130,6 +130,9 @@ $alert-wp-radio-border-color:                  $input-wp-border-color !default;
 /// @prop - Padding of the label for the radio alert
 $alert-wp-radio-label-padding:                 13px 26px !default;
 
+/// @prop - Text color of the label for the radio alert
+$alert-wp-radio-label-text-color:              null !default;
+
 /// @prop - Text color of the label for the checked radio alert
 $alert-wp-radio-label-text-color-checked:      $alert-wp-button-text-color !default;
 
@@ -174,6 +177,9 @@ $alert-wp-radio-icon-border-radius:            $alert-wp-radio-border-radius !de
 
 /// @prop - Padding of the label for the checkbox in the alert
 $alert-wp-checkbox-label-padding:              13px 26px !default;
+
+/// @prop - Text color of the label for the checkbox in the alert
+$alert-wp-checkbox-label-text-color:           null !default;
 
 /// @prop - Text color of the label for the checked checkbox in the alert
 $alert-wp-checkbox-label-text-color-checked:   initial !default;
@@ -337,6 +343,8 @@ $alert-wp-checkbox-icon-transform:             rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  color: $alert-wp-radio-label-text-color;
 }
 
 // Windows Alert Radio Unchecked Circle
@@ -403,6 +411,8 @@ $alert-wp-checkbox-icon-transform:             rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
+  
+  color: $alert-wp-checkbox-label-text-color;
 }
 
 .alert-wp [aria-checked=true] .alert-checkbox-label {

--- a/src/components/alert/alert.wp.scss
+++ b/src/components/alert/alert.wp.scss
@@ -131,7 +131,7 @@ $alert-wp-radio-border-color:                  $input-wp-border-color !default;
 $alert-wp-radio-label-padding:                 13px 26px !default;
 
 /// @prop - Text color of the label for the radio alert
-$alert-wp-radio-label-text-color:              null !default;
+$alert-wp-radio-label-text-color:              initial !default;
 
 /// @prop - Text color of the label for the checked radio alert
 $alert-wp-radio-label-text-color-checked:      $alert-wp-button-text-color !default;
@@ -179,7 +179,7 @@ $alert-wp-radio-icon-border-radius:            $alert-wp-radio-border-radius !de
 $alert-wp-checkbox-label-padding:              13px 26px !default;
 
 /// @prop - Text color of the label for the checkbox in the alert
-$alert-wp-checkbox-label-text-color:           null !default;
+$alert-wp-checkbox-label-text-color:           initial !default;
 
 /// @prop - Text color of the label for the checked checkbox in the alert
 $alert-wp-checkbox-label-text-color-checked:   initial !default;

--- a/src/components/alert/alert.wp.scss
+++ b/src/components/alert/alert.wp.scss
@@ -411,7 +411,7 @@ $alert-wp-checkbox-icon-transform:             rotate(45deg) !default;
 
   text-overflow: ellipsis;
   white-space: nowrap;
-  
+
   color: $alert-wp-checkbox-label-text-color;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
There is no variable to style alert checkbox and radio button text color. This is essential when changing the background color of the alert.

#### Changes proposed in this pull request:

- Add sass variables

**Ionic Version**: 2
**Fixes**: #10301
