### PR TITLE
fix(datetime): picker.refresh() in generate(...) called too early

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -508,6 +508,7 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
 
     picker.ionChange.subscribe(() => {
       this.validate(picker);
+      picker.refresh();
     });
 
     picker.present(pickerOptions);
@@ -516,6 +517,8 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
     picker.onDidDismiss(() => {
       this._isOpen = false;
     });
+
+    picker.refresh();
   }
 
   /**
@@ -673,8 +676,6 @@ export class DateTime extends Ion implements AfterContentInit, ControlValueAcces
         }
       }
     }
-
-    picker.refresh();
   }
 
   /**


### PR DESCRIPTION
#### Short description of what this resolves:
Datetime component was not always showing a correct column selection when min/max is specified.

This is because (1) `picker.present(..)` must be called after `this.validate()` and (2) `picker.refresh()` must be called after `picker.present(..)`.

**Ionic Version**: 2.1

**Fixes**: #9876
