### PR TITLE
Improve documentation of AlertController

### DIFF
--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -132,6 +132,9 @@ export class Alert extends ViewController {
  *
  * @usage
  * ```ts
+ *
+ * import { AlertController } from 'ionic-angular';
+ *
  * constructor(private alertCtrl: AlertController) {
  *
  * }


### PR DESCRIPTION
add : `import { AlertController } from 'ionic-angular';` in usage section

#### Short description of what this resolves:

Help user to implement alert in ionic 2

#### Changes proposed in this pull request:

- add : `import { AlertController } from 'ionic-angular';` in usage section

**Ionic Version**: 2.x
