### PR TITLE
fix(slides): simulate touch events for query params

### DIFF
--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -69,7 +69,6 @@ export function initEvents(s: Slides, plt: Platform): Function {
   if ((s.simulateTouch && !plt.is('ios') && !plt.is('android')) || (s.simulateTouch && !s._supportTouch && plt.is('ios')) || plt.getQueryParam('ionicPlatform')) {
     // mousedown
     plt.registerListener(touchEventsTarget, 'mousedown', (ev: SlideUIEvent) => {
-      console.log('mousedown')
       onTouchStart(s, plt, ev);
     }, { zone: false }, unregs);
 

--- a/src/components/slides/swiper/swiper-events.ts
+++ b/src/components/slides/swiper/swiper-events.ts
@@ -66,9 +66,10 @@ export function initEvents(s: Slides, plt: Platform): Function {
     }, { passive: true, zone: false }, unregs);
   }
 
-  if ((s.simulateTouch && !plt.is('ios') && !plt.is('android')) || (s.simulateTouch && !s._supportTouch && plt.is('ios'))) {
+  if ((s.simulateTouch && !plt.is('ios') && !plt.is('android')) || (s.simulateTouch && !s._supportTouch && plt.is('ios')) || plt.getQueryParam('ionicPlatform')) {
     // mousedown
     plt.registerListener(touchEventsTarget, 'mousedown', (ev: SlideUIEvent) => {
+      console.log('mousedown')
       onTouchStart(s, plt, ev);
     }, { zone: false }, unregs);
 


### PR DESCRIPTION
Closes #10577

#### Short description of what this resolves:
Slide fail to swipe when platform via query params.

#### Changes proposed in this pull request:
This lets touch events be simulated is ionicPlatform is set.


**Ionic Version**: 1.x / 2.x
2.x
**Fixes**: #10577
