### PR TITLE
fix(menu): change side when rtl

### DIFF
--- a/src/components/menu/menu-gestures.ts
+++ b/src/components/menu/menu-gestures.ts
@@ -59,9 +59,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
   onSlide(slide: SlideData, ev: any) {
     if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
       let z = slide.min;
-    }
-
-    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+    } else {
       let z = slide.max;
     }
 
@@ -73,9 +71,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
   onSlideEnd(slide: SlideData, ev: any) {
     if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
       let z = slide.min;
-    }
-
-    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+    } else {
       let z = slide.max;
     }
     
@@ -104,8 +100,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
   getElementStartPos(slide: SlideData, ev: any) {
     if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
       return this.menu.isOpen ? slide.min : slide.max;
-    }
-    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+    } else {
       return this.menu.isOpen ? slide.max : slide.min;
     }
   }
@@ -116,8 +111,7 @@ export class MenuContentGesture extends SlideEdgeGesture {
         min: -this.menu.width(),
         max: 0
       };
-    }
-    this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+    } else {
       return {
         min: 0,
         max: this.menu.width()

--- a/src/components/menu/menu-gestures.ts
+++ b/src/components/menu/menu-gestures.ts
@@ -57,14 +57,28 @@ export class MenuContentGesture extends SlideEdgeGesture {
   }
 
   onSlide(slide: SlideData, ev: any) {
-    let z = (this.menu.side === 'right' ? slide.min : slide.max);
+    if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
+      let z = slide.min;
+    }
+
+    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+      let z = slide.max;
+    }
+
     let stepValue = (slide.distance / z);
 
     this.menu._swipeProgress(stepValue);
   }
 
   onSlideEnd(slide: SlideData, ev: any) {
-    let z = (this.menu.side === 'right' ? slide.min : slide.max);
+    if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
+      let z = slide.min;
+    }
+
+    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+      let z = slide.max;
+    }
+    
     let currentStepValue = (slide.distance / z);
     let velocity = slide.velocity;
     z = Math.abs(z * 0.5);
@@ -88,24 +102,26 @@ export class MenuContentGesture extends SlideEdgeGesture {
   }
 
   getElementStartPos(slide: SlideData, ev: any) {
-    if (this.menu.side === 'right') {
+    if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
       return this.menu.isOpen ? slide.min : slide.max;
     }
-    // left menu
-    return this.menu.isOpen ? slide.max : slide.min;
+    else if (this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+      return this.menu.isOpen ? slide.max : slide.min;
+    }
   }
 
   getSlideBoundaries(): {min: number, max: number} {
-    if (this.menu.side === 'right') {
+    if (this.menu.side === 'right' || (this.menu.side === 'start' && this.plt.isRTL()) || (this.menu.side === 'end' && !this.plt.isRTL())) {
       return {
         min: -this.menu.width(),
         max: 0
       };
     }
-    // left menu
-    return {
-      min: 0,
-      max: this.menu.width()
-    };
+    this.menu.side === 'left' || (this.menu.side === 'end' && this.plt.isRTL()) || (this.menu.side === 'start' && !this.plt.isRTL())) {
+      return {
+        min: 0,
+        max: this.menu.width()
+      };
+    }
   }
 }

