### PR TITLE
docs(nav-push): Declare params variables

### DIFF
--- a/src/components/nav/nav-push.ts
+++ b/src/components/nav/nav-push.ts
@@ -32,6 +32,7 @@ import { Page } from '../../navigation/nav-util';
  *   template: `<button ion-button [navPush]="pushPage" [navParams]="params">Go</button>`
  * })
  * class MyPage {
+ *   params: Objcet;
  *   constructor(){
  *     this.pushPage = LoginPage;
  *     this.params = { id: 42 };

--- a/src/components/nav/nav-push.ts
+++ b/src/components/nav/nav-push.ts
@@ -32,7 +32,8 @@ import { Page } from '../../navigation/nav-util';
  *   template: `<button ion-button [navPush]="pushPage" [navParams]="params">Go</button>`
  * })
  * class MyPage {
- *   params: Objcet;
+ *   params: Object;
+ *   pushPage: any;
  *   constructor(){
  *     this.pushPage = LoginPage;
  *     this.params = { id: 42 };


### PR DESCRIPTION
#### Short description of what this resolves:

Error: Property 'params' does not exist on type MyPage.
#### Changes proposed in this pull request:

- Declare params on MyPage

**Ionic Version**: 2.x

**Fixes**: #
