### PR TITLE
fix(datetime): make datetime min property work without max property

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -772,9 +772,9 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     if (min.year > max.year) {
       min.year = max.year - 100;
     } else if (min.year === max.year) {
-      if (min.month > max.month) {
+      if (max.month && min.month > max.month) {
         min.month = 1;
-      } else if (min.month === max.month && min.day > max.day) {
+      } else if (min.month === max.month && max.day && min.day > max.day) {
         min.day = 1;
       }
     }


### PR DESCRIPTION
#### Short description of what this resolves:
Correctly populates the minimum date of the datetime component even if maximum date is missing

#### Changes proposed in this pull request:
If maximum date month or day are missing, do not compare the minimum date properties to them.
-
-
-

**Ionic Version**: 2.x
**Fixes**: #10502 