### PR TITLE
feat(alert): Added mode setting for alert (ios, md, wp)

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -74,6 +74,7 @@ export class AlertCmp {
     message?: string;
     title?: string;
     subTitle?: string;
+    mode?: string;
     buttons?: any[];
     inputs?: any[];
     enableBackdropDismiss?: boolean;
@@ -95,7 +96,7 @@ export class AlertCmp {
     renderer: Renderer
   ) {
     this.d = params.data;
-    this.mode = _config.get('mode');
+    this.mode = this.d.mode || _config.get('mode');
     renderer.setElementClass(_elementRef.nativeElement, `alert-${this.mode}`, true);
 
     if (this.d.cssClass) {

--- a/src/components/alert/alert-options.ts
+++ b/src/components/alert/alert-options.ts
@@ -4,6 +4,7 @@ export interface AlertOptions {
   subTitle?: string;
   message?: string;
   cssClass?: string;
+  mode?: string;
   inputs?: Array<AlertInputOptions>;
   buttons?: Array<any>;
   enableBackdropDismiss?: boolean;

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -75,6 +75,13 @@ export class Alert extends ViewController {
   }
 
   /**
+   * @param {string} mode Set the mode of the alert (ios, md, wp).
+   */
+  setMode(mode: string) {
+    this.data.mode = mode;
+  }
+
+  /**
    * Present the alert instance.
    *
    * @param {NavOptions} [opts={}] Nav options to go with this transition.
@@ -216,6 +223,7 @@ export class Alert extends ViewController {
  *  | subTitle              | `string`  | The subtitle for the alert.                                               |
  *  | message               | `string`  | The message for the alert.                                                |
  *  | cssClass              | `string`  | Additional classes for custom styles, separated by spaces.                |
+ *  | mode                  | `string`  | Set alert mode (ios, md, wp).                                             |
  *  | inputs                | `array`   | An array of inputs for the alert. See input options.                      |
  *  | buttons               | `array`   | An array of buttons for the alert. See buttons options.                   |
  *  | enableBackdropDismiss | `boolean` | Whether the alert should be dismissed by tapping the backdrop.            |

--- a/src/components/alert/test/basic/app-module.ts
+++ b/src/components/alert/test/basic/app-module.ts
@@ -283,6 +283,16 @@ export class E2EPage {
     alert.present();
   }
 
+  doAlertWithMode() {
+    let alert = this.alertCtrl.create({
+      title: 'Alert!',
+      mode:'md',
+      buttons: ['OK']
+    });
+
+    alert.present();
+  }
+
   ionViewDidLeave() {
     console.log('E2EPage, ionViewDidLeave');
   }

--- a/src/components/alert/test/basic/app-module.ts
+++ b/src/components/alert/test/basic/app-module.ts
@@ -286,7 +286,7 @@ export class E2EPage {
   doAlertWithMode() {
     let alert = this.alertCtrl.create({
       title: 'Alert!',
-      mode:'md',
+      mode: 'md',
       buttons: ['OK']
     });
 

--- a/src/components/alert/test/basic/e2e.ts
+++ b/src/components/alert/test/basic/e2e.ts
@@ -74,3 +74,11 @@ it('should open disabled backdrop alert', function() {
 it('should close with button click', function() {
   element(by.css('.alert-button:last-child')).click();
 });
+
+it('should open alert with mode', function() {
+  element(by.css('.e2eDisabledBackdrop')).click();
+});
+
+it('should close with button click', function() {
+  element(by.css('.alert-button:last-child')).click();
+});

--- a/src/components/alert/test/basic/main.html
+++ b/src/components/alert/test/basic/main.html
@@ -19,6 +19,7 @@
   <button ion-button block class="e2eOpenCheckbox" (click)="doCheckbox()">Checkbox</button>
   <button ion-button block class="e2eFastClose" (click)="doFastClose()">Fast Close</button>
   <button ion-button block class="e2eDisabledBackdrop" (click)="doDisabledBackdropAlert()">Disabled Backdrop Click</button>
+  <button ion-button block class="e2eAlertMode" (click)="doAlertWithMode()">Open alert with mode</button>
 
   <pre>
     Confirm Opened: {{testConfirmOpen}}

--- a/src/components/input/input.ios.scss
+++ b/src/components/input/input.ios.scss
@@ -8,7 +8,7 @@ $text-input-ios-background-color:          $list-ios-background-color !default;
 $text-input-ios-margin-top:                $item-ios-padding-top !default;
 $text-input-ios-margin-right:              ($item-ios-padding-right / 2) !default;
 $text-input-ios-margin-bottom:             $item-ios-padding-bottom !default;
-$text-input-ios-margin-left:               0 !default;
+$text-input-ios-margin-left:               0px !default;
 
 $text-input-ios-input-clear-icon-width:    30px !default;
 $text-input-ios-input-clear-icon-color:    rgba(0, 0, 0, .5) !default;

--- a/src/components/input/input.ios.scss
+++ b/src/components/input/input.ios.scss
@@ -8,7 +8,7 @@ $text-input-ios-background-color:          $list-ios-background-color !default;
 $text-input-ios-margin-top:                $item-ios-padding-top !default;
 $text-input-ios-margin-right:              ($item-ios-padding-right / 2) !default;
 $text-input-ios-margin-bottom:             $item-ios-padding-bottom !default;
-$text-input-ios-margin-left:               0px !default;
+$text-input-ios-margin-left:               0 !default;
 
 $text-input-ios-input-clear-icon-width:    30px !default;
 $text-input-ios-input-clear-icon-color:    rgba(0, 0, 0, .5) !default;


### PR DESCRIPTION
#### Short description of what this resolves:

Added the ability to set the mode for alert popups

#### Changes proposed in this pull request:

-Change the appearance of the alert without changing the global mode.
-If mode is not set, global mode will be used

**Ionic Version**: 2.x
