### PR TITLE
fix(alert): add missing cssClass property for buttons

### DIFF
--- a/src/components/alert/alert-options.ts
+++ b/src/components/alert/alert-options.ts
@@ -27,5 +27,6 @@ export interface AlertInputOptions {
 export interface AlertButton {
   text?: string;
   role?: string;
+  cssClass?: string;
   handler?: Function;
 };


### PR DESCRIPTION
#### Short description of what this resolves:
Commit 46fe1ff53cfc2cfef152b560d01882eebca8c678 defined the `AlertButton` interface for the `buttons` array, but it's missing the `cssClass` property as described in the **Button options** section of the docs: http://ionicframework.com/docs/v2/api/components/alert/AlertController/#advanced

#### Changes proposed in this pull request:

- Add the `cssClass` property to the `AlertButton` interface.

**Ionic Version**: 1.x / 2.x
2.3.0

**Fixes**: #
