### PR TITLE
fix(datetime): Fix floating label with empty ion-datetime

### DIFF
--- a/src/components/datetime/datetime.ts
+++ b/src/components/datetime/datetime.ts
@@ -8,7 +8,7 @@ import { PickerColumn } from '../picker/picker-options';
 import { Form } from '../../util/form';
 import { BaseInput } from '../../util/base-input';
 import { Item } from '../item/item';
-import { deepCopy, isBlank, isPresent, isArray, isString, assert, clamp } from '../../util/util';
+import { deepCopy, isBlank, isPresent, isArray, isObject, isString, assert, clamp } from '../../util/util';
 import { dateValueRange, renderDateTime, renderTextFormat, convertDataToISO, convertFormatToKey, getValueFromFormat, parseTemplate, parseDate, updateDate, DateTimeData, daysInMonth, dateSortValue, dateDataSortValue, LocaleData } from '../../util/datetime-util';
 
 /**
@@ -758,6 +758,16 @@ export class DateTime extends BaseInput<DateTimeData> implements AfterContentIni
    */
   getValue(): DateTimeData {
     return this._value;
+  }
+
+  /**
+   * @hidden
+   */
+  hasValue(): boolean {
+    const val = this._value;
+    return isPresent(val)
+      && isObject(val)
+      && Object.keys(val).length > 0;
   }
 
   /**

--- a/src/components/datetime/test/datetime.spec.ts
+++ b/src/components/datetime/test/datetime.spec.ts
@@ -658,6 +658,20 @@ describe('DateTime', () => {
 
   });
 
+  describe('hasValue', () => {
+
+    it('should return false if value is not set, and return true if value is set', zoned(() => {
+      expect(datetime.hasValue()).toEqual(false);
+
+      datetime.setValue('1994-12-15T13:47:20.789Z');
+      expect(datetime.hasValue()).toEqual(true);
+
+      datetime.setValue('');
+      expect(datetime.hasValue()).toEqual(false);
+    }));
+
+  });
+
   var datetime: DateTime;
   var picker: Picker;
 

--- a/src/components/datetime/test/labels/pages/root-page/root-page.html
+++ b/src/components/datetime/test/labels/pages/root-page/root-page.html
@@ -30,6 +30,11 @@
   </ion-item>
 
   <ion-item>
+    <ion-label floating>Floating</ion-label>
+    <ion-datetime [(ngModel)]="floating3"></ion-datetime>
+  </ion-item>
+
+  <ion-item>
     <ion-label fixed>Fixed</ion-label>
     <ion-datetime displayFormat="MM/DD/YYYY" [(ngModel)]="fixed1"></ion-datetime>
   </ion-item>

--- a/src/components/datetime/test/labels/pages/root-page/root-page.ts
+++ b/src/components/datetime/test/labels/pages/root-page/root-page.ts
@@ -9,6 +9,7 @@ export class RootPage {
   stacked2 = '1994-12-15T13:47:20.789';
   floating1 = '1995-04-15';
   floating2 = '1995-04-15';
+  floating3 = '';
   fixed1 = '2002-09-23T15:03:46.789';
   fixed2 = '2002-09-23T15:03:46.789';
   inline1 = '2005-06-17T11:06Z';


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes #11547

#### Changes proposed in this pull request:
- 016064e: fix(datetime): Fix floating label with empty ion-datetime

**Ionic Version**: 1.x / 2.x / 3.x
3.x

**Fixes**: #11547
