### PR TITLE
fix(): allow overriding variables

### DIFF
--- a/src/components/alert/alert.md.scss
+++ b/src/components/alert/alert.md.scss
@@ -117,7 +117,7 @@ $alert-md-input-margin-bottom:                5px !default;
 // deprecated
 $alert-md-input-margin-left:                  0 !default;
 /// @prop - Margin start of the alert input
-$alert-md-input-margin-start:                 $alert-md-input-margin-left;
+$alert-md-input-margin-start:                 $alert-md-input-margin-left !default;
 
 /// @prop - Flex wrap of the alert button group
 $alert-md-button-group-flex-wrap:             wrap-reverse !default;

--- a/src/components/card/card.ios.scss
+++ b/src/components/card/card.ios.scss
@@ -17,7 +17,7 @@ $card-ios-margin-bottom:               12px !default;
 // deprecated
 $card-ios-margin-left:                 12px !default;
 /// @prop - Margin start of the card
-$card-ios-margin-start:                $card-ios-margin-left;
+$card-ios-margin-start:                $card-ios-margin-left !default;
 
 /// @prop - Padding top of the card
 $card-ios-padding-top:                 13px !default;
@@ -25,7 +25,7 @@ $card-ios-padding-top:                 13px !default;
 // deprecated
 $card-ios-padding-right:               16px !default;
 /// @prop - Padding end of the card
-$card-ios-padding-end:                 $card-ios-padding-right;
+$card-ios-padding-end:                 $card-ios-padding-right !default;
 
 /// @prop - Padding bottom of the card
 $card-ios-padding-bottom:              14px !default;
@@ -33,7 +33,7 @@ $card-ios-padding-bottom:              14px !default;
 // deprecated
 $card-ios-padding-left:                16px !default;
 /// @prop - Padding start of the card
-$card-ios-padding-start:               $card-ios-padding-left;
+$card-ios-padding-start:               $card-ios-padding-left !default;
 
 /// @prop - Padding top of the media on the card
 $card-ios-padding-media-top:           10px !default;

--- a/src/components/card/card.md.scss
+++ b/src/components/card/card.md.scss
@@ -17,7 +17,7 @@ $card-md-margin-bottom:               10px !default;
 // deprecated
 $card-md-margin-left:                 10px !default;
 /// @prop - Margin start of the card
-$card-md-margin-start:                $card-md-margin-left;
+$card-md-margin-start:                $card-md-margin-left !default;
 
 
 /// @prop - Padding top of the card
@@ -26,7 +26,7 @@ $card-md-padding-top:                 13px !default;
 // deprecated
 $card-md-padding-right:               16px !default;
 /// @prop - Padding right of the card
-$card-md-padding-end:                 $card-md-padding-right;
+$card-md-padding-end:                 $card-md-padding-right !default;
 
 /// @prop - Padding bottom of the card
 $card-md-padding-bottom:              13px !default;
@@ -34,7 +34,7 @@ $card-md-padding-bottom:              13px !default;
 // deprecated
 $card-md-padding-left:                16px !default;
 /// @prop - Padding start of the card
-$card-md-padding-start:               $card-md-padding-left;
+$card-md-padding-start:               $card-md-padding-left !default;
 
 /// @prop - Padding top of the media on the card
 $card-md-padding-media-top:           10px !default;

--- a/src/components/card/card.wp.scss
+++ b/src/components/card/card.wp.scss
@@ -17,7 +17,7 @@ $card-wp-margin-bottom:               8px !default;
 // deprecated
 $card-wp-margin-left:                 8px !default;
 /// @prop - Margin start of the card
-$card-wp-margin-start:                $card-wp-margin-left;
+$card-wp-margin-start:                $card-wp-margin-left !default;
 
 /// @prop - Padding top of the card
 $card-wp-padding-top:                 13px !default;
@@ -25,7 +25,7 @@ $card-wp-padding-top:                 13px !default;
 // deprecated
 $card-wp-padding-right:               16px !default;
 /// @prop - Padding end of the card
-$card-wp-padding-end:                 $card-wp-padding-right;
+$card-wp-padding-end:                 $card-wp-padding-right !default;
 
 /// @prop - Padding bottom of the card
 $card-wp-padding-bottom:              13px !default;
@@ -33,7 +33,7 @@ $card-wp-padding-bottom:              13px !default;
 // deprecated
 $card-wp-padding-left:                16px !default;
 /// @prop - Padding start of the card
