### PR TITLE
feat(alert): add attributes min & max to alert inputs

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -51,7 +51,7 @@ import { ViewController } from '../../navigation/view-controller';
         '<template ngSwitchDefault>' +
           '<div class="alert-input-group">' +
             '<div *ngFor="let i of d.inputs" class="alert-input-wrapper">' +
-              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" class="alert-input">' +
+              '<input [placeholder]="i.placeholder" [(ngModel)]="i.value" [type]="i.type" [min]="i.min" [max]="i.max" class="alert-input">' +
             '</div>' +
           '</div>' +
         '</template>' +
@@ -157,6 +157,8 @@ export class AlertCmp {
         disabled: !!input.disabled,
         id: isPresent(input.id) ? input.id : `alert-input-${this.id}-${index}`,
         handler: isPresent(input.handler) ? input.handler : null,
+        min: isPresent(input.min) ? input.min : null,
+        max: isPresent(input.max) ? input.max : null
       };
     });
 

--- a/src/components/alert/alert-options.ts
+++ b/src/components/alert/alert-options.ts
@@ -19,6 +19,6 @@ export interface AlertInputOptions {
   checked?: boolean;
   disabled?: boolean;
   id?: string;
-  min?: string;
-  max?: string;
+  min?: string | number;
+  max?: string | number;
 }

--- a/src/components/alert/alert-options.ts
+++ b/src/components/alert/alert-options.ts
@@ -19,4 +19,6 @@ export interface AlertInputOptions {
   checked?: boolean;
   disabled?: boolean;
   id?: string;
+  min?: string;
+  max?: string;
 }

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -244,6 +244,8 @@ export class Alert extends ViewController {
  *  | label       | `string`  | The input's label (only for radio/checkbox inputs)              |
  *  | checked     | `boolean` | Whether or not the input is checked.                            |
  *  | id          | `string`  | The input's id.                                                 |
+ *  | min         | `string`  | The input's minimum authorized value (only for date inputs)     |
+ *  | max         | `string`  | The input's maximum authorized value (only for date inputs)     |
  *
  *  Button options
  *

--- a/src/components/alert/alert.ts
+++ b/src/components/alert/alert.ts
@@ -244,8 +244,12 @@ export class Alert extends ViewController {
  *  | label       | `string`  | The input's label (only for radio/checkbox inputs)              |
  *  | checked     | `boolean` | Whether or not the input is checked.                            |
  *  | id          | `string`  | The input's id.                                                 |
- *  | min         | `string`  | The input's minimum authorized value (only for date inputs)     |
- *  | max         | `string`  | The input's maximum authorized value (only for date inputs)     |
+ *  | min         | `string | number`  | The input's minimum authorized value (string only for date inputs, number
+ *  only for number inputs)
+ *  |
+ *  | max         | `string | number`  | The input's maximum authorized value (string only for date inputs, number
+ *  only for number inputs)
+ *  |
  *
  *  Button options
  *

--- a/src/components/alert/test/basic/app.module.ts
+++ b/src/components/alert/test/basic/app.module.ts
@@ -121,6 +121,16 @@ export class E2EPage {
       name: 'name5',
       type: 'date'
     });
+    alert.addInput({
+      name: 'name6',
+      type: 'number',
+      min: -5,
+      max: 10
+    });
+    alert.addInput({
+      name: 'name7',
+      type: 'number'
+    });
     alert.addButton({
       text: 'Cancel',
       handler: (data: any) => {

--- a/src/components/alert/test/basic/app.module.ts
+++ b/src/components/alert/test/basic/app.module.ts
@@ -109,6 +109,18 @@ export class E2EPage {
       type: 'url',
       placeholder: 'Favorite site ever'
     });
+    // input date with min & max
+    alert.addInput({
+      name: 'name4',
+      type: 'date',
+      min: '2017-03-01',
+      max: '2018-01-12'
+    });
+    // input date without min nor max
+    alert.addInput({
+      name: 'name5',
+      type: 'date'
+    });
     alert.addButton({
       text: 'Cancel',
       handler: (data: any) => {


### PR DESCRIPTION
#### Short description of what this resolves:
We cannot set currently min & max attributes for inputs used in Alerts.
It can be quite useful for input of type "date".

#### Changes proposed in this pull request:
- add min & max attributes to AlertCmp
- add an input date with min & max set to the alert e2e test (function doPrompt())
- add an input date without min nor max set to the alert e2e test (function doPrompt())

**Ionic Version**: 2.1.0

**Fixes**: #10590
