### PR TITLE
Fix method signature mismatch in template & class

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -34,7 +34,7 @@ import { Platform } from '../../platform/platform';
         '<ion-icon name="md-arrow-back"></ion-icon>' +
       '</button>' +
       '<div #searchbarIcon class="searchbar-search-icon"></div>' +
-      '<input #searchbarInput class="searchbar-input" (input)="inputChanged($event)" (blur)="inputBlurred($event)" (focus)="inputFocused($event)" ' +
+      '<input #searchbarInput class="searchbar-input" (input)="inputChanged($event)" (blur)="inputBlurred()" (focus)="inputFocused()" ' +
         '[attr.placeholder]="placeholder" ' +
         '[attr.type]="type" ' +
         '[attr.autocomplete]="_autocomplete" ' +


### PR DESCRIPTION
#### Short description of what this resolves:
The latest release introduced a signature mismatch in Searchbar causing AOT builds to fail. The PR fixes this.

#### Changes proposed in this pull request:

- Update the `inputBlurred` method call in template to match the signature in the class
- Update the `inputFocused` method call in template to match the signature in the class

**Ionic Version**: 1.x / 2.x / 3.x

**Fixes**: #11598
