### PR TITLE
fix(toggle/checkbox): trigger ui update when using virtalScroll with

### DIFF
--- a/src/components/checkbox/checkbox.ts
+++ b/src/components/checkbox/checkbox.ts
@@ -184,6 +184,7 @@ export class Checkbox extends Ion implements IonicTapInput, AfterContentInit, Co
       fn(isChecked);
       this._setChecked(isChecked);
       this.onTouched();
+      this._cd.detectChanges();
     };
   }
 


### PR DESCRIPTION
Angular Reactive Forms

#### Short description of what this resolves:

It appears that https://github.com/driftyco/ionic/issues/9856 was prematurely closed.  The problem persists when using virtualScroll with Angular Reactive Forms i.e. the UI doesn't update in response to a click/tap.

#### Changes proposed in this pull request:

call `this._cd.detectChanges()` in response to a handler registered via the `registerOnChange` method of the Checkbox Component, not sure why it was omitted from the original fix.  Practically I've observed this happen as a result of `setupControl` being called from `@angular/forms/src/directives/reactive_directives/form_group_directive.ts`.

**Ionic Version**: 2.1

**Fixes**: #9856
