### PR TITLE
fix(VirtualScroll): initialize trackByFn reference

### DIFF
--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -373,7 +373,7 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
   set virtualTrackBy(val: TrackByFn) {
     if (isPresent(val)) {
       this._virtualTrackBy = val;
-      this._createDiffer();
+      this._updateDiffer();
     }
   }
   get virtualTrackBy(): TrackByFn {
@@ -528,12 +528,6 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
   }
 
   private _updateDiffer() {
-    if (isBlank(this._differ)) {
-      this._createDiffer();
-    }
-  }
-
-  private _createDiffer() {
     if (isPresent(this._records)) {
       this._differ = this._iterableDiffers.find(this._records).create(this._virtualTrackBy);
     }

--- a/src/components/virtual-scroll/virtual-scroll.ts
+++ b/src/components/virtual-scroll/virtual-scroll.ts
@@ -373,7 +373,7 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
   set virtualTrackBy(val: TrackByFn) {
     if (isPresent(val)) {
       this._virtualTrackBy = val;
-      this._updateDiffer();
+      this._createDiffer();
     }
   }
   get virtualTrackBy(): TrackByFn {
@@ -528,7 +528,13 @@ export class VirtualScroll implements DoCheck, AfterContentInit, OnDestroy {
   }
 
   private _updateDiffer() {
-    if (isBlank(this._differ) && isPresent(this._records)) {
+    if (isBlank(this._differ)) {
+      this._createDiffer();
+    }
+  }
+
+  private _createDiffer() {
+    if (isPresent(this._records)) {
       this._differ = this._iterableDiffers.find(this._records).create(this._virtualTrackBy);
     }
   }


### PR DESCRIPTION
#### Short description of what this resolves:
The `virtualScroll` input setter can be called first, which calls initializes `_differ` with the default `virtualTrackBy` function. When the `virtualTrackBy` input setter is called later, `_differ` is no longer blank, and so the input `virtualTrackBy` is not used.

#### Changes proposed in this pull request:
Do not check whether `_differ` is undefined in the `virtualTrackBy` setter.

**Ionic Version**: 3.x
**Fixes**: Issue #7531, PR #11492
