### PR TITLE
chore(dependencies) Allow minor dependencies updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,16 +25,16 @@
     "link": "gulp release.prepareReleasePackage && cd dist/ionic-angular && npm link"
   },
   "dependencies": {
-    "@angular/common": "4.1.2",
-    "@angular/compiler": "4.1.2",
-    "@angular/compiler-cli": "4.1.2",
-    "@angular/core": "4.1.2",
-    "@angular/forms": "4.1.2",
-    "@angular/http": "4.1.2",
-    "@angular/platform-browser": "4.1.2",
-    "@angular/platform-browser-dynamic": "4.1.2",
+    "@angular/common": "~4.1.0",
+    "@angular/compiler": "~4.1.0",
+    "@angular/compiler-cli": "~4.1.0",
+    "@angular/core": "~4.1.0",
+    "@angular/forms": "~4.1.0",
+    "@angular/http": "~4.1.0",
+    "@angular/platform-browser": "~4.1.0",
+    "@angular/platform-browser-dynamic": "~4.1.0",
     "ionicons": "~3.0.0",
-    "rxjs": "5.1.1",
+    "rxjs": "~5.1.0",
     "zone.js": "^0.8.10"
   },
   "devDependencies": {


### PR DESCRIPTION
#### Short description of what this resolves:
Allow minor dependencies updates of Angular 4 and rxjs.

#### Changes proposed in this pull request:

- Allow Angular minor updates. Ex: Angular 4.1.0 allows update to the versions 4.1.2, 4.1.3, 4.1.?? and not 4.2.??
- The some for rxjs library.

**Ionic Version**: 1.x / 2.x / 3.x
Ionic 3.3

**Fixes**: #
Avoid manual updates in others projects.
