### PR TITLE
Allow ios back button to be clicked when segment buttons are in the nav bar

### DIFF
--- a/src/components/toolbar/toolbar.ios.scss
+++ b/src/components/toolbar/toolbar.ios.scss
@@ -309,6 +309,7 @@ $navbar-ios-height:                         $toolbar-ios-height !default;
 
 .back-button-ios {
   overflow: visible;
+  z-index: 99;
 
   order: map-get($toolbar-order-ios, back-button);
 


### PR DESCRIPTION
#### Short description of what this resolves:

fixes #7671 where the ios back button isn't clickable with a segment in the header

#### Changes proposed in this pull request:

just add a z-index to the ios specific style. this mimics the way the ion-buttons component handles staying above the segment buttons as well.

**Ionic Version**: 1.x / 2.x

**Fixes**: #
