### PR TITLE
fix(datetime): emit ioncancel event on backdrop click for datetime

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -513,7 +513,10 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     picker.present(pickerOptions);
 
     this._isOpen = true;
-    picker.onDidDismiss(() => {
+    picker.onDidDismiss((data: any, role: any) => {
+      if (role === 'backdrop') {
+        this.ionCancel.emit(null);
+      }
       this._isOpen = false;
     });
   }

--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -513,7 +513,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     picker.present(pickerOptions);
 
     this._isOpen = true;
-    picker.onDidDismiss((data: any, role: any) => {
+    picker.onDidDismiss(() => {
       this._isOpen = false;
     });
   }

--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -514,9 +514,6 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
 
     this._isOpen = true;
     picker.onDidDismiss((data: any, role: any) => {
-      if (role === 'backdrop') {
-        this.ionCancel.emit(null);
-      }
       this._isOpen = false;
     });
   }

--- a/src/components/picker/picker-component.ts
+++ b/src/components/picker/picker-component.ts
@@ -614,7 +614,12 @@ export class PickerCmp {
 
   bdClick() {
     if (this.enabled && this.d.enableBackdropDismiss) {
-      this.dismiss('backdrop');
+      let cancelBtn = this.d.buttons.find(b => b.role === 'cancel');
+      if (cancelBtn) {
+        this.btnClick(cancelBtn);
+      } else {
+        this.dismiss('backdrop');
+      }
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
The datepicker component will emit ioncancel event on backdrop click

#### Changes proposed in this pull request:
If dismiss was received with role backdrop, emit ioncancel
-
-
-

**Ionic Version**: 1.x / 2.x
2.x
**Fixes**: #
