### PR TITLE
fix(slides): fix rtl support

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -135,7 +135,7 @@ import { ViewController } from '../../navigation/view-controller';
 @Component({
   selector: 'ion-slides',
   template:
-    '<div class="swiper-container">' +
+    '<div class="swiper-container" [attr.dir]="_rtl? \'rtl\' : null">' +
       '<div class="swiper-wrapper">' +
         '<ng-content></ng-content>' +
       '</div>' +
@@ -244,6 +244,14 @@ export class Slides extends Ion {
     this._pager = isTrueProperty(val);
   }
   private _pager = false;
+
+/**
+ * @input {string} If dir attribute is equal to rtl, set interal _rtl to true;
+ */
+  @Input()
+  set dir(val: string) {
+    this._rtl = (val.toLowerCase() === 'rtl');
+  }
 
   /**
    * @input {string}  Type of pagination. Possible values are:

--- a/src/components/slides/test/rtl/app.module.ts
+++ b/src/components/slides/test/rtl/app.module.ts
@@ -1,0 +1,46 @@
+import { Component, ViewChild, NgModule } from '@angular/core';
+import { IonicApp, IonicModule, Slides } from '../../../../../ionic-angular';
+
+
+@Component({
+  templateUrl: 'main.html'
+})
+export class E2EPage {
+  @ViewChild(Slides) slider: Slides;
+
+  onSlideWillChange(s: Slides) {
+    console.log(`onSlideWillChange: ${s}`);
+  }
+
+  onSlideDidChange(s: Slides) {
+    console.log(`onSlideDidChange: ${s}`);
+  }
+
+  onSlideDrag(s: Slides) {
+    console.log(`onSlideDrag: ${s}`);
+  }
+
+}
+
+@Component({
+  template: '<ion-nav [root]="root"></ion-nav>'
+})
+export class E2EApp {
+  root = E2EPage;
+}
+
+@NgModule({
+  declarations: [
+    E2EApp,
+    E2EPage
+  ],
+  imports: [
+    IonicModule.forRoot(E2EApp)
+  ],
+  bootstrap: [IonicApp],
+  entryComponents: [
+    E2EApp,
+    E2EPage
+  ]
+})
+export class AppModule {}

--- a/src/components/slides/test/rtl/main.html
+++ b/src/components/slides/test/rtl/main.html
@@ -1,0 +1,21 @@
+<ion-slides style="background: black"
+            (ionSlideWillChange)="onSlideWillChange($event)"
+            (ionSlideDidChange)="onSlideDidChange($event)"
+            (ionSlideDrag)="onSlideDrag($event)"
+            pager="true"
+            dir="rtl"
+            effect="slide">
+
+  <ion-slide style="background: red; color: white;">
+    <h1>شريحة ١</h1>
+  </ion-slide>
+
+  <ion-slide style="background: white; color: blue;">
+    <h1>شريحة ٢</h1>
+  </ion-slide>
+
+  <ion-slide style="background: blue; color: white;">
+    <h1>شريحة ٣</h1>
+  </ion-slide>
+
+</ion-slides>


### PR DESCRIPTION
#### Short description of what this resolves:

- fix rtl functionalities in slides when attribute (dir=“rtl”) added to
ion-slides.
- e2e test added: ‘slides/test/rtl’

**Ionic Version**: 2.x

**Fixes**: 
[#10028](https://github.com/driftyco/ionic/issues/10028)
[#10146](https://github.com/driftyco/ionic/issues/10146)
