### PR TITLE
docs(slides): fix variable name in animation examples

### DIFF
--- a/core/src/components/slides/readme.md
+++ b/core/src/components/slides/readme.md
@@ -23,7 +23,7 @@ By default, Ionic slides use the built-in `slide` animation effect. Custom anima
 #### Coverflow
 
 ```typescript
-const slidesOpts = {
+const slideOpts = {
   slidesPerView: 3,
   coverflowEffect: {
     rotate: 50,
@@ -116,7 +116,7 @@ const slidesOpts = {
 #### Cube
 
 ```typescript
-const slidesOpts = {
+const slideOpts = {
   grabCursor: true,
   cubeEffect: {
     shadow: true,
@@ -276,7 +276,7 @@ const slidesOpts = {
 #### Fade
 
 ```typescript
-const slidesOpts = {
+const slideOpts = {
   on: {
     beforeInit() {
       const swiper = this;


### PR DESCRIPTION
Some variables used `slidesOpts` others used `slideOpts`. Changed all vars to `slideOpts` for consistency.