### PR TITLE
fix(react): fix to regression in overlay hooks dismiss method

### DIFF
--- a/packages/react/src/hooks/useController.ts
+++ b/packages/react/src/hooks/useController.ts
@@ -50,13 +50,10 @@ export function useController<OptionsType, OverlayType extends OverlayBase>(
     [controller]
   );
 
-  const dismiss = useCallback(
-    () => async () => {
-      overlayRef.current && (await overlayRef.current.dismiss());
-      overlayRef.current = undefined;
-    },
-    []
-  );
+  const dismiss = useCallback(async () => {
+    overlayRef.current && (await overlayRef.current.dismiss());
+    overlayRef.current = undefined;
+  }, []);
 
   return {
     present,


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Regression in 5.8.2 made it so the dismiss functions from the overlay hooks didn't dismiss the overlay.

Issue Number: #24030


## What is the new behavior?
 Fixed the `useCallback` hook used to memoize the dismiss function so it can be properly called.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->
