### PR TITLE
fix(docs): broken url to ion-img in virtual scroll docs

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -107,7 +107,7 @@ import { VirtualFooter, VirtualHeader, VirtualItem } from './virtual-item';
  * to manage HTTP requests and image rendering. While scrolling through items
  * quickly, `<ion-img>` knows when and when not to make requests, when and
  * when not to render images, and only loads the images that are viewable
- * after scrolling. [Read more about `ion-img`.](../img/Img/)
+ * after scrolling. [Read more about `ion-img`.](../../img/Img/)
  *
  * It's also important for app developers to ensure image sizes are locked in,
  * and after images have fully loaded they do not change size and affect any


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the broken link to ion-img docs in [Virtual Scroll docs page](https://ionicframework.com/docs/v2/api/components/virtual-scroll/VirtualScroll/#images-within-virtual-scroll).

#### Changes proposed in this pull request:
- Change the hyperlink of ion-img to correct one.

**Ionic Version**: 2.1.0

**Fixes**: #10554