### PR TITLE
feat(RTL): better RTL support

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,6 +95,7 @@
     "gulp-uglify": "2.0.0",
     "gulp-util": "3.0.7",
     "gulp-watch": "4.3.9",
+    "hail2u-scss-functions": "^1.2.2",
     "html-entities": "1.2.0",
     "inquirer": "3.0.1",
     "ionic-cz-conventional-changelog": "1.0.0",

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -340,3 +340,14 @@ ion-footer {
 [text-capitalize] {
   text-transform: capitalize;
 }
+
+// Float
+// --------------------------------------------------
+
+[pull-left] {
+  float: left;
+}
+
+[pull-right] {
+  float: right;
+}

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -293,8 +293,7 @@ ion-footer {
 // Text Alignment
 // --------------------------------------------------
 
-[text-left],
-[dir="ltr"] [text-left] {
+[text-left] {
   text-align: left;
 }
 
@@ -302,9 +301,16 @@ ion-footer {
   text-align: center;
 }
 
-[text-right],
-[dir="ltr"] [text-right] {
+[text-right] {
   text-align: right;
+}
+
+[text-start] {
+  text-align: start;
+}
+
+[text-end] {
+  text-align: end;
 }
 
 [text-justify] {
@@ -318,15 +324,6 @@ ion-footer {
 [text-wrap] {
   white-space: normal;
 }
-
-[dir="rtl"] [text-left] {
-  text-align: right;
-}
-
-[dir="rtl"] [text-right] {
-  text-align: left;
-}
-
 
 // Text Transformation
 // --------------------------------------------------

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -293,7 +293,8 @@ ion-footer {
 // Text Alignment
 // --------------------------------------------------
 
-[text-left], [dir="ltr"] [text-left] {
+[text-left],
+[dir="ltr"] [text-left] {
   text-align: left;
 }
 
@@ -301,7 +302,8 @@ ion-footer {
   text-align: center;
 }
 
-[text-right], [dir="ltr"] [text-right] {
+[text-right],
+[dir="ltr"] [text-right] {
   text-align: right;
 }
 
@@ -344,11 +346,13 @@ ion-footer {
 // Float
 // --------------------------------------------------
 
-[pull-left], [dir="ltr"] [pull-left] {
+[pull-left],
+[dir="ltr"] [pull-left] {
   float: left;
 }
 
-[pull-right], [dir="ltr"] [pull-right] {
+[pull-right],
+[dir="ltr"] [pull-right] {
   float: right;
 }
 

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -293,7 +293,7 @@ ion-footer {
 // Text Alignment
 // --------------------------------------------------
 
-[text-left] {
+[text-left], [dir="ltr"] [text-left] {
   text-align: left;
 }
 
@@ -301,7 +301,7 @@ ion-footer {
   text-align: center;
 }
 
-[text-right] {
+[text-right], [dir="ltr"] [text-right] {
   text-align: right;
 }
 
@@ -315,6 +315,14 @@ ion-footer {
 
 [text-wrap] {
   white-space: normal;
+}
+
+[dir="rtl"] [text-left] {
+  text-align: right;
+}
+
+[dir="rtl"] [text-right] {
+  text-align: left;
 }
 
 

--- a/src/components/app/app.scss
+++ b/src/components/app/app.scss
@@ -344,10 +344,18 @@ ion-footer {
 // Float
 // --------------------------------------------------
 
-[pull-left] {
+[pull-left], [dir="ltr"] [pull-left] {
   float: left;
 }
 
-[pull-right] {
+[pull-right], [dir="ltr"] [pull-right] {
   float: right;
+}
+
+[dir="rtl"] [pull-left] {
+  float: right;
+}
+
+[dir="rtl"] [pull-right] {
+  float: left;
 }

--- a/src/components/button/button-icon.scss
+++ b/src/components/button/button-icon.scss
@@ -11,16 +11,32 @@
   pointer-events: none;
 }
 
-[icon-left] ion-icon {
+[icon-left] ion-icon,
+[dir="ltr"] [icon-left] ion-icon {
   @include button-icon;
 
   padding-right: .3em;
 }
 
-[icon-right] ion-icon {
+[icon-right] ion-icon,
+[dir="ltr"] [icon-right] ion-icon {
   @include button-icon;
 
   padding-left: .4em;
+}
+
+[dir="rtl"] [icon-left] ion-icon {
+  @include button-icon;
+
+  padding-left: .4em;
+  padding-right: initial;
+}
+
+[dir="rtl"] [icon-right] ion-icon {
+  @include button-icon;
+
+  padding-right: .3em;
+  padding-left: initial;
 }
 
 .button[icon-only] {

--- a/src/components/segment/segment.ios.scss
+++ b/src/components/segment/segment.ios.scss
@@ -73,7 +73,8 @@ $segment-button-ios-toolbar-icon-size:          2.2rem !default;
 $segment-button-ios-toolbar-icon-line-height:   2.4rem !default;
 
 
-.segment-ios .segment-button {
+.segment-ios .segment-button,
+[dir="ltr"] .segment-ios .segment-button {
   flex: 1;
 
   width: 0;
@@ -127,6 +128,21 @@ $segment-button-ios-toolbar-icon-line-height:   2.4rem !default;
 
     border-left-width: 0;
     border-radius: 0 $segment-button-ios-border-radius $segment-button-ios-border-radius 0;
+  }
+}
+
+[dir="rtl"] .segment-ios .segment-button {
+  &:first-of-type {
+    margin-left: 0;
+
+    border-radius: 0 $segment-button-ios-border-radius $segment-button-ios-border-radius 0;
+  }
+
+  &:last-of-type {
+    margin-right: 0;
+
+    border-left-width: $segment-button-ios-border-width;
+    border-radius: $segment-button-ios-border-radius 0 0 $segment-button-ios-border-radius;
   }
 }
 

--- a/src/fonts/ionicons.scss
+++ b/src/fonts/ionicons.scss
@@ -33,3 +33,68 @@ ion-icon {
   text-transform: none;
   speak: none;
 }
+
+// RTL Support
+// --------------------------
+
+@function str-replace($string, $search, $replace: '') {
+  $index: str-index($string, $search);
+
+  @if $index {
+    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
+  }
+
+  @return $string;
+}
+
+@mixin notIn($attribute, $operator, $ignoreList...) {
+  // If only a single value given
+  @if (length($ignoreList) == 1) {
+    // It is probably a list variable so set ignore list to the variable
+    $ignoreList: nth($ignoreList, 1);
+  }
+
+  // Set up an empty $notOutput variable
+  $notOutput: '';
+  // For each item in the list
+  @each $not in $ignoreList {
+    // Generate a :not([attribute='ignored_item']) segment for each item in the ignore list and put them back to back
+    $notOutput: $notOutput + ":not([#{$attribute}#{$operator}='#{str-replace($not, '-', ' ')}'])";
+  }
+  //output the full :not() rule including all ignored items
+  &#{$notOutput} {
+    @content;
+  }
+}
+
+[flip] {
+  -moz-transform: scaleX(-1);
+  -o-transform: scaleX(-1);
+  -webkit-transform: scaleX(-1);
+  transform: scaleX(-1);
+}
+
+$ltr-begin: "logo";
+
+$ltr-icons: "at", "attach",
+"bluetooth",
+"checkbox", "checkbox-outline", "checkmark", "checkmark-circle", "checkmark-circle-outline", "chrome",
+"closed-captioning",
+  // Adding cloud because of "cloud-done" & "thunderstorm"
+"cloud", "cloud-circle", "cloud-done", "cloud-download", "cloud-outline", "cloud-upload", "thunderstorm",
+"done-all",
+"help", "help-circle",
+"information", "information-circle", "ionic",
+"musical-note", "musical-notes",
+"no-smoking",
+"play",
+"timer", "trending-down", "trending-up",
+"volume-down", "volume-mute", "volume-off", "volume-up";
+
+[dir="rtl"] ion-icon {
+  @include notIn("aria-label", "^", $ltr-begin) { // Does not start with
+    @include notIn("aria-label", "", $ltr-icons) { // Does not equal
+      @extend [flip];
+    }
+  }
+}

--- a/src/fonts/ionicons.scss
+++ b/src/fonts/ionicons.scss
@@ -50,7 +50,7 @@ ion-icon {
   // For each item in the list
   @each $not in $ignoreList {
     // Generate a :not([attribute='ignored_item']) segment for each item in the ignore list and put them back to back
-    $notOutput: $notOutput + ":not([#{$attribute}#{$operator}='#{str-replace($not, '-', ' ')}'])";
+    $notOutput: #{"#{$notOutput}:not([#{$attribute}#{$operator}='#{str-replace($not, '-', ' ')}'])"};
   }
   //output the full :not() rule including all ignored items
   &#{$notOutput} {

--- a/src/fonts/ionicons.scss
+++ b/src/fonts/ionicons.scss
@@ -8,6 +8,7 @@ $ionicons-font-path: $font-path !default;
 
 @import "ionicons-icons";
 @import "ionicons-variables";
+@import "~hail2u-scss-functions/string/_str-replace";
 
 
 @font-face {
@@ -36,16 +37,6 @@ ion-icon {
 
 // RTL Support
 // --------------------------
-
-@function str-replace($string, $search, $replace: '') {
-  $index: str-index($string, $search);
-
-  @if $index {
-    @return str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace);
-  }
-
-  @return $string;
-}
 
 @mixin notIn($attribute, $operator, $ignoreList...) {
   // If only a single value given


### PR DESCRIPTION
#### Short description of what this resolves:
- Much better RTL support

#### Changes proposed in this pull request:
- Add `text-start` and `text-end`. Work exactly the same on `ltr`, but flips directions on `rtl`.
This also avoids confusion, when doing `text-left` on `rtl` it means left, but `text-start` means right
- Add `pull-right` and `pull-left` (bootstrap style naming) for `float`, and flipped on RTL
- Flip every icon except for logos and specific icons that are the same in RTL. (I am from Israel, I made the list)
- Flip tabs border-radius - fixes
![image](https://cloud.githubusercontent.com/assets/5757359/24820105/183ebf22-1bf0-11e7-8bd8-eb92e8fa062c.png)
- Flip `icon-left` and `icon-right` padding

**Ionic Version**: 3.x

**Fixes**: 
Partially: https://github.com/driftyco/ionic/issues/11115
Fully: https://github.com/driftyco/ionic/issues/10685