### PR TITLE
fix(navcontrollerbase): popToRoot should not remove root view

### DIFF
--- a/src/navigation/nav-controller-base.ts
+++ b/src/navigation/nav-controller-base.ts
@@ -331,7 +331,7 @@ export class NavControllerBase extends Ion implements NavController {
       if (ti.removeCount < 0) {
         ti.removeCount = (viewsLength - ti.removeStart);
       }
-      ti.leavingRequiresTransition = ((ti.removeStart + ti.removeCount) === viewsLength);
+      ti.leavingRequiresTransition = (ti.removeCount > 0) && ((ti.removeStart + ti.removeCount) === viewsLength);
     }
 
     if (ti.insertViews) {

--- a/src/navigation/test/nav-controller.spec.ts
+++ b/src/navigation/test/nav-controller.spec.ts
@@ -622,6 +622,25 @@ describe('NavController', () => {
         });
     }, 10000);
 
+    it('should not pop first view if it\'s the only view', (done: Function) => {
+      let view1 = mockView(MockView1);
+      mockViews(nav, [view1]);
+
+      nav.popToRoot(null, trnsDone).then(() => {
+        let hasCompleted = true;
+        let requiresTransition = false;
+        expect(trnsDone).toHaveBeenCalledWith(
+          hasCompleted, requiresTransition, undefined, undefined, undefined
+        );
+        expect(nav.length()).toEqual(1);
+        expect(nav.getByIndex(0).component).toEqual(MockView1);
+        done();
+      }).catch((err: Error) => {
+        fail(err);
+        done(err);
+      });
+    }, 10000);
+
   });
 
   describe('remove', () => {


### PR DESCRIPTION
#### Short description of what this resolves:

When calling `popToRoot` on the root view itself, the root view will no longer be removed.
Demo of current state: http://plnkr.co/edit/7rWOPzOb3rUftEN0nYx6?p=preview

#### Changes proposed in this pull request:

I spent quite some time looking through the code, but I'm not 100% sure if this fix is in the right place. I noticed that `ti.removeCount` was 0, but `ti.leavingRequiresTransition` (and therefore `ti.requiresTransition`) were true, which I assume should not be the case since there should be no transition.

I was able to fix the bug in many different places, but this one seemed to fit best.

**Ionic Version**: 2.x / 3.x

Issue: #11500