### PR TITLE
fix(infinite-scroll):infinite-scroll can be placed in child componene…

### DIFF
--- a/src/components/infinite-scroll/infinite-scroll.ts
+++ b/src/components/infinite-scroll/infinite-scroll.ts
@@ -155,7 +155,7 @@ export class InfiniteScroll {
   @Output() ionInfinite: EventEmitter<InfiniteScroll> = new EventEmitter<InfiniteScroll>();
 
   constructor(
-    @Host() private _content: Content,
+    private _content: Content,
     private _zone: NgZone,
     private _elementRef: ElementRef,
     private _dom: DomController


### PR DESCRIPTION
…ts, fixes #6531

#### Short description of what this resolves:
Resolves #6531 , Can now place infinite-scroll inside custom component

#### Changes proposed in this pull request:
- Remove @Host from the content, so the dependency injection is looking for closest parent, and not just the immediate parent.
-
-

**Ionic Version**: 1.x / 2.x
2.0.1
**Fixes**: #6531
