### PR TITLE
docs(slides): correct images src path to point to assets directory

### DIFF
--- a/demos/src/slides/pages/page-one/page-one.html
+++ b/demos/src/slides/pages/page-one/page-one.html
@@ -1,5 +1,5 @@
 <ion-slides loop="true" style="background-color: black">
   <ion-slide *ngFor="let image of [1,2,3,4,5]">
-    <img data-src="./slide{{image}}.jpeg">
+    <img data-src="./assets/slide{{image}}.jpeg">
   </ion-slide>
 </ion-slides>


### PR DESCRIPTION
#### Short description of what this resolves:
Documentation minor fix
Corrects src path of images in the Slides demo.

#### Changes proposed in this pull request:

- Change the src path of the img from `"./slide{{image}}.jpeg"` to `"./assets/slide{{image}}.jpeg"`, since images are located in `./assets` directory

**Ionic Version**: 3.x

**Fixes**: #11335 
