### PR TITLE
fix(tabs): invalid active component detection

### DIFF
--- a/src/components/tabs/tabs.ts
+++ b/src/components/tabs/tabs.ts
@@ -511,7 +511,7 @@ export class Tabs extends Ion implements AfterViewInit, RootNode {
         });
       } else {
         getComponent(this._linker, tab.root).then(viewController => {
-          if (viewController !== active.component) {
+          if (viewController.component !== active.component) {
             // Otherwise, if the page we're on is not our real root
             // reset it to our default root type
             return tab.setRoot(tab.root);


### PR DESCRIPTION
getComponent() returns a ViewController, so we must reference the
component property when checking against the active component

Ionic Version: 3.x