### PR TITLE
fix(datetime): not always disabling day values when dayValues set

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -619,6 +619,23 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
       }
     }
 
+    // create sort values for the min/max datetimes
+    let minCompareVal = dateDataSortValue(this._min);
+    let maxCompareVal = dateDataSortValue(this._max);
+
+    if (monthCol) {
+      // enable/disable which months are valid
+      // to show within the min/max date range
+      for (let i = 0; i < monthCol.options.length; i++) {
+        monthOpt = monthCol.options[i];
+
+        // loop through each month and see if it
+        // is within the min/max date range
+        monthOpt.disabled = (dateSortValue(selectedYear, monthOpt.value, 31) < minCompareVal ||
+          dateSortValue(selectedYear, monthOpt.value, 1) > maxCompareVal);
+      }
+    }
+
     // default to assuming this month has 31 days
     let numDaysInMonth = 31;
     let selectedMonth: number;
@@ -633,28 +650,11 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
       }
     }
 
-    // create sort values for the min/max datetimes
-    let minCompareVal = dateDataSortValue(this._min);
-    let maxCompareVal = dateDataSortValue(this._max);
-
-    if (monthCol) {
-      // enable/disable which months are valid
-      // to show within the min/max date range
-      for (i = 0; i < monthCol.options.length; i++) {
-        monthOpt = monthCol.options[i];
-
-        // loop through each month and see if it
-        // is within the min/max date range
-        monthOpt.disabled = (dateSortValue(selectedYear, monthOpt.value, 31) < minCompareVal ||
-          dateSortValue(selectedYear, monthOpt.value, 1) > maxCompareVal);
-      }
-    }
-
     if (dayCol) {
       if (isPresent(selectedMonth)) {
         // enable/disable which days are valid
         // to show within the min/max date range
-        for (i = 0; i < dayCol.options.length; i++) {
+        for (let i = 0; i < dayCol.options.length; i++) {
           dayOpt = dayCol.options[i];
 
           // loop through each day and see if it
@@ -663,13 +663,14 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
 
           dayOpt.disabled = (compareVal < minCompareVal ||
             compareVal > maxCompareVal ||
-            numDaysInMonth <= i);
+            numDaysInMonth < dayOpt.value);
         }
 
       } else {
         // enable/disable which numbers of days to show in this month
-        for (i = 0; i < dayCol.options.length; i++) {
-          dayCol.options[i].disabled = (numDaysInMonth <= i);
+        for (let i = 0; i < dayCol.options.length; i++) {
+          dayOpt = dayCol.options[i];
+          dayOpt.disabled = (numDaysInMonth < dayOpt.value);
         }
       }
     }

--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -590,7 +590,6 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
    * @private
    */
   validate(picker: Picker) {
-    let i: number;
     let today = new Date();
     let columns = picker.getColumns();
 
@@ -626,7 +625,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     if (monthCol) {
       // enable/disable which months are valid
       // to show within the min/max date range
-      for (let i = 0; i < monthCol.options.length; i++) {
+      for (var i = 0; i < monthCol.options.length; i++) {
         monthOpt = monthCol.options[i];
 
         // loop through each month and see if it
@@ -654,7 +653,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
       if (isPresent(selectedMonth)) {
         // enable/disable which days are valid
         // to show within the min/max date range
-        for (let i = 0; i < dayCol.options.length; i++) {
+        for (var i = 0; i < dayCol.options.length; i++) {
           dayOpt = dayCol.options[i];
 
           // loop through each day and see if it
@@ -668,7 +667,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
 
       } else {
         // enable/disable which numbers of days to show in this month
-        for (let i = 0; i < dayCol.options.length; i++) {
+        for (var i = 0; i < dayCol.options.length; i++) {
           dayOpt = dayCol.options[i];
           dayOpt.disabled = (numDaysInMonth < dayOpt.value);
         }

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -107,7 +107,7 @@ describe('DateTime', () => {
 
     it('should enable all of the values given', () => {
       datetime.monthValues = '6,7,8';
-      datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 14';
+      datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 31';
       datetime.yearValues = '2014,2015';
 
       datetime.pickerFormat = 'MM DD YYYY';
@@ -121,6 +121,7 @@ describe('DateTime', () => {
       expect(columns[1].options.length).toEqual(13); // days
       expect(columns[2].options.length).toEqual(2); // years
 
+      columns[0].selectedIndex = 1; // July
       datetime.validate(picker);
 
       // Months
@@ -132,6 +133,11 @@ describe('DateTime', () => {
       for (var i = 0; i < columns[1].options.length; i++) {
         expect(columns[1].options[i].disabled).toEqual(false);
       }
+
+      columns[0].selectedIndex = 0; // June
+      datetime.validate(picker);
+
+      expect(columns[1].options[12].disabled).toEqual(true);
     });
   });
 


### PR DESCRIPTION
#### Short description of what this resolves:
Datetime component was not correctly hiding/disable days for short months when dayValues was set. 

E.g. set `dayValues="1, 2, 31"` and select February

**Ionic Version**: 2.1
