### PR TITLE
refactor(loading): remove unused delay option

### DIFF
--- a/src/components/loading/loading-options.ts
+++ b/src/components/loading/loading-options.ts
@@ -5,6 +5,5 @@ export interface LoadingOptions {
   cssClass?: string;
   showBackdrop?: boolean;
   dismissOnPageChange?: boolean;
-  delay?: number;
   duration?: number;
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Removes unused and undocumented option from LoadingOptions that causes confusion when auto-complete suggested by IDEs.

#### Changes proposed in this pull request:

- Removes LoadingOptions.delay?

**Ionic Version**: 3.x
