### PR TITLE
fix(item): flip forward ios icon when rtl

### DIFF
--- a/src/components/item/item.ios.scss
+++ b/src/components/item/item.ios.scss
@@ -210,6 +210,17 @@ $item-ios-sliding-content-background:     $list-ios-background-color !default;
     background-position: right ($item-ios-padding-right - 2) center;
     background-size: 14px 14px;
   }
+  [dir="rtl"] .item-ios[detail-push] .item-inner,
+  [dir="rtl"] button.item-ios:not([detail-none]) .item-inner,
+  [dir="rtl"] a.item-ios:not([detail-none]) .item-inner {
+    @include svg-background-image($item-ios-detail-push-svg);
+
+    padding-left: 32px;
+
+    background-repeat: no-repeat;
+    background-position: left ($item-ios-padding-left - 2) center;
+    background-size: 14px 14px;
+  }
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
flip the forward icon on item in ios when the direction is rtl

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes partially**: #11115 