### PR TITLE
fix(searchbar): caret moving to the end when typing

### DIFF
--- a/src/components/searchbar/searchbar.ts
+++ b/src/components/searchbar/searchbar.ts
@@ -188,7 +188,9 @@ export class Searchbar extends BaseInput<string> {
    */
   _inputUpdated() {
     const ele = this._searchbarInput.nativeElement;
-    if (ele) {
+    // It is important not to re-assign the value if it is the same, because,
+    // otherwise, the caret is moved to the end of the input
+    if (ele && ele.value !== this.value) {
       ele.value = this.value;
     }
     this.positionElements();


### PR DESCRIPTION
#### Short description of what this resolves:

The issue is reproducible on the [demo page](http://ionicframework.com/docs/components/#searchbar):
- type something (for example `Aviv`)
- go to the beginning of the field
- type something (for example `Tel `)
- after typing the first char (`T`), the caret unexpectedly moves to the end of the field, and the field finally contains `TAvivel ` instead of `Tel Aviv`.

#### Changes proposed in this pull request:

- In `_inputUpdated`, before updating the value of the input, check whether the assignment is useful.

**Ionic Version**: 3.2.1
