### PR TITLE
ion-card: allow bottom border for the item inputs

### DIFF
--- a/src/components/card/card.md.scss
+++ b/src/components/card/card.md.scss
@@ -103,7 +103,7 @@ $card-md-header-color:                #222 !default;
   border-bottom: 0;
 }
 
-.card-md .item-md.item-block .item-inner {
+.card-md .item-md.item-block:not(.item-input) .item-inner {
   border: 0;
 }
 


### PR DESCRIPTION
ion-card: allow bottom border for the item inputs