### PR TITLE
Update documentation for ion-slide

### DIFF
--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -1035,7 +1035,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the next slides.
-   * @param shouldLockSwipeToNext {boolean}
+   * @param {boolean} shouldLockSwipeToNext 
    */
   lockSwipeToNext(shouldLockSwipeToNext: boolean) {
     this._allowSwipeToNext = !shouldLockSwipeToNext;
@@ -1043,7 +1043,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the previous slides.
-   * @param shouldLockSwipeToPrev {boolean}
+   * @param {boolean} shouldLockSwipeToPrev 
    */
   lockSwipeToPrev(shouldLockSwipeToPrev: boolean) {
     this._allowSwipeToPrev = !shouldLockSwipeToPrev;
@@ -1051,7 +1051,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to change slides.
-   * @param shouldLockSwipes {boolean}
+   * @param {boolean} shouldLockSwipes
    */
   lockSwipes(shouldLockSwipes: boolean) {
     this._allowSwipeToNext = this._allowSwipeToPrev = !shouldLockSwipes;
@@ -1059,7 +1059,7 @@ export class Slides extends Ion {
 
   /**
    * Enable or disable keyboard control.
-   * @param shouldEnableKeyboard {boolean}
+   * @param {boolean} shouldEnableKeyboard
    */
   enableKeyboardControl(shouldEnableKeyboard: boolean) {
     enableKeyboardControl(this, this._plt, shouldEnableKeyboard);

--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -1035,6 +1035,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the next slides.
+   * @param shouldLockSwipeToNext {boolean}
    */
   lockSwipeToNext(shouldLockSwipeToNext: boolean) {
     this._allowSwipeToNext = !shouldLockSwipeToNext;
@@ -1042,6 +1043,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the previous slides.
+   * @param shouldLockSwipeToPrev {boolean}
    */
   lockSwipeToPrev(shouldLockSwipeToPrev: boolean) {
     this._allowSwipeToPrev = !shouldLockSwipeToPrev;
@@ -1049,6 +1051,7 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to change slides.
+   * @param shouldLockSwipes {boolean}
    */
   lockSwipes(shouldLockSwipes: boolean) {
     this._allowSwipeToNext = this._allowSwipeToPrev = !shouldLockSwipes;
@@ -1056,6 +1059,7 @@ export class Slides extends Ion {
 
   /**
    * Enable or disable keyboard control.
+   * @param shouldEnableKeyboard {boolean}
    */
   enableKeyboardControl(shouldEnableKeyboard: boolean) {
     enableKeyboardControl(this, this._plt, shouldEnableKeyboard);

--- a/src/components/slides/slides.ts
+++ b/src/components/slides/slides.ts
@@ -1035,7 +1035,8 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the next slides.
-   * @param {boolean} shouldLockSwipeToNext 
+   * @param {boolean} shouldLockSwipeToNext If set to true the user will not be able to swipe to the next slide. 
+   * Set to false to unlock this behaviour.
    */
   lockSwipeToNext(shouldLockSwipeToNext: boolean) {
     this._allowSwipeToNext = !shouldLockSwipeToNext;
@@ -1043,7 +1044,8 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to the previous slides.
-   * @param {boolean} shouldLockSwipeToPrev 
+   * @param {boolean} shouldLockSwipeToPrev If set to true the user will not be able to swipe to the previous slide.
+   * Set to false to unlock this behaviour.
    */
   lockSwipeToPrev(shouldLockSwipeToPrev: boolean) {
     this._allowSwipeToPrev = !shouldLockSwipeToPrev;
@@ -1051,7 +1053,8 @@ export class Slides extends Ion {
 
   /**
    * Lock or unlock the ability to slide to change slides.
-   * @param {boolean} shouldLockSwipes
+   * @param {boolean} shouldLockSwipes If set to true user can not swipe in either direction on slide. 
+   * False allows swiping in both directions.
    */
   lockSwipes(shouldLockSwipes: boolean) {
     this._allowSwipeToNext = this._allowSwipeToPrev = !shouldLockSwipes;
@@ -1059,7 +1062,7 @@ export class Slides extends Ion {
 
   /**
    * Enable or disable keyboard control.
-   * @param {boolean} shouldEnableKeyboard
+   * @param {boolean} shouldEnableKeyboard If set to true the slider can be controled by a keyboard.
    */
   enableKeyboardControl(shouldEnableKeyboard: boolean) {
     enableKeyboardControl(this, this._plt, shouldEnableKeyboard);


### PR DESCRIPTION
#### Short description of what this resolves:
Reading the documentation and following along left me lost as to why the .lockNextSlides() was not working, this was because it required a boolean parameter that was not reflected in the documentation. This PR adds the JSDoc @param to show that the function requires a boolean parameter. Does not include a definition for the single parameters so this may cause issue in the theme of the docs template.

#### Changes proposed in this pull request:

- Updated documentation to include @params 

**Ionic Version**: 1.x / 2.x
v2
**Fixes**: #
