### PR TITLE
docs(issue): add reference to ionic v1 for v1.x issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,5 @@
 **Ionic version:**  (check one with "x")
-[ ] **1.x**
+[ ] **1.x** (For Ionic 1.x issues, please use https://github.com/driftyco/ionic-v1)
 [ ] **2.x**
 [ ] **3.x**
 


### PR DESCRIPTION
#### Short description of what this resolves:
People using Ionic v1.x and opening issues here
Like - https://github.com/driftyco/ionic/issues/11264, https://github.com/driftyco/ionic/issues/11725

#### Changes proposed in this pull request:
- Add a link to v1 repo

**Ionic Version**: 2.x / 3.x
