### PR TITLE
feat(alert): custom alert

### DIFF
--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -95,7 +95,7 @@ export class AlertCmp {
   gestureBlocker: BlockerDelegate;
 
   @ViewChild('viewport', {read: ViewContainerRef}) _viewport: ViewContainerRef;
-  createdComponent: any;
+  instance: any;
 
   constructor(
     public _viewCtrl: ViewController,
@@ -152,7 +152,14 @@ export class AlertCmp {
 
       // ******** DOM WRITE ****************
       const componentRef = this._viewport.createComponent(componentFactory, this._viewport.length, childInjector, []);
-      this.createdComponent = componentRef.instance;
+      this.instance = componentRef.instance;
+      this._viewCtrl._setInstance(componentRef.instance);
+
+      this._viewCtrl.didLoad.subscribe(this.ionViewDidLoad.bind(this));
+      this._viewCtrl.willEnter.subscribe(this.ionViewWillEnter.bind(this));
+      this._viewCtrl.willLeave.subscribe(this.ionViewWillLeave.bind(this));
+      this._viewCtrl.didEnter.subscribe(this.ionViewDidEnter.bind(this));
+      this._viewCtrl.didLeave.subscribe(this.ionViewDidLeave.bind(this));
     }
   }
 
@@ -331,12 +338,12 @@ export class AlertCmp {
   }
 
   getValues(): any {
-    if (this.createdComponent) {
+    if (this.instance) {
 
-      if (typeof this.createdComponent.getValues === 'function')
-        return this.createdComponent.getValues();
+      if (typeof this.instance.getValues === 'function')
+        return this.instance.getValues();
 
-      return this.createdComponent;
+      return this.instance;
     }
 
     if (this.inputType === 'radio') {

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, HostListener, Renderer, ViewEncapsulation } from '@angular/core';
+import { Component, ComponentFactoryResolver, ElementRef, HostListener, Renderer, ViewEncapsulation, ViewChild, ViewContainerRef, ReflectiveInjector } from '@angular/core';
 
 import { Config } from '../../config/config';
 import { NON_TEXT_INPUT_REGEX } from '../../util/dom';
@@ -58,6 +58,9 @@ import { AlertInputOptions, AlertOptions, AlertButton } from './alert-options';
         '</ng-template>' +
 
       '</div>' +
+
+      '<div #viewport nav-viewport></div>' +
+
       '<div class="alert-button-group" [ngClass]="{\'alert-button-group-vertical\':d.buttons.length>2}">' +
         '<button ion-button="alert-button" *ngFor="let b of d.buttons" (click)="btnClick(b)" [ngClass]="b.cssClass">' +
           '{{b.text}}' +
@@ -75,7 +78,12 @@ export class AlertCmp {
 
   activeId: string;
   descId: string;
-  d: AlertOptions;
+  d: AlertOptions & {
+    subview?: {
+      component?: any;
+      args?: any
+    }
+  };
   enabled: boolean;
   hdrId: string;
   id: number;
@@ -86,6 +94,9 @@ export class AlertCmp {
   mode: string;
   gestureBlocker: BlockerDelegate;
 
+  @ViewChild('viewport', {read: ViewContainerRef}) _viewport: ViewContainerRef;
+  createdComponent: any;
+
   constructor(
     public _viewCtrl: ViewController,
     public _elementRef: ElementRef,
@@ -93,6 +104,7 @@ export class AlertCmp {
     gestureCtrl: GestureController,
     params: NavParams,
     private _renderer: Renderer,
+    public _cfr: ComponentFactoryResolver,
     private _plt: Platform
   ) {
     // gesture blocker is used to disable gestures dynamically
@@ -125,6 +137,22 @@ export class AlertCmp {
 
     if (!this.d.message) {
       this.d.message = '';
+    }
+  }
+
+  ionViewPreLoad() {
+    if (this.d.subview && this.d.subview.component) {
+
+      const componentFactory = this._cfr.resolveComponentFactory(this.d.subview.component);
+
+      const componentProviders = ReflectiveInjector.resolve([
+        { provide: NavParams, useValue: new NavParams(this.d.subview.args) }
+      ]);
+      const childInjector = ReflectiveInjector.fromResolvedProviders(componentProviders, this._viewport.parentInjector);
+
+      // ******** DOM WRITE ****************
+      const componentRef = this._viewport.createComponent(componentFactory, this._viewport.length, childInjector, []);
+      this.createdComponent = componentRef.instance;
     }
   }
 
@@ -303,6 +331,14 @@ export class AlertCmp {
   }
 
   getValues(): any {
+    if (this.createdComponent) {
+
+      if (typeof this.createdComponent.getValues === 'function')
+        return this.createdComponent.getValues();
+
+      return this.createdComponent;
+    }
+
     if (this.inputType === 'radio') {
       // this is an alert with radio buttons (single value select)
       // return the one value which is checked, otherwise undefined

--- a/src/components/alert/alert-component.ts
+++ b/src/components/alert/alert-component.ts
@@ -93,9 +93,9 @@ export class AlertCmp {
   subHdrId: string;
   mode: string;
   gestureBlocker: BlockerDelegate;
+  isCustomAlert: boolean;
 
   @ViewChild('viewport', {read: ViewContainerRef}) _viewport: ViewContainerRef;
-  instance: any;
 
   constructor(
     public _viewCtrl: ViewController,
@@ -127,6 +127,7 @@ export class AlertCmp {
     this.msgId = 'alert-msg-' + this.id;
     this.activeId = '';
     this.lastClick = 0;
+    this.isCustomAlert = false;
 
     if (this.d.message) {
       this.descId = this.msgId;
@@ -141,26 +142,29 @@ export class AlertCmp {
   }
 
   ionViewPreLoad() {
-    if (this.d.subview && this.d.subview.component) {
-
-      const componentFactory = this._cfr.resolveComponentFactory(this.d.subview.component);
-
-      const componentProviders = ReflectiveInjector.resolve([
-        { provide: NavParams, useValue: new NavParams(this.d.subview.args) }
-      ]);
-      const childInjector = ReflectiveInjector.fromResolvedProviders(componentProviders, this._viewport.parentInjector);
-
-      // ******** DOM WRITE ****************
-      const componentRef = this._viewport.createComponent(componentFactory, this._viewport.length, childInjector, []);
-      this.instance = componentRef.instance;
-      this._viewCtrl._setInstance(componentRef.instance);
-
-      this._viewCtrl.didLoad.subscribe(this.ionViewDidLoad.bind(this));
-      this._viewCtrl.willEnter.subscribe(this.ionViewWillEnter.bind(this));
-      this._viewCtrl.willLeave.subscribe(this.ionViewWillLeave.bind(this));
-      this._viewCtrl.didEnter.subscribe(this.ionViewDidEnter.bind(this));
-      this._viewCtrl.didLeave.subscribe(this.ionViewDidLeave.bind(this));
+    const data = this.d;
+    if (!data.subview || !data.subview.component) {
+      return;
     }
+
+    const componentFactory = this._cfr.resolveComponentFactory(data.subview.component);
+
+    const componentProviders = ReflectiveInjector.resolve([
+      { provide: NavParams, useValue: new NavParams(data.subview.args) }
+    ]);
+    const childInjector = ReflectiveInjector.fromResolvedProviders(componentProviders, this._viewport.parentInjector);
+
+    // ******** DOM WRITE ****************
+    const viewController = this._viewCtrl;
+    const componentRef = this._viewport.createComponent(componentFactory, this._viewport.length, childInjector, []);
+    viewController._setInstance(componentRef.instance);
+
+    viewController.didLoad.subscribe(this.ionViewDidLoad.bind(this));
+    viewController.willEnter.subscribe(this.ionViewWillEnter.bind(this));
+    viewController.didEnter.subscribe(this.ionViewDidEnter.bind(this));
+    viewController.willLeave.subscribe(this.ionViewWillLeave.bind(this));
+    viewController.didLeave.subscribe(this.ionViewDidLeave.bind(this));
+    this.isCustomAlert = true;
   }
 
   ionViewDidLoad() {
@@ -338,12 +342,8 @@ export class AlertCmp {
   }
 
   getValues(): any {
-    if (this.instance) {
-
-      if (typeof this.instance.getValues === 'function')
-        return this.instance.getValues();
-
-      return this.instance;
+    if (this.isCustomAlert) {
+      return this._viewCtrl.instance;
     }
 
     if (this.inputType === 'radio') {

--- a/src/components/alert/alert-controller.ts
+++ b/src/components/alert/alert-controller.ts
@@ -223,10 +223,20 @@ export class AlertController {
   constructor(private _app: App, public config: Config) { }
 
   /**
-   * Display an alert with a title, inputs, and buttons
+   * Display an alert with a title, inputs or a subcomponent, and buttons
    * @param {AlertOptions} opts Alert. See the table below
+   * @param {object} component The subcomponent
+   * @param {object} data Any data to pass to the subcomponent view
    */
-  create(opts: AlertOptions = {}): Alert {
+  create(opts: AlertOptions = {}, component?: any, data?: any): Alert {
+    if (component) {
+      if (opts && opts.inputs) {
+        console.warn(`Alert cannot mix inputs und subcomponent.`);
+      }
+
+      let extraOpts = {subview: {component: component, args: data} };
+      opts = Object.assign({}, opts, extraOpts);
+    }
     return new Alert(this._app, opts, this.config);
   }
 

--- a/src/components/alert/test/basic/app/app.module.ts
+++ b/src/components/alert/test/basic/app/app.module.ts
@@ -4,6 +4,7 @@ import { IonicApp, IonicModule } from '../../../../..';
 
 import { AppComponent } from './app.component';
 import { PageOneModule } from '../pages/page-one/page-one.module';
+import { CustomInnerComponentModule } from '../pages/custom-component/custom-component.module';
 
 @NgModule({
   declarations: [
@@ -12,7 +13,8 @@ import { PageOneModule } from '../pages/page-one/page-one.module';
   imports: [
     BrowserModule,
     IonicModule.forRoot(AppComponent, {}),
-    PageOneModule
+    PageOneModule,
+    CustomInnerComponentModule
   ],
   bootstrap: [IonicApp]
 })

--- a/src/components/alert/test/basic/pages/custom-component/custom-component.html
+++ b/src/components/alert/test/basic/pages/custom-component/custom-component.html
@@ -1,0 +1,14 @@
+<ion-item>
+  <ion-label stacked>Kind</ion-label>
+  <ion-select [(ngModel)]="kind">
+    <ion-option value="fruits">Fruits</ion-option>
+    <ion-option value="numbers">Numbers</ion-option>
+  </ion-select>
+</ion-item>
+
+<ion-item>
+  <ion-label stacked>Value</ion-label>
+  <ion-select [(ngModel)]="selectedValue">
+    <ion-option *ngFor="let val of validValues()" [value]="val">{{ val }}</ion-option>
+  </ion-select>
+</ion-item>

--- a/src/components/alert/test/basic/pages/custom-component/custom-component.module.ts
+++ b/src/components/alert/test/basic/pages/custom-component/custom-component.module.ts
@@ -1,0 +1,14 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from '../../../../../..';
+
+import { CustomInnerComponent } from './custom-component';
+
+@NgModule({
+  declarations: [
+    CustomInnerComponent,
+  ],
+  imports: [
+    IonicPageModule.forChild(CustomInnerComponent)
+  ]
+})
+export class CustomInnerComponentModule {}

--- a/src/components/alert/test/basic/pages/custom-component/custom-component.ts
+++ b/src/components/alert/test/basic/pages/custom-component/custom-component.ts
@@ -1,0 +1,23 @@
+import { Component } from '@angular/core';
+import { IonicPage, NavParams } from '../../../../../..';
+
+@IonicPage()
+@Component({
+  templateUrl: 'custom-component.html'
+})
+export class CustomInnerComponent {
+    kind: string
+    selectedValue: string
+
+    constructor(navParams: NavParams) {
+        this.kind = navParams.get('kind')
+        this.selectedValue = navParams.get('val')
+    }
+
+    validValues() {
+      if(this.kind === 'fruits')
+        return ['Apple', 'Banana', 'Pear'];
+
+      return ['one', 'two', 'three'];
+    }
+}

--- a/src/components/alert/test/basic/pages/page-one/page-one.html
+++ b/src/components/alert/test/basic/pages/page-one/page-one.html
@@ -17,6 +17,7 @@
   <button ion-button block class="e2eOpenPrompt" (click)="doPrompt()">Prompt</button>
   <button ion-button block class="e2eOpenRadio" (click)="doRadio()">Radio</button>
   <button ion-button block class="e2eOpenCheckbox" (click)="doCheckbox()">Checkbox</button>
+  <button ion-button block class="e2eOpenCustom" (click)="doCustom()">Custom</button>
   <button ion-button block class="e2eFastClose" (click)="doFastClose()">Fast Close</button>
   <button ion-button block class="e2eDisabledBackdrop" (click)="doDisabledBackdropAlert()">Disabled Backdrop Click</button>
   <button ion-button block class="e2eAlertMode" (click)="doAlertWithMode('md')">md Mode</button>
@@ -32,6 +33,8 @@
     Radio Result: {{testRadioResult}}
     Checkbox Opened: {{testCheckboxOpen}}
     Checkbox Result: {{testCheckboxResult}}
+    Custom Opened: {{testCustomOpen}}
+    Custom Result: {{testCustomResult}}
   </pre>
 
 </ion-content>

--- a/src/components/alert/test/basic/pages/page-one/page-one.ts
+++ b/src/components/alert/test/basic/pages/page-one/page-one.ts
@@ -1,5 +1,6 @@
 import { Component } from '@angular/core';
 import { AlertController, IonicPage, ModalController } from '../../../../../..';
+import { CustomInnerComponent } from '../custom-component/custom-component';
 
 @IonicPage()
 @Component({
@@ -14,6 +15,8 @@ export class PageOne {
   testRadioResult: string = '';
   testCheckboxOpen: boolean = false;
   testCheckboxResult: string = '';
+  testCustomOpen: boolean = false;
+  testCustomResult: string = '';
 
   constructor(private alertCtrl: AlertController, private modalCtrl: ModalController) { }
 
@@ -272,6 +275,27 @@ export class PageOne {
 
     alert.present().then(() => {
       this.testCheckboxOpen = true;
+    });
+  }
+
+  doCustom() {
+    let alert = this.alertCtrl.create({
+      title: 'custom',
+      buttons: [{
+          text: 'OK',
+          handler: (component: CustomInnerComponent) => {
+            console.log('Custom component data:', component.selectedValue);
+            this.testCustomResult = component.selectedValue;
+          }
+      }, {
+          text: 'Cancel',
+          role: 'cancel'
+      }]
+    }, CustomInnerComponent, {kind: "fruits", val: "Banana"});
+    alert.onDidDismiss( () => this.testCustomOpen = false )
+
+    alert.present().then(() => {
+      this.testCustomOpen = true
     });
   }
 

--- a/src/components/app/app.ts
+++ b/src/components/app/app.ts
@@ -4,7 +4,7 @@ import { Title, DOCUMENT } from '@angular/platform-browser';
 import { IonicApp } from './app-root';
 import * as Constants from './app-constants';
 import { ClickBlock } from './click-block';
-import { runInDev } from '../../util/util';
+import { runInDev, assert } from '../../util/util';
 import { Config } from '../../config/config';
 import { isNav, NavOptions, DIRECTION_FORWARD, DIRECTION_BACK } from '../../navigation/nav-util';
 import { MenuController } from './menu-controller';
@@ -226,6 +226,8 @@ export class App {
    * @hidden
    */
   present(enteringView: ViewController, opts: NavOptions, appPortal?: number): Promise<any> {
+    assert(enteringView.isOverlay, 'presented view controller needs to be an overlay');
+
     const portal = this._appRoot._getPortal(appPortal);
 
     // Set Nav must be set here in order to dimiss() work synchnously.

--- a/src/components/app/overlay-portal.ts
+++ b/src/components/app/overlay-portal.ts
@@ -9,6 +9,7 @@ import { Keyboard } from '../../platform/keyboard';
 import { NavControllerBase } from '../../navigation/nav-controller-base';
 import { Platform } from '../../platform/platform';
 import { TransitionController } from '../../transitions/transition-controller';
+import { ViewController } from '../../navigation/view-controller';
 
 /**
  * @hidden
@@ -40,8 +41,10 @@ export class OverlayPortal extends NavControllerBase {
 
     // on every page change make sure the portal has
     // dismissed any views that should be auto dismissed on page change
-    app.viewDidLeave.subscribe((ev: any) => {
-      !ev.isOverlay && this.dismissPageChangeViews();
+    app.viewDidLeave.subscribe((view: ViewController) => {
+      if (!view.isOverlay) {
+        this.dismissPageChangeViews();
+      }
     });
   }
 

--- a/src/components/item/item-reorder-gesture.ts
+++ b/src/components/item/item-reorder-gesture.ts
@@ -134,7 +134,8 @@ export class ItemReorderGesture {
   }
 
   private itemForCoord(coord: PointerCoordinates): HTMLElement {
-    const x = this.offset.x - 100;
+    const sideOffset = this.plt.isRTL ? 100 : -100;
+    const x = this.offset.x + sideOffset;
     const y = coord.y;
     const element = this.plt.getElementFromPoint(x, y);
     return findReorderItem(element, this.reorderList.getNativeElement());

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -151,6 +151,7 @@ export class Select extends BaseInput<any> implements OnDestroy {
 
   _multi: boolean = false;
   _options: QueryList<Option>;
+  _overlay: ActionSheet | Alert | Popover;
   _texts: string[] = [];
   _text: string = '';
 
@@ -364,6 +365,7 @@ export class Select extends BaseInput<any> implements OnDestroy {
     overlay.present(selectOptions);
 
     this._fireFocus();
+
     overlay.onDidDismiss((value: any) => {
       this._fireBlur();
 
@@ -371,9 +373,23 @@ export class Select extends BaseInput<any> implements OnDestroy {
         this.value = value;
         this.ionChange.emit(value);
       }
+
+      this._overlay = undefined;
     });
+
+    this._overlay = overlay;
   }
 
+  /**
+   * Close the select interface.
+   */
+  close() {
+    if (!this._overlay || !this.isFocus()) {
+      return;
+    }
+
+    return this._overlay.dismiss();
+  }
 
   /**
    * @input {boolean} If true, the element can accept multiple values.

--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -1117,7 +1117,7 @@ export class NavControllerBase extends Ion implements NavController {
   dismissPageChangeViews() {
     for (let view of this._views) {
       if (view.data && view.data.dismissOnPageChange) {
-        view.dismiss().catch(null);
+        view.dismiss().catch(() => {});
       }
     }
   }

--- a/src/navigation/nav-interfaces.ts
+++ b/src/navigation/nav-interfaces.ts
@@ -2,30 +2,30 @@ import { NavOptions } from './nav-util';
 
 export interface Nav {
   goToRoot(opts: NavOptions): Promise<any>;
-};
+}
 
 export interface Tabs {
   _tabs: Tab[];
   select(tabOrIndex: number | Tab, opts: NavOptions): void;
   _top: number;
   setTabbarPosition(top: number, bottom: number): void;
-};
+}
 
 export interface Tab {
   tabUrlPath: string;
   tabTitle: string;
   index: number;
-};
+}
 
 export interface Content {
   resize(): void;
-};
+}
 
 export interface Footer {
-};
+}
 
 export interface Header {
-};
+}
 
 export interface Navbar {
   setBackButtonText(backButtonText: string): void;

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -48,6 +48,12 @@ export class ViewController {
   _cssClass: string;
 
   /**
+   * Observable to be subscribed to when the current component has been loaded
+   * @returns {Observable} Returns an observable
+   */
+  didLoad: EventEmitter<any> = new EventEmitter();
+
+  /**
    * Observable to be subscribed to when the current component will become active
    * @returns {Observable} Returns an observable
    */
@@ -70,12 +76,6 @@ export class ViewController {
    * @returns {Observable} Returns an observable
    */
   didLeave: EventEmitter<any> = new EventEmitter();
-
-  /**
-   * Observable to be subscribed to when the current component has been created
-   * @returns {Observable} Returns an observable
-   */
-  didLoad: EventEmitter<any> = new EventEmitter();
 
   /**
    * Observable to be subscribed to when the current component has been destroyed

--- a/src/navigation/view-controller.ts
+++ b/src/navigation/view-controller.ts
@@ -72,6 +72,12 @@ export class ViewController {
   didLeave: EventEmitter<any> = new EventEmitter();
 
   /**
+   * Observable to be subscribed to when the current component has been created
+   * @returns {Observable} Returns an observable
+   */
+  didLoad: EventEmitter<any> = new EventEmitter();
+
+  /**
    * Observable to be subscribed to when the current component has been destroyed
    * @returns {Observable} Returns an observable
    */
@@ -438,6 +444,7 @@ export class ViewController {
    */
   _didLoad() {
     assert(this._state === STATE_ATTACHED, 'view state must be ATTACHED');
+    this.didLoad.emit(null);
     this._lifecycle('DidLoad');
   }
 

--- a/src/util/module-loader.ts
+++ b/src/util/module-loader.ts
@@ -74,29 +74,25 @@ export interface LoadedModule {
 /**
  * @hidden
  */
-export function setupPreloadingImplementation(config: Config, deepLinkConfig: DeepLinkConfig, moduleLoader: ModuleLoader) {
-  if (config.getBoolean('preloadModules')) {
-      const linksToLoad = deepLinkConfig.links.filter(link => !!link.loadChildren && link.priority !== 'off');
+export function setupPreloadingImplementation(config: Config, deepLinkConfig: DeepLinkConfig, moduleLoader: ModuleLoader): Promise<any> {
+  if (config.getBoolean('preloadModules') && deepLinkConfig && deepLinkConfig.links) {
+    const linksToLoad = deepLinkConfig.links.filter(link => !!link.loadChildren && link.priority !== 'off');
 
-      // Load the high priority modules first
-      const highPriorityPromises = linksToLoad.map(link => {
-        if (link.priority === 'high') {
-          return moduleLoader.load(link.loadChildren);
-        }
-      });
+    // Load the high priority modules first
+    const highPriorityPromises = linksToLoad.filter(link => link.priority === 'high')
+      .map(link => moduleLoader.load(link.loadChildren));
 
-      Promise.all(highPriorityPromises).then(() => {
-        // Load the low priority modules after the high priority are done
-        const lowPriorityPromises = linksToLoad.map(link => {
-          if (link.priority === 'low') {
-            return moduleLoader.load(link.loadChildren);
-          }
-        });
-        return Promise.all(lowPriorityPromises);
-      }).catch(err => {
-        console.error(err.message);
-      });
-    }
+    return Promise.all(highPriorityPromises).then(() => {
+      // Load the low priority modules after the high priority are done
+      const lowPriorityPromises = linksToLoad.filter(link => link.priority === 'low')
+        .map(link => moduleLoader.load(link.loadChildren));
+      return Promise.all(lowPriorityPromises);
+    }).catch(err => {
+      console.error(err.message);
+    });
+  } else {
+    return Promise.resolve();
+  }
 }
 
 /**

--- a/src/util/module-loader.ts
+++ b/src/util/module-loader.ts
@@ -75,24 +75,26 @@ export interface LoadedModule {
  * @hidden
  */
 export function setupPreloadingImplementation(config: Config, deepLinkConfig: DeepLinkConfig, moduleLoader: ModuleLoader): Promise<any> {
-  if (config.getBoolean('preloadModules') && deepLinkConfig && deepLinkConfig.links) {
-    const linksToLoad = deepLinkConfig.links.filter(link => !!link.loadChildren && link.priority !== 'off');
-
-    // Load the high priority modules first
-    const highPriorityPromises = linksToLoad.filter(link => link.priority === 'high')
-      .map(link => moduleLoader.load(link.loadChildren));
-
-    return Promise.all(highPriorityPromises).then(() => {
-      // Load the low priority modules after the high priority are done
-      const lowPriorityPromises = linksToLoad.filter(link => link.priority === 'low')
-        .map(link => moduleLoader.load(link.loadChildren));
-      return Promise.all(lowPriorityPromises);
-    }).catch(err => {
-      console.error(err.message);
-    });
-  } else {
+  if (!deepLinkConfig || !deepLinkConfig.links || !config.getBoolean('preloadModules')) {
     return Promise.resolve();
   }
+  const linksToLoad = deepLinkConfig.links.filter(link => !!link.loadChildren && link.priority !== 'off');
+
+  // Load the high priority modules first
+  const highPriorityPromises = linksToLoad
+    .filter(link => link.priority === 'high')
+    .map(link => moduleLoader.load(link.loadChildren));
+
+  return Promise.all(highPriorityPromises).then(() => {
+    // Load the low priority modules after the high priority are done
+    const lowPriorityPromises = linksToLoad
+      .filter(link => link.priority === 'low')
+      .map(link => moduleLoader.load(link.loadChildren));
+
+    return Promise.all(lowPriorityPromises);
+  }).catch(err => {
+    console.error(err.message);
+  });
 }
 
 /**


### PR DESCRIPTION
#### Short description of what this resolves:

This adds the ability to provide a custom component to the alert controller, similar to popover. This gives the possibility to easily create small dialogs, where ionic provides the title and buttons and the client code just needs to provide the content view.

Example:

    alertController.create({
        title: "title",
        buttons: ["OK"]
    }, InnerComponent, {say: "hello"} ).present();


    @Component({template: "inner component: {{text}}"})
    export class InnerComponent {
        text: string

        constructor(navParams: NavParams) {
            this.text = navParams.get("say")
        }
    }

![customalarm](https://cloud.githubusercontent.com/assets/7298549/24976692/c23b4e72-1fca-11e7-8df6-c799722ab613.jpg)

**Ionic Version**: 3.x
