### PR TITLE
fix(slides): negative number indicates position starting at end

### DIFF
--- a/src/components/slides/swiper/swiper-pagination.ts
+++ b/src/components/slides/swiper/swiper-pagination.ts
@@ -63,7 +63,7 @@ export function updatePaginationClasses(s: Slides) {
 
   // Types
   if (s.paginationType === 'bullets' && s._bullets) {
-    let selector = current + ( current < 0 ? s._bullets.length : 0 );
+    var selector = current + ( current < 0 ? s._bullets.length : 0 );
     for (var i = 0; i < s._bullets.length; i++) {
       if (i === selector) {
         addClass(s._bullets[i], CLS.bulletActive);

--- a/src/components/slides/swiper/swiper-pagination.ts
+++ b/src/components/slides/swiper/swiper-pagination.ts
@@ -63,8 +63,9 @@ export function updatePaginationClasses(s: Slides) {
 
   // Types
   if (s.paginationType === 'bullets' && s._bullets) {
+    let selector = current + ( current < 0 ? s._bullets.length : 0 );
     for (var i = 0; i < s._bullets.length; i++) {
-      if (i === current) {
+      if (i === selector) {
         addClass(s._bullets[i], CLS.bulletActive);
       } else {
         removeClass(s._bullets[i], CLS.bulletActive);


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes the issues referenced. Swiping back on a slider with looping enabled now correctly sets the active bullet. 

e2e tested with `gulp e2e.watch --f=slides/loop` and looks good 👍 

#### Changes proposed in this pull request:

- The slider now handles negative index values by indicating the position starting at end.

**Ionic Version**:  2.x / 3.x

**Fixes**: #10826 #10883 
