### PR TITLE
chore(CI): Updating ionicframework homepage automatically on release

### DIFF
--- a/scripts/docs/deploy.sh
+++ b/scripts/docs/deploy.sh
@@ -38,6 +38,8 @@ function run {
     ./node_modules/.bin/gulp docs.dgeni --doc-version="$VERSION_NAME"
     ./node_modules/.bin/gulp docs.dgeni --doc-version="nightly"
 
+    ./node_modules/.bin/gulp docs.homepageVersionUpdate
+
   else
 
     if [ -d "$DOCS_DEST/nightly/api" ]; then

--- a/scripts/gulp/constants.ts
+++ b/scripts/gulp/constants.ts
@@ -17,6 +17,7 @@ export const ES_2015 = 'es2015';
 export const ES5 = 'es5';
 export const INDEX_JS = 'index.js';
 export const BUNDLES = 'bundles';
+export const SITE_NAME = 'ionic-site';
 
 // File Paths
 export const PROJECT_ROOT = join(__dirname, '../..');
@@ -36,6 +37,7 @@ export const DIST_VENDOR_ROOT = join(DIST_ROOT, VENDOR_NAME);
 export const NODE_MODULES_ROOT = join(PROJECT_ROOT, NODE_MODULES);
 export const SCRIPTS_ROOT = join(PROJECT_ROOT, SCRIPTS_NAME);
 export const SRC_ROOT = join(PROJECT_ROOT, SRC_NAME);
+export const SITE_ROOT = join(PROJECT_ROOT, '..', SITE_NAME);
 
 export const SRC_COMPONENTS_ROOT = join(SRC_ROOT, COMPONENTS_NAME);
 export const WORKERS_SRC = join(SCRIPTS_ROOT, 'workers');

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -10,6 +10,8 @@ import { valid }from 'semver';
 import { argv } from 'yargs';
 
 import { DIST_DEMOS_ROOT } from '../constants';
+import { SITE_ROOT } from '../constants';
+import { PROJECT_ROOT } from '../constants';
 
 task('docs', ['docs.dgeni', 'docs.demos', 'docs.sassVariables']);
 
@@ -135,4 +137,17 @@ task('docs.sassVariables', () => {
       mkdirp.sync('tmp');
       writeFileSync(outputFile, JSON.stringify(variables));
     }));
+});
+
+task('docs.homepageVersionUpdate', () => {
+  // This assumes you're currently releasing
+  const sourcePackageJSON = require(`${PROJECT_ROOT}/package.json`);
+  let now = new Date();
+
+  const frameworkInfo = JSON.stringify({
+    version: sourcePackageJSON.version,
+    date: now.toISOString().split('T')[0]
+  }, null, 2);
+
+  writeFileSync(`${SITE_ROOT}/server/data/framework-info.json`, frameworkInfo);
 });


### PR DESCRIPTION
#### Short description of what this resolves:

Updates a JSON file that ionicframework.com now uses to identify what the latest release is.


#### Changes proposed in this pull request:

- create a necessary new vars following @danbucholtz conventions
- create a new `docs.homepageVersionUpdate` gulp task 
- call the gulp task during a site deploy when a release is detected

**Ionic Version**: 3.x
