### PR TITLE
Fix references to old event names

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -969,7 +969,7 @@ export class Slides extends Ion {
    *
    * @param {number} index  The index number of the slide.
    * @param {number} [speed]  Transition duration (in ms).
-   * @param {boolean} [runCallbacks] Whether or not to emit the `ionWillChange`/`ionDidChange` events. Default true.
+   * @param {boolean} [runCallbacks] Whether or not to emit the `ionSlideWillChange`/`ionSlideDidChange` events. Default true.
    */
   slideTo(index: number, speed?: number, runCallbacks?: boolean) {
     slideTo(this, this._plt, index, speed, runCallbacks);
@@ -979,7 +979,7 @@ export class Slides extends Ion {
    * Transition to the next slide.
    *
    * @param {number} [speed]  Transition duration (in ms).
-   * @param {boolean} [runCallbacks]  Whether or not to emit the `ionWillChange`/`ionDidChange` events. Default true.
+   * @param {boolean} [runCallbacks]  Whether or not to emit the `ionSlideWillChange`/`ionSlideDidChange` events. Default true.
    */
   slideNext(speed?: number, runCallbacks?: boolean) {
     slideNext(this, this._plt, runCallbacks, speed, true);
@@ -989,7 +989,7 @@ export class Slides extends Ion {
    * Transition to the previous slide.
    *
    * @param {number} [speed]  Transition duration (in ms).
-   * @param {boolean} [runCallbacks]  Whether or not to emit the `ionWillChange`/`ionDidChange` events. Default true.
+   * @param {boolean} [runCallbacks]  Whether or not to emit the `ionSlideWillChange`/`ionSlideDidChange` events. Default true.
    */
   slidePrev(speed?: number, runCallbacks?: boolean) {
     slidePrev(this, this._plt, runCallbacks, speed, true);


### PR DESCRIPTION
#### Short description of what this resolves:
In the slidePrev, slideNext, and slideTo docs it still shows the old event names.

#### Changes proposed in this pull request:

- Simple documentation change of old event names to new ones.


**Ionic Version**: 2.x