-$card-wp-padding-start:               $card-wp-padding-left;
+$card-wp-padding-start:               $card-wp-padding-left !default;
 
 /// @prop - Padding top of the media on the card
 $card-wp-padding-media-top:           10px !default;

--- a/src/components/datetime/datetime.ios.scss
+++ b/src/components/datetime/datetime.ios.scss
@@ -9,7 +9,7 @@ $datetime-ios-padding-top:         $item-ios-padding-top !default;
 // deprecated
 $datetime-ios-padding-right:       ($item-ios-padding-end / 2) !default;
 /// @prop - Padding end of the DateTime component
-$datetime-ios-padding-end:         $datetime-ios-padding-right;
+$datetime-ios-padding-end:         $datetime-ios-padding-right !default;
 
 /// @prop - Padding bottom of the DateTime component
 $datetime-ios-padding-bottom:      $item-ios-padding-bottom !default;
@@ -17,7 +17,7 @@ $datetime-ios-padding-bottom:      $item-ios-padding-bottom !default;
 // deprecated
 $datetime-ios-padding-left:        $item-ios-padding-start !default;
 /// @prop - Padding start of the DateTime component
-$datetime-ios-padding-start:       $datetime-ios-padding-left;
+$datetime-ios-padding-start:       $datetime-ios-padding-left !default;
 
 /// @prop - Color of the DateTime placeholder
 $datetime-ios-placeholder-color:   #999 !default;

--- a/src/components/datetime/datetime.md.scss
+++ b/src/components/datetime/datetime.md.scss
@@ -9,7 +9,7 @@ $datetime-md-padding-top:         $item-md-padding-top !default;
 // deprecated
 $datetime-md-padding-right:       ($item-md-padding-end / 2) !default;
 /// @prop - Padding end of the DateTime component
-$datetime-md-padding-end:         $datetime-md-padding-right;
+$datetime-md-padding-end:         $datetime-md-padding-right !default;
 
 /// @prop - Padding bottom of the DateTime component
 $datetime-md-padding-bottom:      $item-md-padding-bottom !default;
@@ -17,7 +17,7 @@ $datetime-md-padding-bottom:      $item-md-padding-bottom !default;
 // deprecated
 $datetime-md-padding-left:        $item-md-padding-start !default;
 /// @prop - Padding start of the DateTime component
-$datetime-md-padding-start:       $datetime-md-padding-left;
+$datetime-md-padding-start:       $datetime-md-padding-left !default;
 
 /// @prop - Color of the DateTime placeholder
 $datetime-md-placeholder-color:   #999 !default;

--- a/src/components/datetime/datetime.wp.scss
+++ b/src/components/datetime/datetime.wp.scss
@@ -12,7 +12,7 @@ $datetime-wp-padding-top:         $item-wp-padding-top !default;
 // deprecated
 $datetime-wp-padding-right:       ($item-wp-padding-end / 2) !default;
 /// @prop - Padding end of the DateTime component
-$datetime-wp-padding-end:         $datetime-wp-padding-right;
+$datetime-wp-padding-end:         $datetime-wp-padding-right !default;
 
 /// @prop - Padding bottom of the DateTime component
 $datetime-wp-padding-bottom:      $item-wp-padding-bottom !default;
@@ -20,7 +20,7 @@ $datetime-wp-padding-bottom:      $item-wp-padding-bottom !default;
 // deprecated
 $datetime-wp-padding-left:        $item-wp-padding-start !default;
 /// @prop - Padding start of the DateTime component
-$datetime-wp-padding-start:       $datetime-wp-padding-left;
+$datetime-wp-padding-start:       $datetime-wp-padding-left !default;
 
 /// @prop - Border width of the DateTime component
 $datetime-wp-border-width:        2px !default;

--- a/src/components/input/input.ios.scss
+++ b/src/components/input/input.ios.scss
@@ -20,7 +20,7 @@ $text-input-ios-margin-bottom:             $item-ios-padding-bottom !default;
 // deprecated
 $text-input-ios-margin-left:               0 !default;
 /// @prop - Margin start of the input
-$text-input-ios-margin-start:              $text-input-ios-margin-left;
+$text-input-ios-margin-start:              $text-input-ios-margin-left !default;
 
 /// @prop - Width of the icon used to clear the input
 $text-input-ios-input-clear-icon-width:    30px !default;

--- a/src/components/list/list.ios.scss
+++ b/src/components/list/list.ios.scss
@@ -41,7 +41,7 @@ $list-inset-ios-border-radius:        4px !default;
 // deprecated
 $list-ios-header-padding-left:        $item-ios-padding-start !default;
 /// @prop - Padding start of the header in a list
