### PR TITLE
fix(rtl): reverse reorder transition in RTL

### DIFF
--- a/src/components/item/item-reorder.scss
+++ b/src/components/item/item-reorder.scss
@@ -24,6 +24,10 @@ ion-reorder {
   touch-action: manipulation;
 }
 
+[dir="rtl"] ion-reorder {
+  transform: translate3d(-160%, 0, 0);
+}
+
 ion-reorder ion-icon {
   pointer-events: none;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
reverse the transition of the reorder button in RTL

#### Changes proposed in this pull request:

- make it -160 instead of 160 in RTL

**Ionic Version**: 3.x

**Fixes**: It's complementary for this pull request #11395
