### PR TITLE
Added ionDragEnd output event to be emitted on leave for ion-range

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -307,6 +307,10 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
    */
   @Output() ionChange: EventEmitter<Range> = new EventEmitter<Range>();
 
+  /**
+   * @output {Range} Emitted when the range selector is being left (pointer up).
+   */
+  @Output() ionLeave: EventEmitter<Range> = new EventEmitter<Range>();
 
   constructor(
     private _form: Form,
@@ -411,6 +415,9 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
 
       // trigger a haptic end
       this._haptic.gestureSelectionEnd();
+	  
+      // trigger ionLeave event
+      this.ionLeave.emit(this);
     }
   }
 

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -303,6 +303,11 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   }
 
   /**
+   * @output {Range} Emitted when the range selector drag starts.
+   */
+  @Output() ionFocus: EventEmitter<Range> = new EventEmitter<Range>();
+  
+  /**
    * @output {Range} Emitted when the range value changes.
    */
   @Output() ionChange: EventEmitter<Range> = new EventEmitter<Range>();
@@ -310,7 +315,7 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   /**
    * @output {Range} Emitted when the range selector drag ends.
    */
-  @Output() ionDragEnd: EventEmitter<Range> = new EventEmitter<Range>();
+  @Output() ionBlur: EventEmitter<Range> = new EventEmitter<Range>();
 
   constructor(
     private _form: Form,
@@ -360,6 +365,9 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
       return false;
     }
 
+    // trigger ionFocus event
+    this.ionFocus.emit(this);
+	
     // prevent default so scrolling does not happen
     ev.preventDefault();
     ev.stopPropagation();
@@ -416,8 +424,8 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
       // trigger a haptic end
       this._haptic.gestureSelectionEnd();
 	  
-      // trigger ionDragEnd event
-      this.ionDragEnd.emit(this);
+      // trigger ionBlur event
+      this.ionBlur.emit(this);
     }
   }
 

--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -308,9 +308,9 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
   @Output() ionChange: EventEmitter<Range> = new EventEmitter<Range>();
 
   /**
-   * @output {Range} Emitted when the range selector is being left (pointer up).
+   * @output {Range} Emitted when the range selector drag ends.
    */
-  @Output() ionLeave: EventEmitter<Range> = new EventEmitter<Range>();
+  @Output() ionDragEnd: EventEmitter<Range> = new EventEmitter<Range>();
 
   constructor(
     private _form: Form,
@@ -416,8 +416,8 @@ export class Range extends Ion implements AfterViewInit, ControlValueAccessor, O
       // trigger a haptic end
       this._haptic.gestureSelectionEnd();
 	  
-      // trigger ionLeave event
-      this.ionLeave.emit(this);
+      // trigger ionDragEnd event
+      this.ionDragEnd.emit(this);
     }
   }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Currently, there is no way to know if `ionic-range` is being focused or not.

#### Changes proposed in this pull request:

- Add an output event called `ionDragEnd` to `ion-range`, that is being triggered when the range is being left (pointer up)
- `<ion-range (ionDragEnd)="onDragEnd($event)"></ion-range>`

**Ionic Version**: 2.2.0

**Fixes**: This feature request: https://github.com/driftyco/ionic/issues/10760