### PR TITLE
chore(package.json): update to latest Angular release

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "zone.js": "^0.8.9"
   },
   "devDependencies": {
-    "@ionic/app-scripts": "1.3.5",
+    "@ionic/app-scripts": "1.3.6",
     "@ionic/commit-hooks": "1.0.3",
     "@types/connect": "3.4.30",
     "@types/del": "2.2.31",

--- a/package.json
+++ b/package.json
@@ -25,20 +25,20 @@
     "link": "gulp release.prepareReleasePackage && cd dist/ionic-angular && npm link"
   },
   "dependencies": {
-    "@angular/common": "4.0.2",
-    "@angular/compiler": "4.0.2",
-    "@angular/compiler-cli": "4.0.2",
-    "@angular/core": "4.0.2",
-    "@angular/forms": "4.0.2",
-    "@angular/http": "4.0.2",
-    "@angular/platform-browser": "4.0.2",
-    "@angular/platform-browser-dynamic": "4.0.2",
+    "@angular/common": "4.1.0",
+    "@angular/compiler": "4.1.0",
+    "@angular/compiler-cli": "4.1.0",
+    "@angular/core": "4.1.0",
+    "@angular/forms": "4.1.0",
+    "@angular/http": "4.1.0",
+    "@angular/platform-browser": "4.1.0",
+    "@angular/platform-browser-dynamic": "4.1.0",
     "ionicons": "~3.0.0",
     "rxjs": "5.1.1",
-    "zone.js": "^0.8.5"
+    "zone.js": "^0.8.9"
   },
   "devDependencies": {
-    "@ionic/app-scripts": "1.3.4",
+    "@ionic/app-scripts": "1.3.5",
     "@ionic/commit-hooks": "1.0.3",
     "@types/connect": "3.4.30",
     "@types/del": "2.2.31",


### PR DESCRIPTION
#### Short description of what this resolves:
In Angular 4.1 are no breaking changes. The update should be no problem.

#### Changes proposed in this pull request:

- Angular 4.1
- zone.js 0.8.9
- app-scripts 1.3.5

**Ionic Version**: 1.x / 2.x / 3.x
3.x