### PR TITLE
docs(.github): add v3 for github documents

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,7 @@
 **Ionic version:**  (check one with "x")
 [ ] **1.x**
 [ ] **2.x**
+[ ] **3.x**
 
 **I'm submitting a ...**  (check one with "x")
 [ ] bug report

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,6 +7,6 @@
 -
 -
 
-**Ionic Version**: 1.x / 2.x
+**Ionic Version**: 1.x / 2.x / 3.x
 
 **Fixes**: #


### PR DESCRIPTION
Now that v3 is officially in beta, this is needed for bug reports / pull requests

#### Changes proposed in this pull request:

- Added v3 for issues template

**Ionic Version**: 3.x