### PR TITLE
fix(searchbar): add IE support

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -289,7 +289,7 @@ export class Searchbar extends Ion {
 
       // Get the width of the span then remove it
       var textWidth = tempSpan.offsetWidth;
-      tempSpan.remove();
+      doc.body.removeChild(tempSpan);
 
       // Set the input padding left
       var inputLeft = 'calc(50% - ' + (textWidth / 2) + 'px)';


### PR DESCRIPTION
remove() as a method on HTMLElements is not supported on IE.

#### Short description of what this resolves:
Add cross-browser support for searchbar.
This fixes IE error, and windows build of Ionic project.


#### Changes proposed in this pull request:

-
-
-

**Ionic Version**: 1.x / 2.x
2.x
**Fixes**: #
Object doesn't support property or method 'remove'