### PR TITLE
Add 'Page' as part of class name for page generator template

### DIFF
--- a/scripts/templates/page/ts.tmpl
+++ b/scripts/templates/page/ts.tmpl
@@ -12,13 +12,13 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
   selector: 'page-$FILENAME',
   templateUrl: '$FILENAME.html',
 })
-export class $CLASSNAME {
+export class $CLASSNAMEPage {
 
   constructor(public navCtrl: NavController, public navParams: NavParams) {
   }
 
   ionViewDidLoad() {
-    console.log('ionViewDidLoad $CLASSNAME');
+    console.log('ionViewDidLoad $CLASSNAMEPage');
   }
 
 }


### PR DESCRIPTION
#### Short description of what this resolves:
To keep the naming convention consistent with other ionic starter templates, either update this template or other starter templates.

#### Changes proposed in this pull request:

- Add 'Page' as part of class name
- Add 'Page' as part of class name for console log.

**Ionic Version**: 3.x

**Fixes**: #11129 
