### PR TITLE
chore(menu): remove unused $z-index-menu-backdrop

### DIFF
--- a/src/themes/ionic.globals.scss
+++ b/src/themes/ionic.globals.scss
@@ -32,7 +32,6 @@ $hairlines-width: .55px !default;
 // Grouped by elements which would be siblings
 
 $z-index-menu-overlay:           80;
-$z-index-menu-backdrop:          79;
 $z-index-overlay:                1000;
 $z-index-click-block:            99999;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Confusion

#### Changes proposed in this pull request:

- Remove unused SCSS variable ($z-index-menu-backdrop)

**Ionic Version**: 1.x / 2.x
2.x

**Fixes**: Confusion
