### PR TITLE
refactor(nav): Exception in lifecycle will print stack trace

### DIFF
--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -572,7 +572,7 @@ export class ViewController {
 
       } catch (e) {
         console.error(`${this.name} ${methodName} error: ${e.message}`);
-        console.error(e);
+        throw(e);
       }
     }
   }

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -572,6 +572,7 @@ export class ViewController {
 
       } catch (e) {
         console.error(`${this.name} ${methodName} error: ${e.message}`);
+        console.error(e);
       }
     }
   }


### PR DESCRIPTION
#### Short description of what this resolves:
Now its very hard to tell what is the error and where it is coming from because the `_lifecycle` method doesn't print the exception stacktrace.

#### Changes proposed in this pull request:

-Just added `console.log`


**Ionic Version**: 1.x / 2.x
2
