### PR TITLE
fix(Range): setting min/max should update UI

### DIFF
--- a/src/components/range/range.ts
+++ b/src/components/range/range.ts
@@ -146,6 +146,7 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
     val = Math.round(val);
     if (!isNaN(val)) {
       this._min = val;
+      this._inputUpdated();
     }
   }
 
@@ -160,6 +161,7 @@ export class Range extends BaseInput<any> implements AfterContentInit, ControlVa
     val = Math.round(val);
     if (!isNaN(val)) {
       this._max = val;
+      this._inputUpdated();
     }
   }
 

--- a/src/components/range/test/basic/pages/root-page/root-page.html
+++ b/src/components/range/test/basic/pages/root-page/root-page.html
@@ -93,6 +93,14 @@
     </ion-item>
 
     <ion-item>
+      <ion-label>dynamic min and max</ion-label>
+      <ion-range [min]="min" [max]="max" [(ngModel)]="singeValue5">
+        <ion-label range-left><input type="text" style="width: 50px;" [(ngModel)]="min" /></ion-label>
+        <ion-label range-right><input type="text" style="width: 50px;" [(ngModel)]="max" /></ion-label>
+      </ion-range>
+    </ion-item>
+
+    <ion-item>
       <ion-label>dual, pin, {{dualValue | json}}</ion-label>
       <ion-range dualKnobs="true" pin="true" [(ngModel)]="dualValue"></ion-range>
     </ion-item>

--- a/src/components/range/test/basic/pages/root-page/root-page.ts
+++ b/src/components/range/test/basic/pages/root-page/root-page.ts
@@ -10,8 +10,12 @@ export class RootPage {
   singleValue2: number = 150;
   singleValue3: number = 64;
   singleValue4: number = 1300;
+  singleValue5: number = 0;
   dualValue: any;
   dualValue2 = {lower: 33, upper: 60};
+
+  min: number = -50;
+  max: number = 50;
 
   rangeCtrl = new FormControl({value: '66', disabled: true});
   dualRangeCtrl = new FormControl({value: {lower: 33, upper: 60}, disabled: true});


### PR DESCRIPTION
#### Short description of what this resolves:

Setting min or max of an ion-range doesn't update the UI.

#### Changes proposed in this pull request:

- Refresh UI when min or max are set

**Ionic Version**:  3.x

**Fixes**: #11719
