### PR TITLE
Incorrect .radio-inner width/height calculation

### DIFF
--- a/src/components/radio/radio.md.scss
+++ b/src/components/radio/radio.md.scss
@@ -75,8 +75,8 @@ $radio-md-item-right-margin:      $item-md-padding-media-top 10px $item-md-paddi
   top: $radio-md-icon-border-width;
   left: $radio-md-icon-border-width;
 
-  width: $radio-md-icon-width / 2;
-  height: $radio-md-icon-height / 2;
+  width: $radio-md-icon-width - 8;
+  height: $radio-md-icon-height - 8;
 
   border-radius: 50%;
   background-color: $radio-md-color-on;

--- a/src/components/radio/radio.md.scss
+++ b/src/components/radio/radio.md.scss
@@ -75,8 +75,8 @@ $radio-md-item-right-margin:      $item-md-padding-media-top 10px $item-md-paddi
   top: $radio-md-icon-border-width;
   left: $radio-md-icon-border-width;
 
-  width: $radio-md-icon-width - 8;
-  height: $radio-md-icon-height - 8;
+  width: $radio-md-icon-width - $radio-md-icon-border-width * 4;
+  height: $radio-md-icon-height - $radio-md-icon-border-width * 4;
 
   border-radius: 50%;
   background-color: $radio-md-color-on;


### PR DESCRIPTION
#### Short description of what this resolves:
Resizing of the radio button icon using `$radio-md-icon-width` and `$radio-md-icon-height` variables in Android platform was incorrect. The inner round shifted to the right-bottom position.


#### Changes proposed in this pull request:

- Fixed width and height calculation of the inner round.

**Ionic Version**: 2.x
