### PR TITLE
feat(platform): add the handler electron platform ready

### DIFF
--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -1,7 +1,7 @@
 import { OpaqueToken } from '@angular/core';
 
 import { Platform, PlatformConfig } from './platform';
-import { isCordova, isIos, isIosUIWebView } from './platform-utils';
+import { isCordova, isElectron, isIos, isIosUIWebView } from './platform-utils';
 
 
 export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
@@ -218,6 +218,23 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
     },
     isMatch(plt: Platform): boolean {
       return isCordova(plt);
+    }
+  },
+
+  /**
+   * electron
+   */
+  'electron': {
+    initialize: function(plt: Platform) {
+      plt.prepareReady = function() {
+        // 1) ionic bootstrapped
+        plt.windowLoad(function() {
+          plt.triggerReady('electron');
+        });
+      };
+    },
+    isMatch(plt: Platform): boolean {
+      return isElectron(plt);
     }
   }
 };

--- a/src/platform/platform-registry.ts
+++ b/src/platform/platform-registry.ts
@@ -225,6 +225,7 @@ export const PLATFORM_CONFIGS: { [key: string]: PlatformConfig } = {
    * electron
    */
   'electron': {
+    superset: 'core',
     initialize: function(plt: Platform) {
       plt.prepareReady = function() {
         // 1) ionic bootstrapped

--- a/src/platform/platform-utils.ts
+++ b/src/platform/platform-utils.ts
@@ -6,6 +6,10 @@ export function isCordova(plt: Platform): boolean {
   return !!(win['cordova'] || win['PhoneGap'] || win['phonegap']);
 }
 
+export function isElectron(plt: Platform): boolean {
+  return plt.testUserAgent('Electron');
+}
+
 export function isIos(plt: Platform): boolean {
   // shortcut function to be reused internally
   // checks navigator.platform to see if it's an actual iOS device

--- a/src/platform/test/platform.spec.ts
+++ b/src/platform/test/platform.spec.ts
@@ -444,6 +444,22 @@ describe('Platform', () => {
     expect(plt.is('tablet')).toEqual(true);
   });
 
+  it('should set electron via user agent', () => {
+    plt.setQueryParams('');
+    plt.setDefault('core');
+    plt.setUserAgent(OSX_10_ELECTRON_1_4_15_UA);
+    plt.init();
+
+    expect(plt.is('core')).toEqual(false);
+    expect(plt.is('mobile')).toEqual(false);
+    expect(plt.is('windows')).toEqual(false);
+    expect(plt.is('android')).toEqual(false);
+    expect(plt.is('ios')).toEqual(false);
+    expect(plt.is('ipad')).toEqual(false);
+    expect(plt.is('tablet')).toEqual(false);
+    expect(plt.is('electron')).toEqual(true);
+  })
+
   it('should set core platform for osx desktop firefox', () => {
     plt.setQueryParams('');
     plt.setDefault('core');
@@ -549,6 +565,7 @@ describe('Platform', () => {
 const OSX_10_FIREFOX_43_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:43.0) Gecko/20100101 Firefox/43.0';
 const OSX_10_SAFARI_9_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/601.4.4 (KHTML, like Gecko) Version/9.0.3 Safari/601.4.4';
 const OSX_10_CHROME_49_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.110 Safari/537.36';
+const OSX_10_ELECTRON_1_4_15_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_3) AppleWebKit/537.36 (KHTML, like Gecko) ionic-hello-world/1.4.15 Chrome/53.0.2785.143 Electron/1.4.15 Safari/537.36';
 
 const WINDOWS_10_CHROME_40_UA = 'Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.93 Safari/537.36';
 const WINDOWS_10_EDGE_12_UA = 'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0';


### PR DESCRIPTION
#### Short description of what this resolves:

The ionic platform running in electron doesn't detect that it's running there and never fires the `device ready` event. This change aims to introduce the electron platform as an available platform and resolve the platform ready when the page has loaded (like the browser).  (First PR to 2.0, let me know if there's anything else I need to do!)

#### Changes proposed in this pull request:

- Add the isElectron platform utility
- Add the electron platform to the registry

**Ionic Version**: 2.2

**Fixes**: #6274