### PR TITLE
fix : "ion-slides" - fast rerendering causes a crash

### DIFF
--- a/src/components/slides/swiper/swiper.ts
+++ b/src/components/slides/swiper/swiper.ts
@@ -893,10 +893,12 @@ export function enableTouchControl(s: Slides) {
 function cleanupStyles(s: Slides) {
   // Container
   removeClass(s.container, s._classNames);
-  s.container.removeAttribute('style');
+  if (s.container) //fix #10830
+    s.container.removeAttribute('style');
 
   // Wrapper
-  s._wrapper.removeAttribute('style');
+  if (s._wrapper) //fix #10830
+    s._wrapper.removeAttribute('style');
 
   // Slides
   if (s._slides && s._slides.length) {

--- a/src/components/slides/swiper/swiper.ts
+++ b/src/components/slides/swiper/swiper.ts
@@ -891,12 +891,13 @@ export function enableTouchControl(s: Slides) {
 
 // Cleanup dynamic styles
 function cleanupStyles(s: Slides) {
-  if (!s.container || !s._wrapper)//fix #10830
-    return 
-    
+  if (!s.container || !s._wrapper) {
+    //fix #10830
+    return;
+  }
+
   // Container
   removeClass(s.container, s._classNames);
-  
   s.container.removeAttribute('style');
 
   // Wrapper

--- a/src/components/slides/swiper/swiper.ts
+++ b/src/components/slides/swiper/swiper.ts
@@ -891,14 +891,16 @@ export function enableTouchControl(s: Slides) {
 
 // Cleanup dynamic styles
 function cleanupStyles(s: Slides) {
+  if (!s.container || !s._wrapper)//fix #10830
+    return 
+    
   // Container
   removeClass(s.container, s._classNames);
-  if (s.container) //fix #10830
-    s.container.removeAttribute('style');
+  
+  s.container.removeAttribute('style');
 
   // Wrapper
-  if (s._wrapper) //fix #10830
-    s._wrapper.removeAttribute('style');
+  s._wrapper.removeAttribute('style');
 
   // Slides
   if (s._slides && s._slides.length) {


### PR DESCRIPTION
add condition, to check if slider exist before remove

#### Short description of what this resolves:
 bug on fast rerendering  #10830

#### Changes proposed in this pull request:

- check if slider exist before clean

**Ionic Version**: 2.2.1

**Fixes**: #10830