-$list-ios-header-padding-start:       $list-ios-header-padding-left;
+$list-ios-header-padding-start:       $list-ios-header-padding-left !default;
 
 /// @prop - Border bottom of the header in a list
 $list-ios-header-border-bottom:       $hairlines-width solid $list-ios-border-color !default;

--- a/src/components/list/list.md.scss
+++ b/src/components/list/list.md.scss
@@ -44,7 +44,7 @@ $list-md-header-margin-bottom:   13px !default;
 // deprecated
 $list-md-header-padding-left:   $item-md-padding-start !default;
 /// @prop - Padding start of the header in a list
-$list-md-header-padding-start:   $list-md-header-padding-left;
+$list-md-header-padding-start:   $list-md-header-padding-left !default;
 
 /// @prop - Minimum height of the header in a list
 $list-md-header-min-height:      4.5rem !default;

--- a/src/components/list/list.wp.scss
+++ b/src/components/list/list.wp.scss
@@ -41,7 +41,7 @@ $list-inset-wp-border-radius:    2px !default;
 // deprecated
 $list-wp-header-padding-left:    $item-wp-padding-start !default;
 /// @prop - Padding start of the header in a list
-$list-wp-header-padding-start:   $list-wp-header-padding-left;
+$list-wp-header-padding-start:   $list-wp-header-padding-left !default;
 
 /// @prop - Border bottom of the header in a list
 $list-wp-header-border-bottom:   1px solid $list-wp-border-color !default;

--- a/src/components/select/select.ios.scss
+++ b/src/components/select/select.ios.scss
@@ -9,7 +9,7 @@ $select-ios-padding-top:         $item-ios-padding-top !default;
 // deprecated
 $select-ios-padding-right:       ($item-ios-padding-end / 2) !default;
 /// @prop - Padding end of the select
-$select-ios-padding-end:         $select-ios-padding-right;
+$select-ios-padding-end:         $select-ios-padding-right !default;
 
 /// @prop - Padding bottom of the select
 $select-ios-padding-bottom:      $item-ios-padding-bottom !default;
@@ -17,7 +17,7 @@ $select-ios-padding-bottom:      $item-ios-padding-bottom !default;
 // deprecated
 $select-ios-padding-left:        $item-ios-padding-start !default;
 /// @prop - Padding start of the select
-$select-ios-padding-start:       $select-ios-padding-left;
+$select-ios-padding-start:       $select-ios-padding-left !default;
 
 /// @prop - Color of the select icon
 $select-ios-icon-color:          #999 !default;

--- a/src/components/select/select.md.scss
+++ b/src/components/select/select.md.scss
@@ -9,7 +9,7 @@ $select-md-padding-top:         $item-md-padding-top !default;
 // deprecated
 $select-md-padding-right:       ($item-md-padding-end / 2) !default;
 /// @prop - Padding end of the select
-$select-md-padding-end:         $select-md-padding-right;
+$select-md-padding-end:         $select-md-padding-right !default;
 
 /// @prop - Padding bottom of the select
 $select-md-padding-bottom:      $item-md-padding-bottom !default;
@@ -17,7 +17,7 @@ $select-md-padding-bottom:      $item-md-padding-bottom !default;
 // deprecated
 $select-md-padding-left:        $item-md-padding-start !default;
 /// @prop - Padding start of the select
-$select-md-padding-start:       $select-md-padding-left;
+$select-md-padding-start:       $select-md-padding-left !default;
 
 /// @prop - Color of the select icon
 $select-md-icon-color:          #999 !default;

--- a/src/themes/ionic.theme.dark.ios.scss
+++ b/src/themes/ionic.theme.dark.ios.scss
@@ -71,11 +71,11 @@ $item-ios-divider-color:               $text-color !default;
 $item-ios-padding-top:                11px !default;
 // deprecated
 $item-ios-padding-right:              16px !default;
-$item-ios-padding-end:                $item-ios-padding-right;
+$item-ios-padding-end:                $item-ios-padding-right !default;
 $item-ios-padding-bottom:             11px !default;
 // deprecated
 $item-ios-padding-left:               16px !default;
-$item-ios-padding-start:              $item-ios-padding-left;
+$item-ios-padding-start:              $item-ios-padding-left !default;
 $item-ios-padding-media-top:          10px !default;
 $item-ios-padding-media-bottom:       10px !default;
 $item-ios-padding-icon-top:           9px !default;

