### PR TITLE
chore(angular): update to 2.4.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,18 +25,18 @@
     "link": "gulp release.prepareReleasePackage && cd dist/ionic-angular && npm link"
   },
   "dependencies": {
-    "@angular/common": "2.2.1",
-    "@angular/compiler": "2.2.1",
-    "@angular/compiler-cli": "2.2.1",
-    "@angular/core": "2.2.1",
-    "@angular/forms": "2.2.1",
-    "@angular/http": "2.2.1",
-    "@angular/platform-browser": "2.2.1",
-    "@angular/platform-browser-dynamic": "2.2.1",
-    "@angular/platform-server": "2.2.1",
+    "@angular/common": "2.4.8",
+    "@angular/compiler": "2.4.8",
+    "@angular/compiler-cli": "2.4.8",
+    "@angular/core": "2.4.8",
+    "@angular/forms": "2.4.8",
+    "@angular/http": "2.4.8",
+    "@angular/platform-browser": "2.4.8",
+    "@angular/platform-browser-dynamic": "2.4.8",
+    "@angular/platform-server": "2.4.8",
     "ionicons": "~3.0.0",
-    "rxjs": "5.0.0-beta.12",
-    "zone.js": "~0.6.26"
+    "rxjs": "5.0.1",
+    "zone.js": "0.7.2"
   },
   "devDependencies": {
     "@ionic/app-scripts": "1.1.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -259,6 +259,10 @@ export { reorderArray } from './util/util';
 export { Animation, AnimationOptions, EffectProperty, EffectState, PlayOptions } from './animations/animation';
 export { PageTransition } from './transitions/page-transition';
 export { Transition } from './transitions/transition';
+export { PlatformConfigToken } from './platform/platform-registry';
+export { registerModeConfigs } from './config/mode-registry';
+export { registerTransitions } from './transitions/transition-registry';
+export { IonicGestureConfig } from './gestures/gesture-config';
 
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Updates our Angular dependency to 2.4.8. Also updates rx and zone to what Angular 2.4.8 requires.

#### Changes proposed in this pull request:

- Update Angular to 2.4.8
- Update rxjs to 5.0.1
- Update zone.js to 0.7.2

**Ionic Version**: 2.x

**Fixes**: #10422
