### PR TITLE
The components was not imported in demo code.

### DIFF
--- a/src/components/alert/alert-controller.ts
+++ b/src/components/alert/alert-controller.ts
@@ -49,6 +49,8 @@ import { Config } from '../../config/config';
  *
  * @usage
  * ```ts
+ * import { AlertController } from 'ionic-angular';
+ *
  * constructor(private alertCtrl: AlertController) {
  *
  * }


### PR DESCRIPTION
Added an importation for use the alert controller on line 52.

#### Short description of what this resolves:
The example code did not include an import statement for use the component.


#### Changes proposed in this pull request:
- Add an import statement.

**Ionic Version**: 2.x

**Fixes**: #11567 