### PR TITLE
Document cssClass option to ModalController

### DIFF
--- a/src/components/modal/modal-controller.ts
+++ b/src/components/modal/modal-controller.ts
@@ -65,6 +65,7 @@ import { DeepLinker } from '../../navigation/deep-linker';
  * |-----------------------|------------|------------------------------------------------------------------------------------------------------------------|
  * | showBackdrop          |`boolean`   | Whether to show the backdrop. Default true.                                                                      |
  * | enableBackdropDismiss |`boolean`   | Whether the popover should be dismissed by tapping the backdrop. Default true.                                   |
+ * | cssClass              |`string`    | Additional classes for custom styles, separated by spaces.                                                       |
  *
  * A modal can also emit data, which is useful when it is used to add or edit
  * data. For example, a profile page could slide up in a modal, and on submit,


### PR DESCRIPTION
Adds documentation for cssClass option to ModalController.create

**Ionic Version**: 3.x

**Fixes**: #10020 (doesn't actually fix it, just documents the prior fix)
