### PR TITLE
test(datetime): add unit tests to make sure we return a string when we should

### DIFF
--- a/src/components/datetime/test/basic/pages/root-page/root-page.html
+++ b/src/components/datetime/test/basic/pages/root-page/root-page.html
@@ -109,4 +109,9 @@
     <ion-datetime displayFormat="HH:mm:ss" [(ngModel)]="time"></ion-datetime>
   </ion-item>
 
+  <ion-item>
+    <ion-label>No displayFormat: {{noFormatDate}}</ion-label>
+    <ion-datetime [(ngModel)]="noFormatDate"></ion-datetime>
+  </ion-item>
+
 </ion-content>

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -140,15 +140,38 @@ describe('DateTime', () => {
       expect(columns[1].options[12].disabled).toEqual(true);
     });
 
-    it('should return a string', () => {
+    it('should always return a string', () => {
       datetime.monthValues = '6,7,8';
       datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 31';
       datetime.yearValues = '2014,2015';
 
-      datetime.generate();
+      datetime.registerOnChange((value: string) => {
+        expect(value).toEqual(jasmine.any(String));
+      });
+    });
 
-      expect(datetime._value).toEqual(jasmine.any(String));
-    })
+    it('should return a string when setValue is passed an object', zoned(() => {
+      const dateTimeData = {
+        hour: {
+          text: '12',
+          value: 12,
+        },
+        minute: {
+          text: '09',
+          value: 9,
+        },
+        ampm: {
+          text: 'pm',
+          value: 'pm',
+        },
+      };
+
+      datetime.setValue(dateTimeData);
+
+      datetime.registerOnChange((value: string) => {
+        expect(value).toEqual(jasmine.any(String));
+      });
+    }));
   });
 
   describe('writeValue', () => {

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -139,6 +139,16 @@ describe('DateTime', () => {
 
       expect(columns[1].options[12].disabled).toEqual(true);
     });
+
+    it('should return a string', () => {
+      datetime.monthValues = '6,7,8';
+      datetime.dayValues = '01,02,03,04,05,06,08,09,10, 11, 12, 13, 31';
+      datetime.yearValues = '2014,2015';
+
+      datetime.generate();
+
+      expect(datetime._value).toEqual(jasmine.any(String));
+    })
   });
 
   describe('writeValue', () => {


### PR DESCRIPTION
#### Short description of what this resolves:
A breaking change, unfortunately, snuck into datetime recently where we were returning an object when it should have been a string. This e2e and unit tests ensure that we always return a string.

#### Changes proposed in this pull request:

- add unit tests to datetime
- add an extra e2e test to datetime

**Ionic Version**: 3.x
