### PR TITLE
chore(CI): upgrade to Circle CI v2 and leverage multiple containers for demo builds 

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Build Demos
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "CI2" ]; then
               ./node_modules/.bin/gulp demos.prod --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
             fi
       - add_ssh_keys

--- a/circle.yml
+++ b/circle.yml
@@ -23,10 +23,10 @@ jobs:
       - save_cache:
          key: node_modules_{{ checksum "package.json" }}
          paths:
-         - ~/ionic-native/node_modules/
+         - ~/ionic/node_modules/
       - run:
           name: Run tslint
-          command: gulp lint.ts
+          command: ./node_modules/.bin/gulp lint.ts
       - add_ssh_keys
       - deploy:
           name: Update docs

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Build Demos
           command: |
-            if [ "${CIRCLE_BRANCH}" == "CI2" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./node_modules/.bin/gulp demos.prod --production=true --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
             fi
       - add_ssh_keys

--- a/circle.yml
+++ b/circle.yml
@@ -34,5 +34,6 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./scripts/ci/deploy.sh
             else
+              ./scripts/ci/deploy.sh
               echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."
             fi

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Build Demos
           command: |
-            if [ "${CIRCLE_BRANCH}" == "CI2" ]; then
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
               ./node_modules/.bin/gulp demos.prod --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
             fi
       - add_ssh_keys

--- a/circle.yml
+++ b/circle.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Build Demos
           command: |
-            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+            if [ "${CIRCLE_BRANCH}" == "CI2" ]; then
               ./node_modules/.bin/gulp demos.prod --production=true --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
             fi
       - add_ssh_keys

--- a/circle.yml
+++ b/circle.yml
@@ -1,22 +1,38 @@
-general:
-  branches:
-    ignore:
-      - ins_n_outs
-machine:
-  node:
-    version: 4.1.0
-  post:
-    - npm install -g npm@3.x.x
-dependencies:
-  pre:
-    - ./scripts/docs/prepare.sh
-  cache_directories:
-    - "~/ionic-site" # cache ionic-site
-test:
-  override:
-    - gulp lint.ts
-deployment:
- tasks:
-   branch: "master"
-   commands:
-     - ./scripts/ci/deploy.sh
+version: 2
+jobs:
+  build:
+    working_directory: ~/ionic/
+    docker:
+      - image: node:7
+    steps:
+      - checkout
+      - restore_cache:
+         key: ionic-site
+      - run:
+         name: Prepare ionic-site repo
+         command: ./scripts/docs/prepare.sh
+      - save_cache:
+         key: ionic-site
+         paths:
+         - ~/ionic-site/
+      - restore_cache:
+         key: node_modules_{{ checksum "package.json" }}
+      - run:
+         name: Install node modules
+         command: npm i
+      - save_cache:
+         key: node_modules_{{ checksum "package.json" }}
+         paths:
+         - ~/ionic-native/node_modules/
+      - run:
+          name: Run tslint
+          command: gulp lint.ts
+      - add_ssh_keys
+      - deploy:
+          name: Update docs
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ./scripts/ci/deploy.sh
+            else
+              echo "We are on ${CIRCLE_BRANCH} branch, not going to update docs."
+            fi

--- a/circle.yml
+++ b/circle.yml
@@ -27,6 +27,12 @@ jobs:
       - run:
           name: Run tslint
           command: ./node_modules/.bin/gulp lint.ts
+      - run:
+          name: Build Demos
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "master" ]; then
+              ./node_modules/.bin/gulp demos.prod --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
+            fi
       - add_ssh_keys
       - deploy:
           name: Update docs

--- a/circle.yml
+++ b/circle.yml
@@ -31,7 +31,7 @@ jobs:
           name: Build Demos
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
-              ./node_modules/.bin/gulp demos.prod --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
+              ./node_modules/.bin/gulp demos.prod --production=true --batch=$CIRCLE_NODE_INDEX --batches=$CIRCLE_NODE_TOTAL
             fi
       - add_ssh_keys
       - deploy:

