### PR TITLE
fix(label): use translateY so input caret shows up due to webkit issue

### DIFF
--- a/core/src/components/label/label.md.scss
+++ b/core/src/components/label/label.md.scss
@@ -13,15 +13,19 @@
 // Material Design Stacked & Floating Labels
 // --------------------------------------------------
 
+/**
+ * When translating the label, we need to use translateY
+ * instead of translate3d due to a WebKit bug: https://bugs.webkit.org/show_bug.cgi?id=215731
+ */
 :host(.label-stacked) {
   @include transform-origin(start, top);
-  @include transform(translate3d(0, 50%, 0), scale(.75));
+  @include transform(translateY(50%), scale(.75));
 
   transition: color 150ms $label-md-transition-timing-function;
 }
 
 :host(.label-floating) {
-  @include transform(translate3d(0, 96%, 0));
+  @include transform(translateY(96%));
   @include transform-origin(start, top);
 
   transition:
@@ -41,7 +45,7 @@
 :host-context(.item-has-focus).label-floating,
 :host-context(.item-has-placeholder).label-floating,
 :host-context(.item-has-value).label-floating {
-  @include transform(translate3d(0, 50%, 0), scale(.75));
+  @include transform(translateY(50%), scale(.75));
 }
 
 :host-context(.item-has-focus).label-stacked,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: resolves https://github.com/ionic-team/ionic-framework/issues/21943


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Uses translateY instead of translate3d in MD mode

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
