### PR TITLE
Correctly document usage for selected elements

### DIFF
--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -30,6 +30,10 @@ export const SELECT_VALUE_ACCESSOR: any = {
  * The select component takes child `ion-option` components. If `ion-option` is not
  * given a `value` attribute then it will use its text as the value.
  *
+ * If `ngModel` is bound to `ion-select`, the selected value will be based on the 
+ * bound value of the model. Otherwise, the `selected` attribute can be used on
+ * `ion-option` components.
+ *
  * ### Interfaces
  *
  * By default, the `ion-select` uses the {@link ../../alert/AlertController AlertController API}
@@ -51,7 +55,7 @@ export const SELECT_VALUE_ACCESSOR: any = {
  * <ion-item>
  *   <ion-label>Gender</ion-label>
  *   <ion-select [(ngModel)]="gender">
- *     <ion-option value="f" selected="true">Female</ion-option>
+ *     <ion-option value="f">Female</ion-option>
  *     <ion-option value="m">Male</ion-option>
  *   </ion-select>
  * </ion-item>


### PR DESCRIPTION
#### Short description of what this resolves:

The current documentation has `selected="true"` combined with `ngModel` binding, but this does not work. In fact, the demo on the page does not use `selected`. I removed this from the example code.

I also added a paragraph explaining how to set an option as selected.

#### Changes proposed in this pull request:

- Update documentation and example for `ion-select`

**Ionic Version**: 2.x