--- a/src/components/menu/menu-types.ts
+++ b/src/components/menu/menu-types.ts
@@ -84,7 +84,14 @@ class MenuRevealType extends MenuType {
   constructor(menu: Menu, plt: Platform) {
     super(plt);
 
-    let openedX = (menu.width() * (menu.side === 'right' ? -1 : 1)) + 'px';
+    if (menu.side === 'right' || (menu.side === 'start' && plt.isRTL()) || (menu.side === 'end' && !plt.isRTL())) {
+      let openedX = (menu.width() * -1) + 'px';
+    }
+    
+    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
+      let openedX = (menu.width() * 1) + 'px';
+    }
+      
     let contentOpen = new Animation(plt, menu.getContentElement());
     contentOpen.fromTo('translateX', '0px', openedX);
     this.ani.add(contentOpen);
@@ -105,13 +112,13 @@ class MenuPushType extends MenuType {
 
     let contentOpenedX: string, menuClosedX: string, menuOpenedX: string;
 
-    if (menu.side === 'right') {
-      // right side
+    if (menu.side === 'right' || (menu.side === 'start' && plt.isRTL()) || (menu.side === 'end' && !plt.isRTL())) {
       contentOpenedX = -menu.width() + 'px';
-      menuClosedX = menu.width() + 'px';
       menuOpenedX = '0px';
-
-    } else {
+      menuClosedX = menu.width() + 'px';
+    }
+    
+    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
       contentOpenedX = menu.width() + 'px';
       menuOpenedX = '0px';
       menuClosedX = -menu.width() + 'px';
@@ -140,13 +147,11 @@ class MenuOverlayType extends MenuType {
     super(plt);
 
     let closedX: string, openedX: string;
-    if (menu.side === 'right') {
-      // right side
+    if (menu.side === 'right' || (menu.side === 'start' && plt.isRTL()) || (menu.side === 'end' && !plt.isRTL())) {
       closedX = 8 + menu.width() + 'px';
       openedX = '0px';
-
-    } else {
-      // left side
+    }
+    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
       closedX = -(8 + menu.width()) + 'px';
       openedX = '0px';
     }

--- a/src/components/menu/menu-types.ts
+++ b/src/components/menu/menu-types.ts
@@ -86,9 +86,7 @@ class MenuRevealType extends MenuType {
 
     if (menu.side === 'right' || (menu.side === 'start' && plt.isRTL()) || (menu.side === 'end' && !plt.isRTL())) {
       let openedX = (menu.width() * -1) + 'px';
-    }
-    
-    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
+    } else {
       let openedX = (menu.width() * 1) + 'px';
     }
       
@@ -116,9 +114,7 @@ class MenuPushType extends MenuType {
       contentOpenedX = -menu.width() + 'px';
       menuOpenedX = '0px';
       menuClosedX = menu.width() + 'px';
-    }
-    
-    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
+    } else {
       contentOpenedX = menu.width() + 'px';
       menuOpenedX = '0px';
       menuClosedX = -menu.width() + 'px';
@@ -150,8 +146,7 @@ class MenuOverlayType extends MenuType {
     if (menu.side === 'right' || (menu.side === 'start' && plt.isRTL()) || (menu.side === 'end' && !plt.isRTL())) {
       closedX = 8 + menu.width() + 'px';
       openedX = '0px';
-    }
-    else if (menu.side === 'left' || (menu.side === 'end' && plt.isRTL()) || (menu.side === 'start' && !plt.isRTL())) {
+    } else {
       closedX = -(8 + menu.width()) + 'px';
       openedX = '0px';
     }

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -339,8 +339,11 @@ export class Menu implements RootNode {
     }
 
     // normalize the "side"
-    if (this.side !== 'left' && this.side !== 'right') {
+    if (this.side !== 'left' && this.side !== 'right' && !_plt.isRTL()) {
       this.side = 'left';
+    }
+    else if (this.side !== 'left' && this.side !== 'right' && _plt.isRTL()) {
+      this.side = 'right';
     }
     this.setElementAttribute('side', this.side);
 

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -339,10 +339,10 @@ export class Menu implements RootNode {
     }
 
     // normalize the "side"
-    if (this.side !== 'left' && this.side !== 'right' && !_plt.isRTL()) {
+    if (this.side !== 'left' && this.side !== 'right' && this.side !== 'start' && this.side !== 'end' && !_plt.isRTL()) {
       this.side = 'left';
     }
-    else if (this.side !== 'left' && this.side !== 'right' && _plt.isRTL()) {
+    else if (this.side !== 'left' && this.side !== 'right' && this.side !== 'start' && this.side !== 'end' && _plt.isRTL()) {
       this.side = 'right';
     }
     this.setElementAttribute('side', this.side);

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -341,8 +341,7 @@ export class Menu implements RootNode {
     // normalize the "side"
     if (this.side !== 'left' && this.side !== 'right' && this.side !== 'start' && this.side !== 'end' && !_plt.isRTL()) {
       this.side = 'left';
-    }
-    else if (this.side !== 'left' && this.side !== 'right' && this.side !== 'start' && this.side !== 'end' && _plt.isRTL()) {
+    } else {
       this.side = 'right';
     }
     this.setElementAttribute('side', this.side);

--- a/src/components/menu/menu.ts
+++ b/src/components/menu/menu.ts
@@ -16,6 +16,8 @@ import { Platform } from '../../platform/platform';
 import { UIEventManager } from '../../gestures/ui-event-manager';
 import { RootNode } from '../split-pane/split-pane';
 
+type side = 'left' | 'right' | 'start' | 'end';
+
 /**
  * @name Menu
  * @description
@@ -192,6 +194,7 @@ import { RootNode } from '../split-pane/split-pane';
   encapsulation: ViewEncapsulation.None,
   providers: [{provide: RootNode, useExisting: forwardRef(() => Menu) }]
 })
+
 export class Menu implements RootNode {
 
   private _cntEle: HTMLElement;
@@ -205,6 +208,8 @@ export class Menu implements RootNode {
   private _events: UIEventManager;
   private _gestureBlocker: BlockerDelegate;
   private _isPane: boolean = false;
+  private _side: side = 'start';
+  private _plt: Platform;
 
   /**
    * @hidden
@@ -239,7 +244,17 @@ export class Menu implements RootNode {
   /**
    * @input {string} Which side of the view the menu should be placed. Default `"left"`.
    */
-  @Input() side: string;
+  get side(): side {
+    if (val === 'right' || (val === 'start' && _plt.isRTL()) || (val === 'end' && !_plt.isRTL())) {
+      return 'right';
+    }
+    return 'left';
+  }
+
+  @Input('side')
+  set side(val: side) {
+    this._side = val;
+  }
 
   /**
    * @input {string} The display type of the menu. Default varies based on the mode,
@@ -338,12 +353,6 @@ export class Menu implements RootNode {
       return console.error('Menu: must have a [content] element to listen for drag events on. Example:\n\n<ion-menu [content]="content"></ion-menu>\n\n<ion-nav #content></ion-nav>');
     }
 
-    // normalize the "side"
-    if (this.side !== 'left' && this.side !== 'right' && this.side !== 'start' && this.side !== 'end' && !_plt.isRTL()) {
-      this.side = 'left';
-    } else {
-      this.side = 'right';
-    }
     this.setElementAttribute('side', this.side);
 
     // normalize the "type"

--- a/src/components/menu/test/menu.spec.ts
+++ b/src/components/menu/test/menu.spec.ts
@@ -116,6 +116,42 @@ describe('MenuController', () => {
       expect(menu).toEqual(someMenu);
     });
 
+    it('should get the only left menu when is not rtl', () => {
+      let someMenu = mockMenu();
+      someMenu.side = 'start';
+      menuCtrl._register(someMenu);
+
+      let menu = menuCtrl.get('left');
+      expect(menu).toEqual(someMenu);
+    });
+
+    it('should get the only right menu when is rtl', () => {
+      let someMenu = mockMenu();
+      someMenu.side = 'start';
+      menuCtrl._register(someMenu);
+
+      let menu = menuCtrl.get('right');
+      expect(menu).toEqual(someMenu);
+    });
+
+    it('should get the only right menu when is not rtl', () => {
+      let someMenu = mockMenu();
+      someMenu.side = 'end';
+      menuCtrl._register(someMenu);
+
+      let menu = menuCtrl.get('right');
+      expect(menu).toEqual(someMenu);
+    });
+
+    it('should get the only left menu when is rtl', () => {
+      let someMenu = mockMenu();
+      someMenu.side = 'end';
+      menuCtrl._register(someMenu);
+
+      let menu = menuCtrl.get('left');
+      expect(menu).toEqual(someMenu);
+    });
+
     it('should get the enabled left menu', () => {
       let someMenu1 = mockMenu();
       someMenu1.side = 'left';


### PR DESCRIPTION
*Note:* the menu will be in the better side of the html direction when the page load the first time.

#### Short description of what this resolves:
Change for the better side when direction is rtl

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes partially**: #11115 