--- a/src/themes/ionic.theme.dark.md.scss
+++ b/src/themes/ionic.theme.dark.md.scss
@@ -60,11 +60,11 @@ $list-md-activated-background-color:  #d9d9d9 !default;
 $item-md-padding-top:                 13px !default;
 // deprecated
 $item-md-padding-right:               16px !default;
-$item-md-padding-end:                 $item-md-padding-right;
+$item-md-padding-end:                 $item-md-padding-right !default;
 $item-md-padding-bottom:              13px !default;
 // deprecated
 $item-md-padding-left:                16px !default;
-$item-md-padding-start:               $item-md-padding-left;
+$item-md-padding-start:               $item-md-padding-left !default;
 $item-md-padding-media-top:           9px !default;
 $item-md-padding-media-bottom:        9px !default;
 $item-md-padding-icon-top:            11px !default;

--- a/src/themes/ionic.theme.dark.wp.scss
+++ b/src/themes/ionic.theme.dark.wp.scss
@@ -61,11 +61,11 @@ $list-wp-activated-background-color:  #d9d9d9 !default;
 $item-wp-padding-top:                 13px !default;
 // deprecated
 $item-wp-padding-right:               16px !default;
-$item-wp-padding-end:                 $item-wp-padding-right;
+$item-wp-padding-end:                 $item-wp-padding-right !default;
 $item-wp-padding-bottom:              13px !default;
 // deprecated
 $item-wp-padding-left:                16px !default;
-$item-wp-padding-start:               $item-wp-padding-left;
+$item-wp-padding-start:               $item-wp-padding-left !default;
 $item-wp-padding-media-top:           9px !default;
 $item-wp-padding-media-bottom:        9px !default;
 $item-wp-padding-icon-top:            11px !default;

--- a/src/themes/ionic.theme.default.ios.scss
+++ b/src/themes/ionic.theme.default.ios.scss
@@ -53,11 +53,11 @@ $list-ios-activated-background-color:  #d9d9d9 !default;
 $item-ios-padding-top:                11px !default;
 // deprecated
 $item-ios-padding-right:              16px !default;
-$item-ios-padding-end:                $item-ios-padding-right;
+$item-ios-padding-end:                $item-ios-padding-right !default;
 $item-ios-padding-bottom:             11px !default;
 // deprecated
 $item-ios-padding-left:               16px !default;
-$item-ios-padding-start:              $item-ios-padding-left;
+$item-ios-padding-start:              $item-ios-padding-left !default;
 $item-ios-padding-media-top:          8px !default;
 $item-ios-padding-media-bottom:       8px !default;
 $item-ios-padding-icon-top:           9px !default;

--- a/src/themes/ionic.theme.default.md.scss
+++ b/src/themes/ionic.theme.default.md.scss
@@ -52,11 +52,11 @@ $list-md-activated-background-color:  #f1f1f1 !default;
 $item-md-padding-top:                 13px !default;
 // deprecated
 $item-md-padding-right:               16px !default;
-$item-md-padding-end:                 $item-md-padding-right;
+$item-md-padding-end:                 $item-md-padding-right !default;
 $item-md-padding-bottom:              13px !default;
 // deprecated
 $item-md-padding-left:                16px !default;
-$item-md-padding-start:               $item-md-padding-left;
+$item-md-padding-start:               $item-md-padding-left !default;
 $item-md-padding-media-top:           9px !default;
 $item-md-padding-media-bottom:        9px !default;
 $item-md-padding-icon-top:            11px !default;

--- a/src/themes/ionic.theme.default.wp.scss
+++ b/src/themes/ionic.theme.default.wp.scss
@@ -53,11 +53,11 @@ $list-wp-activated-background-color:  #aaa !default;
 $item-wp-padding-top:                 13px !default;
 // deprecated
 $item-wp-padding-right:               16px !default;
-$item-wp-padding-end:                 $item-wp-padding-right;
+$item-wp-padding-end:                 $item-wp-padding-right !default;
 $item-wp-padding-bottom:              13px !default;
 // deprecated
 $item-wp-padding-left:                16px !default;
-$item-wp-padding-start:               $item-wp-padding-left;
+$item-wp-padding-start:               $item-wp-padding-left !default;
 $item-wp-padding-media-top:           9px !default;
 $item-wp-padding-media-bottom:        9px !default;
 $item-wp-padding-icon-top:            11px !default;


### PR DESCRIPTION
#### Short description of what this resolves:
Missing `!default` on the latest rtl compatible variables introduced by a30379b.

These were the cases I could find, I might have missed some. Maybe it's possible to add a test that checks if all Ionic variables have a `!default`?

PS: please squash these commits 😬

**Ionic Version**: 3.3.0