### PR TITLE
fix(datetime): clear button is now rendered even if showDefaultButtons is false

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -980,8 +980,9 @@ export class Datetime implements ComponentInterface {
   }
 
   private renderFooter() {
+    const { showDefaultButtons, showClearButton } = this;
     const hasSlottedButtons = this.el.querySelector('[slot="buttons"]') !== null;
-    if (!hasSlottedButtons && !this.showDefaultButtons) { return; }
+    if (!hasSlottedButtons && !showDefaultButtons && !showClearButton) { return; }
 
     const clearButtonClick = () => {
       this.reset();
@@ -1004,10 +1005,10 @@ export class Datetime implements ComponentInterface {
           }}>
             <slot name="buttons">
               <ion-buttons>
-                <ion-button color={this.color} onClick={() => this.cancel(true)}>{this.cancelText}</ion-button>
+                {showDefaultButtons && <ion-button id="cancel-button" color={this.color} onClick={() => this.cancel(true)}>{this.cancelText}</ion-button>}
                 <div>
-                  {this.showClearButton && <ion-button color={this.color} onClick={() => clearButtonClick()}>{this.clearText}</ion-button>}
-                  <ion-button color={this.color} onClick={() => this.confirm(true)}>{this.doneText}</ion-button>
+                  {showClearButton && <ion-button id="clear-button" color={this.color} onClick={() => clearButtonClick()}>{this.clearText}</ion-button>}
+                  {showDefaultButtons && <ion-button id="confirm-button" color={this.color} onClick={() => this.confirm(true)}>{this.doneText}</ion-button>}
                 </div>
               </ion-buttons>
             </slot>

--- a/core/src/components/datetime/test/basic/e2e.ts
+++ b/core/src/components/datetime/test/basic/e2e.ts
@@ -1,0 +1,87 @@
+import { newE2EPage } from '@stencil/core/testing';
+import { Datetime } from '../../datetime';
+
+describe('Footer', () => {
+  test('should render default buttons', async () => {
+    const page = await newE2EPage({
+      components: [Datetime],
+      html: '<ion-datetime show-default-buttons="true"></ion-datetime>'
+    });
+
+    const cancelButton = await page.find('ion-datetime >>> #cancel-button');
+    expect(cancelButton).toEqualText('Cancel');
+
+    const confirmButton = await page.find('ion-datetime >>> #confirm-button');
+    expect(confirmButton).toEqualText('Done');
+
+    expect(await page.compareScreenshot()).toMatchScreenshot();
+  });
+
+  test('should render clear button', async () => {
+    const page = await newE2EPage({
+      components: [Datetime],
+      html: '<ion-datetime show-clear-button="true"></ion-datetime>'
+    });
+
+    const clearButton = await page.find('ion-datetime >>> #clear-button');
+    expect(clearButton).toEqualText('Clear');
+
+    expect(await page.compareScreenshot()).toMatchScreenshot();
+  });
+
+  test('should render clear and default buttons', async () => {
+    const page = await newE2EPage({
+      components: [Datetime],
+      html: '<ion-datetime show-default-buttons="true" show-clear-button="true"></ion-datetime>'
+    });
+
+    const cancelButton = await page.find('ion-datetime >>> #cancel-button');
+    expect(cancelButton).toEqualText('Cancel');
+
+    const confirmButton = await page.find('ion-datetime >>> #confirm-button');
+    expect(confirmButton).toEqualText('Done');
+
+    const clearButton = await page.find('ion-datetime >>> #clear-button');
+    expect(clearButton).toEqualText('Clear');
+
+    expect(await page.compareScreenshot()).toMatchScreenshot();
+  });
+
+  test('should render custom buttons', async () => {
+    const page = await newE2EPage({
+      components: [Datetime],
+      html: `
+        <ion-datetime show-default-buttons="true" show-clear-button="true">
+          <ion-buttons slot="buttons">
+            <ion-button id="custom-button">Hello!</ion-button>
+          </ion-buttons>
+        </ion-datetime>
+      `
+    });
+
+    const customButton = await page.find('ion-datetime #custom-button');
+    expect(customButton).not.toBeNull();
+
+    expect(await page.compareScreenshot()).toMatchScreenshot();
+  });
+
+  test('should render custom buttons', async () => {
+    const page = await newE2EPage({
+      components: [Datetime],
+      html: `
+        <ion-datetime show-default-buttons="true" show-clear-button="true">
+          <ion-buttons slot="buttons">
+            <ion-button id="custom-button">Hello!</ion-button>
+          </ion-buttons>
+        </ion-datetime>
+      `
+    });
+
+    const customButton = await page.find('ion-datetime #custom-button');
+    expect(customButton).not.toBeNull();
+
+    expect(await page.compareScreenshot()).toMatchScreenshot();
+  });
+});
+
+


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When testing datetime I noticed that the usage example for showClearButton was not working. This is because the footer buttons were only rendered if `showDefaultButtons` is true. Given that `showClearButton` is not a default button, I am considering this behavior a bug.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `showClearButton` now renders a clear button even if `showDefaultButtons` is `false`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
