### PR TITLE
fix(infinite-scroll): event.timeStamp polyfill for firefox

### DIFF
--- a/src/util/scroll-view.ts
+++ b/src/util/scroll-view.ts
@@ -76,6 +76,10 @@ export class ScrollView {
 
     function scrollCallback(scrollEvent: UIEvent) {
       ev.timeStamp = scrollEvent.timeStamp;
+      // Event.timeStamp is 0 in firefox
+      if (!ev.timeStamp) {
+        ev.timeStamp = Date.now();
+      }
 
       // get the current scrollTop
       // ******** DOM READ ****************


### PR DESCRIPTION
#### Short description of what this resolves:

InifiniteScroll done not works in firefox.
Event.timeStamp is always 0 in firefox.

- https://github.com/driftyco/ionic/blob/master/src/components/infinite-scroll/infinite-scroll.ts#L217
- https://bugzilla.mozilla.org/show_bug.cgi?id=238041

**Ionic Version**: 2.x

**Fixes**: #9596
