### PR TITLE
fix(ci-page-template) replace IonicModule with IonicPageModule

### DIFF
--- a/scripts/templates/page/module.ts.tmpl
+++ b/scripts/templates/page/module.ts.tmpl
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { IonicModule } from 'ionic-angular';
+import { IonicPageModule } from 'ionic-angular';
 import { $CLASSNAME } from './$FILENAME';
 
 @NgModule({
@@ -7,7 +7,7 @@ import { $CLASSNAME } from './$FILENAME';
     $CLASSNAME,
   ],
   imports: [
-    IonicModule.forChild($CLASSNAME),
+    IonicPageModule.forChild($CLASSNAME),
   ],
   exports: [
     $CLASSNAME


### PR DESCRIPTION
#### Short description of what this resolves:

When using *ionic g page ...* the result page module file is using IonicModule and it should use IonicPageModule instead.

#### Changes proposed in this pull request:

- Changed the page module tempate to use IonicPageModule.

**Ionic Version**: 3.x

**Fixes**: #11076
