### PR TITLE
fix(rtl): change item reorder offset for RTL

### DIFF
--- a/src/components/item/item-reorder-gesture.ts
+++ b/src/components/item/item-reorder-gesture.ts
@@ -134,7 +134,8 @@ export class ItemReorderGesture {
   }
 
   private itemForCoord(coord: PointerCoordinates): HTMLElement {
-    const x = this.offset.x - 100;
+    const sideOffset = this.plt.isRTL ? 100 : -100;
+    const x = this.offset.x + sideOffset;
     const y = coord.y;
     const element = this.plt.getElementFromPoint(x, y);
     return findReorderItem(element, this.reorderList.getNativeElement());


### PR DESCRIPTION
#### Short description of what this resolves:
Item reordering is incorrect in RTL

#### Changes proposed in this pull request:
- add 100 instead of subtract 100 when RTL

**Ionic Version**: 3.x

**Fixes**: https://github.com/driftyco/ionic/issues/11211
