### PR TITLE
fix documentation DateTime: config of Month Names (i18n)

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -196,14 +196,19 @@ export const DATETIME_VALUE_ACCESSOR: any = {
  * ### App Config Level
  *
  * ```ts
- * import { ionicBootstrap } from 'ionic-angular';
- *
- * ionicBootstrap(MyApp, customProviders, {
+ * //app.module.ts
+ * @NgModule({
+ * ...,
+ * imports: [
+ *   IonicModule.forRoot(MyApp, {
  *   monthNames: ['janeiro', 'fevereiro', 'mar\u00e7o', ... ],
  *   monthShortNames: ['jan', 'fev', 'mar', ... ],
  *   dayNames: ['domingo', 'segunda-feira', 'ter\u00e7a-feira', ... ],
  *   dayShortNames: ['dom', 'seg', 'ter', ... ],
- * });
+ * })
+ * ],
+ * ...
+ * }) // @NgModule
  * ```
  *
  * ### Component Input Level


### PR DESCRIPTION
#### Short description of what this resolves:
https://ionicframework.com/docs/v2/api/components/datetime/DateTime/

Section Month Names and Day of the Week Names -> App config level

The documentation was not updated after the replacement of ionicBootstrap
So I updated the example to use ionicModule.forRoot instead.

#### Changes proposed in this pull request:

- example updated


**Ionic Version**: 2.x

**Fixes**: #
