### PR TITLE
fix(searchbar): searchbar padding should be on the left

### DIFF
--- a/src/components/searchbar/searchbar.ios.scss
+++ b/src/components/searchbar/searchbar.ios.scss
@@ -139,7 +139,7 @@ $searchbar-ios-toolbar-input-background:  rgba(0, 0, 0, .08) !default;
 // -----------------------------------------
 
 .searchbar-ios .searchbar-ios-cancel {
-  @include padding(0, 8px, 0, 0);
+  @include padding(0, 0, 0, 8px);
   @include margin-horizontal(0, null);
 
   display: none;


### PR DESCRIPTION
#### Short description of what this resolves:
#11342 changed the padding left to be padding right

Change reference: https://github.com/driftyco/ionic/pull/11342/files#diff-2f6627d4c874dfc1d437dfeb446ea85eR142

cc @brandyscarney 