### PR TITLE
Typo: Inside button in Nav component sample code

### DIFF
--- a/core/src/components/nav/test/preview/index.html
+++ b/core/src/components/nav/test/preview/index.html
@@ -40,7 +40,7 @@
             <h1>Page Two</h1>
             <div>
               <ion-nav-push component="page-three">
-                <ion-button class="next">Go to Page Two</ion-button>
+                <ion-button class="next">Go to Page Three</ion-button>
               </ion-nav-push>
             </div>
           </ion-content>


### PR DESCRIPTION
Changed text inside button.
Wrong text: "Go to Page Two"
Correct text "Go to Page Three"

#### Short description of what this resolves:
Typo inside Nav component sample code

#### Changes proposed in this pull request:

- Correct button text from "Go to Page Two" to "Go to Page Three"

**Ionic Version**:  4.x

**Fixes**: #
