### PR TITLE
Fix Navbar link

### DIFF
--- a/src/components/toolbar/toolbar.ts
+++ b/src/components/toolbar/toolbar.ts
@@ -8,7 +8,7 @@ import { ToolbarBase } from './toolbar-base';
  * @name Toolbar
  * @description
  * A Toolbar is a generic bar that is positioned above or below content.
- * Unlike a [Navbar](../../navbar/Navbar), a toolbar can be used as a subheader.
+ * Unlike a [Navbar](../Navbar/), a toolbar can be used as a subheader.
  * When toolbars are placed within an `<ion-header>` or `<ion-footer>`,
  * the toolbars stay fixed in their respective location. When placed within
  * `<ion-content>`, toolbars will scroll with the content.
@@ -90,7 +90,7 @@ import { ToolbarBase } from './toolbar-base';
  *  ```
  *
  * @demo /docs/demos/src/toolbar/
- * @see {@link ../../navbar/Navbar/ Navbar API Docs}
+ * @see {@link ../Navbar/ Navbar API Docs}
  */
 @Component({
   selector: 'ion-toolbar',


### PR DESCRIPTION
#### Short description of what this resolves:
The link to the Navbar API Doc was broken

#### Changes proposed in this pull request:

- `../../navbar/Navbar` -> `../Navbar/` (`../../tabbar/Navbar`)
- this link is on the page twice

**Ionic Version**: 1.x / 2.x / 3.x
