### PR TITLE
Update slides.scss

### DIFF
--- a/src/components/slides/slides.scss
+++ b/src/components/slides/slides.scss
@@ -516,6 +516,7 @@ ion-slides {
 .slide-zoom {
   display: block;
   width: 100%;
+  height: 100%;
   text-align: center;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
height 100% for the wrapper element of the actual slide content is necessary. E.g. if you put an image or video with css property **object-fit: cover** height wouldn't be 100% however this would be expected

#### Changes proposed in this pull request:

- add height 100%
-
-

**Ionic Version**: 1.x / 2.x

**Fixes**: #
