### PR TITLE
[DOCS] Added function wrapper around .subscribe

### DIFF
--- a/src/util/events.ts
+++ b/src/util/events.ts
@@ -20,11 +20,13 @@ import { ScrollView } from '../util/scroll-view';
  *   events.publish('user:created', user, Date.now());
  * }
  *
- * // second page (listen for the user created event)
- * events.subscribe('user:created', (user, time) => {
- *   // user and time are the same arguments passed in `events.publish(user, time)`
- *   console.log('Welcome', user, 'at', time);
- * });
+ * // second page (listen for the user created event after function is called)
+ * function listenForNewUsers() {
+ *   events.subscribe('user:created', (user, time) => {
+ *     // user and time are the same arguments passed in `events.publish(user, time)`
+ *     console.log('Welcome', user, 'at', time);
+ *   });
+ * }
  *
  * ```
  * @demo /docs/demos/src/events/


### PR DESCRIPTION
The documentation noted correctly that one has to publish an event in a function, but forgot to mention that a subscription to an event also has to happen inside of a function.

#### Short description of what this resolves:
Documentation was not complete

#### Changes proposed in this pull request:

- Added function wrapper around .subscribe

**Ionic Version**: 2.x / 3.x

**Fixes**: More complete documentation
