### PR TITLE
fix(scroll-view): do not set initialized until it is enabled

### DIFF
--- a/src/util/scroll-view.ts
+++ b/src/util/scroll-view.ts
@@ -55,7 +55,6 @@ export class ScrollView {
   init(ele: HTMLElement, contentTop: number, contentBottom: number) {
     assert(ele, 'scroll-view, element can not be null');
     this._el = ele;
-    this.initialized = true;
     this.contentTop = contentTop;
     this.contentBottom = contentBottom;
 


### PR DESCRIPTION
#### Short description of what this resolves:
Regression caused by 7e9bad5
Details in #10816

#### Changes proposed in this pull request:

- Do not set initialized before checking it

**Ionic Version**: 2.2.0-201703161917

**Fixes**: #10816
