### PR TITLE
feat(Searchbar) - expose Focus and Blur events

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -154,6 +154,16 @@ export class Searchbar extends BaseInput<string> {
    */
   @Output() ionClear: EventEmitter<UIEvent> = new EventEmitter<UIEvent>();
 
+  /**
+   * @output {event} Emitted when the searchbar gains focus.
+   */
+  @Output() ionFocus: EventEmitter<UIEvent> = new EventEmitter<UIEvent>();
+
+  /**
+   * @output {event} Emitted when the searchbar loses focus.
+   */
+  @Output() ionBlur: EventEmitter<UIEvent> = new EventEmitter<UIEvent>();
+
 
   constructor(
     config: Config,
@@ -283,10 +293,13 @@ export class Searchbar extends BaseInput<string> {
    * @hidden
    * Sets the Searchbar to focused and active on input focus.
    */
-  inputFocused() {
+  inputFocused(ev: any) {
     this._isActive = true;
     this._fireFocus();
     this.positionElements();
+    this._inputDebouncer.debounce(() => {
+      this.ionFocus.emit(ev);
+    });
   }
 
   /**
@@ -294,7 +307,7 @@ export class Searchbar extends BaseInput<string> {
    * Sets the Searchbar to not focused and checks if it should align left
    * based on whether there is a value in the searchbar or not.
    */
-  inputBlurred() {
+  inputBlurred(ev: any) {
     // _shouldBlur determines if it should blur
     // if we are clearing the input we still want to stay focused in the input
     if (this._shouldBlur === false) {
@@ -304,6 +317,9 @@ export class Searchbar extends BaseInput<string> {
     }
     this._fireBlur();
     this.positionElements();
+     this._inputDebouncer.debounce(() => {
+      this.ionBlur.emit(ev);
+    });
   }
 
   /**


### PR DESCRIPTION
Added code to expose the blur and focus events of the input field via EventEmitters (same as "ionInput" emitter). 

An example use case for this: using searchbar for the Google Places autocomplete together with a native Google Maps from @ionic-native. One has to disable / enable the map taps based on whether the searchbar is in focus  or not (otherwise all clicks on the Google Places suggestions dropdown get hijacked by the map). Also, there was a question about this functionality on StackOverflow: http://stackoverflow.com/questions/43756290/how-to-detect-onfocus-and-blur-event-of-ion-searchbar-in-ionic2

#### Short description of what this resolves:
I added two Output() event emitters to searchbar which emit on focus and on blur, respectively. I tested it locally, it worked as expected.

#### Changes proposed in this pull request:

- Add ionFocus and ionBlur Outputs to searchbar
- call ionBlur.emit() and ionFocus.emit() whenever searchbar loses or gains focus

**Ionic Version**: 1.x / 2.x / [[ 3.x ]]

**Fixes**: #11670
