### PR TITLE
Added a missing parameter in the doc in setLang()

### DIFF
--- a/src/platform/platform.ts
+++ b/src/platform/platform.ts
@@ -351,6 +351,7 @@ export class Platform {
    * the language needs to be dynamically changed per user/session.
    * [W3C: Declaring language in HTML](http://www.w3.org/International/questions/qa-html-language-declarations)
    * @param {string} language  Examples: `en-US`, `en-GB`, `ar`, `de`, `zh`, `es-MX`
+   * @param {boolean} updateDocument  Specifies whether the `lang` attribute of `<html>` should be updated
    */
   setLang(language: string, updateDocument: boolean) {
     this._lang = language;


### PR DESCRIPTION
#### Short description of what this resolves:
The doc did not mention a required parameter for setLang(), updateDocument

#### Changes proposed in this pull request:

- Added the missing parameter to the doc

**Ionic Version**: 1.x / 2.x