--- a/scripts/docs/deploy.sh
+++ b/scripts/docs/deploy.sh
@@ -20,7 +20,7 @@ function run {
   VERSION=$(readJsonProp "package.json" "version")
 
   #compile API Demos
-  # ./node_modules/.bin/gulp docs.demos --production=true
+  ./node_modules/.bin/gulp docs.demos --production=true
 
   # if release, copy old version to seperate folder and blow out docs root api
   if $IS_RELEASE; then

--- a/scripts/docs/deploy.sh
+++ b/scripts/docs/deploy.sh
@@ -20,7 +20,7 @@ function run {
   VERSION=$(readJsonProp "package.json" "version")
 
   #compile API Demos
-  ./node_modules/.bin/gulp docs.demos --production=true
+  # ./node_modules/.bin/gulp docs.demos --production=true
 
   # if release, copy old version to seperate folder and blow out docs root api
   if $IS_RELEASE; then

--- a/scripts/gulp/tasks/demos.prod.ts
+++ b/scripts/gulp/tasks/demos.prod.ts
@@ -20,7 +20,6 @@ task('demos.prod', ['demos.prepare'], (done: Function) => {
 
   // okay, first find out all of the demos tests to run by finding all of the 'main.ts' files
   filterDemosEntryPoints().then((filePaths: string[]) => {
-    console.log(`Compiling ${filePaths.length} Demos ...`);
     return buildDemos(filePaths);
   }).then(() => {
     done();
@@ -56,7 +55,15 @@ function getDemosEntryPoints() {
 
 
 function buildDemos(filePaths: string[]) {
-  const functions = filePaths.map(filePath => () => {
+  var batches = chunkArrayInGroups(filePaths, argv.batches || 1);
+  var batch = argv.batch || 1;
+  if(batch > batches.length) {
+    throw new Error(`Batch number higher than total number of batches: ${batch} of ${batches.length}`);
+  }
+
+  console.log(`Compiling ${batches[batch - 1].length} of ${filePaths.length} Demos ...`);
+
+  const functions = batches[batch - 1].map(filePath => () => {
     return buildDemo(filePath);
   });
   let concurrentNumber = 2;
@@ -92,6 +99,17 @@ function buildDemo(filePath: string) {
     const end = Date.now();
     console.log(`${filePath} took a total of ${(end - start) / 1000} seconds to build`);
   });
+}
+
+function chunkArrayInGroups(arr, size) {
+  var result = [];
+  for(var i = 0; i < arr.length; i++) {
+    if (!Array.isArray(result[i % size])) {
+      result[i % size] = [];
+    }
+    result[i % size].push(arr[i]);
+  }
+  return result;
 }
 
 task('demos.clean', (done: Function) => {

--- a/scripts/gulp/tasks/demos.prod.ts
+++ b/scripts/gulp/tasks/demos.prod.ts
@@ -56,14 +56,14 @@ function getDemosEntryPoints() {
 
 function buildDemos(filePaths: string[]) {
   var batches = chunkArrayInGroups(filePaths, argv.batches || 1);
-  var batch = argv.batch || 1;
-  if(batch > batches.length) {
-    throw new Error(`Batch number higher than total number of batches: ${batch} of ${batches.length}`);
+  var batch = argv.batch || 0;
+  if(batch >= batches.length) {
+    throw new Error(`Batch number higher than total number of batches.`);
   }
 
-  console.log(`Compiling ${batches[batch - 1].length} of ${filePaths.length} Demos ...`);
+  console.log(`Compiling ${batches[batch].length} of ${filePaths.length} Demos ...`);
 
-  const functions = batches[batch - 1].map(filePath => () => {
+  const functions = batches[batch].map(filePath => () => {
     return buildDemo(filePath);
   });
   let concurrentNumber = 2;

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -30,7 +30,8 @@ task('docs.dgeni', () => {
   }
 });
 
-task('docs.demos', ['demos.prod'], (done: Function) => {
+task('docs.demos', (done: Function) => {
+  // Copy demos already built from gulp demos.prod task to ionic-site
   const config = require('../../config.json');
   const outputDir = join(config.docsDest, 'demos');
   let promises = [];


### PR DESCRIPTION
#### Short description of what this resolves:
CI builds on Circle CI take around 2 hours. Mostly because of the time is takes to build all 41 demos. Sometimes it's over 2 hours. 

Current: https://circleci.com/gh/driftyco/ionic/6142
New: https://circleci.com/gh/driftyco/ionic/6156

#### Changes proposed in this pull request:

- Upgrade to Circle CI v2
- Modify the `gulp demos.prod` task to allow `batch` and `batches` parameters
- Modify the `gulp docs.demos` task to operate independently of `gulp demos.prod`

**Ionic Version**: 2.x