### PR TITLE
fix(label): only apply error appearance when control is touched

### DIFF
--- a/core/src/components/label/label.md.scss
+++ b/core/src/components/label/label.md.scss
@@ -137,8 +137,8 @@
   color: #{current-color(base)};
 }
 
-:host-context(.ion-invalid).label-stacked:not(.ion-color),
-:host-context(.ion-invalid).label-floating:not(.ion-color) {
+:host-context(.ion-invalid.ion-touched).label-stacked:not(.ion-color),
+:host-context(.ion-invalid.ion-touched).label-floating:not(.ion-color) {
   color: var(--highlight-color-invalid);
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently the Material design appearance of an invalid `ion-label` in an `ion-item`, is applying the error appearance; even though the control has not been interacted with.

Issue Number: #24049


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Fixes the change introduced within this [PR](https://github.com/ionic-team/ionic-framework/pull/23354).

- Aligns v6 label appearance rules to match 5.8.*
- Only applies the invalid error state when the control is touched/interacted with.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Display state of item when `ion-invalid` is initially set.

|Before|After|
|----|----|
|<img width="432" alt="Screen Shot 2021-10-13 at 11 23 22 PM" src="https://user-images.githubusercontent.com/13732623/137245743-fc66a82c-125f-4353-b872-c389d8749f40.png"> |<img width="440" alt="Screen Shot 2021-10-13 at 11 23 00 PM" src="https://user-images.githubusercontent.com/13732623/137245744-174afb61-ba9d-4596-a092-eba71e6056b9.png">|

I'm unsure of the implications with React/Vue. As far as I know, they don't have a form integration coupled with Ionic. This change is technically only necessary for Angular implementations, unless React/Vue are manually managing `ion-touched` on the `ion-item`. 

I could see it being advantageous to leave the web component alone and approach fixing this issue from the framework side, so the value accessor would instead apply `ion-invalid` when the control is invalid and dirty. Let me know if that would be a better fit to align with React/Vue as well.

