### PR TITLE
feat(item-reorder): add side support

### DIFF
--- a/src/components/item/item-reorder-gesture.ts
+++ b/src/components/item/item-reorder-gesture.ts
@@ -135,7 +135,7 @@ export class ItemReorderGesture {
   }
 
   private itemForCoord(coord: PointerCoordinates): HTMLElement {
-    const sideOffset = isRightSide(this.reorderList.side, this.plt.isRTL) ? 100 : -100;
+    const sideOffset = isRightSide(this.reorderList.side, this.plt.isRTL) ? -100 : 100;
     const x = this.offset.x + sideOffset;
     const y = coord.y;
     const element = this.plt.getElementFromPoint(x, y);

--- a/src/components/item/item-reorder-gesture.ts
+++ b/src/components/item/item-reorder-gesture.ts
@@ -2,6 +2,7 @@ import { indexForItem, findReorderItem } from './item-reorder-util';
 import { Platform } from '../../platform/platform';
 import { PointerCoordinates, pointerCoord } from '../../util/dom';
 import { UIEventManager } from '../../gestures/ui-event-manager';
+import { isRightSide, Side } from '../../util/util';
 
 
 /**
@@ -134,7 +135,7 @@ export class ItemReorderGesture {
   }
 
   private itemForCoord(coord: PointerCoordinates): HTMLElement {
-    const sideOffset = this.plt.isRTL ? 100 : -100;
+    const sideOffset = isRightSide(this.reorderList.side, this.plt.isRTL) ? 100 : -100;
     const x = this.offset.x + sideOffset;
     const y = coord.y;
     const element = this.plt.getElementFromPoint(x, y);
@@ -167,6 +168,7 @@ const SCROLL_JUMP = 10;
 const ITEM_REORDER_ACTIVE = 'reorder-active';
 
 export interface ItemReorderGestureDelegate {
+  side: Side;
   getNativeElement: () => any;
   _reorderPrepare: () => void;
   _scrollContent: (scrollPosition: number) => number;

--- a/src/components/item/item-reorder.scss
+++ b/src/components/item/item-reorder.scss
@@ -16,12 +16,18 @@ ion-reorder {
   font-size: 1.7em;
   opacity: .25;
 
-  transform: translate3d(160%, 0, 0);
-
   transition: transform 140ms ease-in;
 
   pointer-events: all;
   touch-action: manipulation;
+
+  &.reorder-end {
+    transform: translate3d(160%, 0, 0);
+  }
+
+  &.reorder-start {
+    transform: translate3d(-160%, 0, 0);
+  }
 }
 
 ion-reorder ion-icon {

--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -2,7 +2,7 @@ import { Directive, ElementRef, EventEmitter, Input, NgZone, Renderer, Optional,
 
 import { Content } from '../content/content';
 import { DomController } from '../../platform/dom-controller';
-import { isTrueProperty, reorderArray } from '../../util/util';
+import { isTrueProperty, reorderArray, Side } from '../../util/util';
 import { ItemReorderGestureDelegate, ItemReorderGesture } from './item-reorder-gesture';
 import { Platform } from '../../platform/platform';
 
@@ -157,6 +157,11 @@ export class ItemReorder implements ItemReorderGestureDelegate {
    * with `from` and `to` properties.
    */
   @Output() ionItemReorder: EventEmitter<ReorderIndexes> = new EventEmitter<ReorderIndexes>();
+
+  /**
+   * @input {string} Which side of the view the menu should be placed. Default `"start"`.
+   */
+  @Input() side: Side = 'start';
 
   constructor(
     private _plt: Platform,

--- a/src/components/item/item-reorder.ts
+++ b/src/components/item/item-reorder.ts
@@ -161,7 +161,7 @@ export class ItemReorder implements ItemReorderGestureDelegate {
   /**
    * @input {string} Which side of the view the menu should be placed. Default `"start"`.
    */
-  @Input() side: Side = 'start';
+  @Input() side: Side = 'end';
 
   constructor(
     private _plt: Platform,

--- a/src/components/item/item.ts
+++ b/src/components/item/item.ts
@@ -7,6 +7,8 @@ import { Icon } from '../icon/icon';
 import { Ion } from '../ion';
 import { Label } from '../label/label';
 import { ItemReorder } from './item-reorder';
+import { isStartSide, Side } from '../../util/util';
+import { Platform } from '../../platform/platform';
 
 
 /**
@@ -276,6 +278,7 @@ import { ItemReorder } from './item-reorder';
   template:
     '<ng-content select="[item-start],[item-left],ion-checkbox:not([item-end]):not([item-right])"></ng-content>' +
     '<div class="item-inner">' +
+      '<ion-reorder *ngIf="_reorderSide == \'start\'" class="reorder-start"></ion-reorder>' +
       '<div class="input-wrapper">' +
         '<ng-content select="ion-label"></ng-content>' +
         '<ion-label *ngIf="_viewLabel">' +
@@ -284,7 +287,7 @@ import { ItemReorder } from './item-reorder';
         '<ng-content select="ion-select,ion-input,ion-textarea,ion-datetime,ion-range,[item-content]"></ng-content>' +
       '</div>' +
       '<ng-content select="[item-end],[item-right],ion-radio,ion-toggle"></ng-content>' +
-      '<ion-reorder *ngIf="_hasReorder"></ion-reorder>' +
+      '<ion-reorder *ngIf="_reorderSide == \'end\'" class="reorder-end"></ion-reorder>' +
     '</div>' +
     '<div class="button-effect"></div>',
   host: {
@@ -299,7 +302,7 @@ export class Item extends Ion {
   _label: Label;
   _viewLabel: boolean = true;
   _name: string = 'item';
-  _hasReorder: boolean;
+  _reorderSide: Side;
 
   /**
    * @hidden
@@ -316,12 +319,13 @@ export class Item extends Ion {
     config: Config,
     elementRef: ElementRef,
     renderer: Renderer,
+    plt: Platform,
     @Optional() reorder: ItemReorder
   ) {
     super(config, elementRef, renderer, 'item');
 
     this._setName(elementRef);
-    this._hasReorder = !!reorder;
+    this._reorderSide = reorder ? (isStartSide(reorder.side, plt.isRTL) ? 'start' : 'end') : null;
     this.id = form.nextId().toString();
 
     // auto add "tappable" attribute to ion-item components that have a click listener

--- a/src/components/item/test/reorder/pages/root-page/root-page.html
+++ b/src/components/item/test/reorder/pages/root-page/root-page.html
@@ -19,18 +19,21 @@
     </button>
   </ion-list>
 
-  <ion-list [reorder]="isReordering" (ionItemReorder)="$event.applyTo(items)">
-    <ion-item-sliding *ngFor="let item of items">
-      <button ion-item (click)="clickedButton(item)">
-        <h2>Sliding item {{item}}</h2>
-      </button>
-      <ion-item-options side="right" icon-left>
-        <button ion-button color='danger'>
-          <ion-icon name="trash"></ion-icon>
-          Remove
+  <div *ngFor="let side of ['left', 'right', 'start', 'end']">
+    <ion-list [reorder]="isReordering" (ionItemReorder)="$event.applyTo(items)" [side]="side">
+      <ion-list-header>{{side}}</ion-list-header>
+      <ion-item-sliding *ngFor="let item of items">
+        <button ion-item (click)="clickedButton(item)">
+          <h2>Sliding item {{item}}</h2>
         </button>
-      </ion-item-options>
-    </ion-item-sliding>
-  </ion-list>
+        <ion-item-options side="right" icon-left>
+          <button ion-button color='danger'>
+            <ion-icon name="trash"></ion-icon>
+            Remove
+          </button>
+        </ion-item-options>
+      </ion-item-sliding>
+    </ion-list>
+  </div>
 
 </ion-content>

--- a/src/components/item/test/reorder/pages/root-page/root-page.ts
+++ b/src/components/item/test/reorder/pages/root-page/root-page.ts
@@ -9,7 +9,7 @@ export class RootPage {
   isReordering: boolean = false;
 
   constructor() {
-    let nu = 9;
+    let nu = 5;
     for (let i = 0; i < nu; i++) {
       this.items.push(i);
     }

--- a/src/util/mock-providers.ts
+++ b/src/util/mock-providers.ts
@@ -529,7 +529,8 @@ export function mockItem(): Item {
   const config = mockConfig();
   const elementRef = mockElementRef();
   const renderer = mockRenderer();
-  return new Item(form, config, elementRef, renderer, null);
+  const platform = mockPlatform();
+  return new Item(form, config, elementRef, renderer, platform, null);
 }
 
 export function mockTabs(app?: App): Tabs {

--- a/src/util/test/base-input.spec.ts
+++ b/src/util/test/base-input.spec.ts
@@ -29,7 +29,7 @@ describe('BaseInput', () => {
 
   it('should configure with item', () => {
     const form = new Form();
-    const item = new Item(form, config, elementRef, renderer, null);
+    const item = new Item(form, config, elementRef, renderer, platform, null);
     const input = mockInput(form, item, null);
 
     expect(input.id).toEqual('input-0-0');

--- a/src/util/util.ts
+++ b/src/util/util.ts
@@ -160,6 +160,24 @@ export function isRightSide(side: Side, isRTL: boolean, defaultRight: boolean = 
   }
 }
 
+/**
+ * @hidden
+ * Given a side, return if it is the start
+ * based on the value of dir
+ * @param side the side
+ * @param isRTL whether the application dir is rtl
+ * @param defaultStart whether the default side is start
+ */
+export function isStartSide(side: Side, isRTL: boolean, defaultStart: boolean = true): boolean {
+  switch (side) {
+    case 'end': return false;
+    case 'start': return true;
+    case 'right': return isRTL;
+    case 'left': return !isRTL;
+    default: return defaultStart;
+  }
+}
+
 
 /** @hidden */
 export function reorderArray(array: any[], indexes: {from: number, to: number}): any[] {


### PR DESCRIPTION
#### Short description of what this resolves:
A user needs this feature

Video:
https://youtu.be/vlRo4PMnhEc

#### Changes proposed in this pull request:
- add [side] to reorder
- change structure of `ion-item`

Of course, this is RTL supported. Except for the `transform`, which will be fixed in an upcoming PR so I did not want to make custom.

**Ionic Version**: 3.x

**Fixes**: https://github.com/driftyco/ionic/issues/11637
