### PR TITLE
chore(platform): resize works correctly

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -594,9 +594,9 @@ export class Platform {
 
         } else {
           if (this._lW > win['innerWidth']) {
-            // Special case: keyboard is open and device is in portrait
-            console.debug('setting _isPortrait to true while keyboard is open and device is portrait');
-            this._isPortrait = true;
+            console.debug('setting _isPortrait to false');
+            this._isPortrait = false;
+            this._lW = win['innerWidth'];
           }
           // the device is in landscape
           if (this._lW <= win['innerWidth']) {

--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -581,10 +581,21 @@ export class Platform {
         if (win['innerWidth'] < win['innerHeight']) {
 
           // the device is in portrait
+          if (this._pW > win['innerWidth']) {
+            console.debug('setting _isPortrait to true');
+            this._isPortrait = true;
+            this._pW = win['innerWidth'];
+          }
           if (this._pW <= win['innerWidth']) {
             console.debug('setting _isPortrait to true');
             this._isPortrait = true;
             this._pW = win['innerWidth'];
+          }
+
+          if (this._pH > win['innerHeight']) {
+            console.debug('setting _isPortrait to true');
+            this._isPortrait = true;
+            this._pH = win['innerHeight'];
           }
           if (this._pH <= win['innerHeight']) {
             console.debug('setting _isPortrait to true');
@@ -593,16 +604,22 @@ export class Platform {
           }
 
         } else {
+          // the device is in landscape
           if (this._lW > win['innerWidth']) {
             console.debug('setting _isPortrait to false');
             this._isPortrait = false;
             this._lW = win['innerWidth'];
           }
-          // the device is in landscape
           if (this._lW <= win['innerWidth']) {
             console.debug('setting _isPortrait to false');
             this._isPortrait = false;
             this._lW = win['innerWidth'];
+          }
+
+          if (this._lH > win['innerHeight']) {
+            console.debug('setting _isPortrait to false');
+            this._isPortrait = false;
+            this._lH = win['innerHeight'];
           }
           if (this._lH <= win['innerHeight']) {
             console.debug('setting _isPortrait to false');

--- a/src/platform/test/platform.spec.ts
+++ b/src/platform/test/platform.spec.ts
@@ -173,6 +173,56 @@ describe('Platform', () => {
     });
   });
 
+  describe('dimensions', () => {
+    it('should return the correct width of the window', () => {
+      expect(plt.width()).toEqual(window.innerWidth);
+    });
+
+    it('should return the correct height of the window', () => {
+      expect(plt.height()).toEqual(window.innerHeight);
+    });
+
+    it('should return the correct width of the window after resize', () => {
+
+      // start with default window
+      expect(plt.width()).toEqual(window.innerWidth);
+
+      let resizedWindow: any = {
+        innerWidth: 200,
+        innerHeight: 300,
+        screen: {
+          width: 200,
+          height: 300
+        }
+      };
+
+      // resize to smaller window
+      plt.setWindow(resizedWindow);
+
+      expect(plt.width()).toEqual(resizedWindow.innerWidth);
+    });
+
+    it('should return the correct height of the window after resize', () => {
+
+      // start with default window
+      expect(plt.height()).toEqual(window.innerHeight);
+
+      let resizedWindow: any = {
+        innerWidth: 200,
+        innerHeight: 300,
+        screen: {
+          width: 200,
+          height: 300
+        }
+      };
+
+      // resize to smaller window
+      plt.setWindow(resizedWindow);
+
+      expect(plt.height()).toEqual(resizedWindow.innerHeight);
+    });
+  });
+
   it('should set core as the fallback', () => {
     plt.setDefault('core');
     plt.setQueryParams('');


### PR DESCRIPTION
#### Short description of what this resolves:
This fixes an issue where dimensions were not getting measured right when the window was resized to be smaller. This caused issues with our new desktop support.

#### Changes proposed in this pull request:

- Make sure dimensions get measured correctly when the window is resized both smaller and bigger
- Add new unit tests that cover the `width()` and `height()` methods and also window resizing

**Ionic Version**: 2.x
