### PR TITLE
avoid fireing ionChange event twice and fire ionSelect event to be consistant with the remaining select interfaces

### DIFF
--- a/src/components/select/select-popover-component.ts
+++ b/src/components/select/select-popover-component.ts
@@ -8,6 +8,7 @@ export interface SelectPopoverOption {
   value: string;
   disabled: boolean;
   checked: boolean;
+  handler?: Function;
 }
 
 /** @hidden */
@@ -30,6 +31,10 @@ export class SelectPopover implements OnInit {
   }
 
   public set value(value: any) {
+    let checkedOption = this.options.find(option => option.value === value);
+    if (checkedOption && checkedOption.handler) {
+      checkedOption.handler();
+    }
     this.viewController.dismiss(value);
   }
 

--- a/src/components/select/select.ts
+++ b/src/components/select/select.ts
@@ -301,7 +301,11 @@ export class Select extends BaseInput<any> implements OnDestroy {
         text: input.text,
         checked: input.selected,
         disabled: input.disabled,
-        value: input.value
+        value: input.value,
+        handler: () => {
+          this.value = input.value;
+          input.ionSelect.emit(input.value);
+        }
       }));
 
       overlay = new Popover(this._app, SelectPopover, {
@@ -368,12 +372,6 @@ export class Select extends BaseInput<any> implements OnDestroy {
 
     overlay.onDidDismiss((value: any) => {
       this._fireBlur();
-
-      if (this.interface === 'popover' && value) {
-        this.value = value;
-        this.ionChange.emit(value);
-      }
-
       this._overlay = undefined;
     });
 


### PR DESCRIPTION
#### Short description of what this resolves:
#11480 

#### Changes proposed in this pull request:

- avoid fireing `ionChage` as it is already fired by button value setter
- add `handler` to `SelectPopoverOption` 
- fire `input.ionSelect.emit(input.value)` instead of  `this.ionChange.emit(value)` to be consistent with `alert` and `action-sheet` 

**Ionic Version**: 3.x

**Fixes**: #11480 
