### PR TITLE
fix(item): flip padding in md item component

### DIFF
--- a/src/components/item/item.md.scss
+++ b/src/components/item/item.md.scss
@@ -51,7 +51,6 @@ $item-md-divider-padding:            5px 15px !default;
 /// @prop - Background for the sliding content
 $item-md-sliding-content-background: $list-md-background-color !default;
 
-
 .item-md {
   position: relative;
 
@@ -64,7 +63,8 @@ $item-md-sliding-content-background: $list-md-background-color !default;
   box-shadow: none;
   transition: background-color 300ms cubic-bezier(.4, 0, .2, 1);
 }
-[dir="ltr"] .item-md {
+
+.item-md {
   padding-right: 0;
   padding-left: ($item-md-padding-left);
 }

--- a/src/components/item/item.md.scss
+++ b/src/components/item/item.md.scss
@@ -55,9 +55,6 @@ $item-md-sliding-content-background: $list-md-background-color !default;
 .item-md {
   position: relative;
 
-  padding-right: 0;
-  padding-left: ($item-md-padding-left);
-
   font-size: $item-md-font-size;
   font-weight: normal;
   text-transform: none;
@@ -66,6 +63,15 @@ $item-md-sliding-content-background: $list-md-background-color !default;
   background-color: $list-md-background-color;
   box-shadow: none;
   transition: background-color 300ms cubic-bezier(.4, 0, .2, 1);
+}
+[dir="ltr"] .item-md {
+  padding-right: 0;
+  padding-left: ($item-md-padding-left);
+}
+
+[dir="rtl"] .item-md {
+  padding-right: ($item-md-padding-right);
+  padding-left: 0;
 }
 
 .item-md.activated {

--- a/src/components/item/item.md.scss
+++ b/src/components/item/item.md.scss
@@ -53,6 +53,9 @@ $item-md-sliding-content-background: $list-md-background-color !default;
 
 .item-md {
   position: relative;
+  
+  padding-right: 0;
+  padding-left: ($item-md-padding-left);
 
   font-size: $item-md-font-size;
   font-weight: normal;
@@ -62,11 +65,6 @@ $item-md-sliding-content-background: $list-md-background-color !default;
   background-color: $list-md-background-color;
   box-shadow: none;
   transition: background-color 300ms cubic-bezier(.4, 0, .2, 1);
-}
-
-.item-md {
-  padding-right: 0;
-  padding-left: ($item-md-padding-left);
 }
 
 [dir="rtl"] .item-md {


### PR DESCRIPTION
#### Short description of what this resolves:
fix the padding (left/right) of the item component in md mode

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes partially**: #11115 
