### PR TITLE
fix(item): account for rounded borders on highlight

### DIFF
--- a/core/src/components/item/item.scss
+++ b/core/src/components/item/item.scss
@@ -357,6 +357,17 @@ button, a {
   position: absolute;
 
   background: var(--highlight-background);
+}
+
+.item-highlight-wrapper {
+  @include border-radius(var(--border-radius));
+  @include position(0, 0, 0, 0);
+
+  pointer-events: none;
+
+  position: absolute;
+
+  overflow: hidden;
 
   z-index: 1;
 }
@@ -367,6 +378,8 @@ button, a {
 
 .item-inner-highlight {
   height: var(--inset-highlight-height);
+
+  z-index: 1;
 }
 
 

--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -311,7 +311,9 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
             </div>
             {canActivate && mode === 'md' && <ion-ripple-effect></ion-ripple-effect>}
           </TagType>
-          <div class="item-highlight"></div>
+          <div class="item-highlight-wrapper">
+            <div class="item-highlight"></div>
+          </div>
       </Host>
     );
   }

--- a/core/src/components/item/test/inputs/e2e.ts
+++ b/core/src/components/item/test/inputs/e2e.ts
@@ -9,7 +9,7 @@ test('item: inputs', async () => {
   await page.click('#submit');
   await checkFormResult(
     page,
-    '{"date":"","select":"n64","toggle":"","input":"","input2":"","checkbox":"","range":"10"}'
+    '{"date":"","select":"n64","toggle":"","input":"","input2":"","input3":"","checkbox":"","range":"10"}'
   );
   await page.waitForTimeout(100);
 
@@ -42,7 +42,7 @@ test('item: inputs', async () => {
   await page.click('#submit');
   await checkFormResult(
     page,
-    '{"date":"2016-12-09","select":"nes","toggle":"on","input":"Some text","input2":"Some text","checkbox":"on","range":"20"}'
+    '{"date":"2016-12-09","select":"nes","toggle":"on","input":"Some text","input2":"Some text","input3":"Some text","checkbox":"on","range":"20"}'
   );
   await page.waitForTimeout(100);
 

--- a/core/src/components/item/test/inputs/index.html
+++ b/core/src/components/item/test/inputs/index.html
@@ -64,6 +64,11 @@
             <ion-input name="input2" id="placeholder" placeholder="Placeholder"></ion-input>
           </ion-item>
 
+          <ion-item class="rounded">
+            <ion-label>Input (rounded)</ion-label>
+            <ion-input name="input3" id="rounded"></ion-input>
+          </ion-item>
+
           <ion-item>
             <ion-label>Checkbox</ion-label>
             <ion-checkbox name="checkbox" id="checkbox" slot="start"></ion-checkbox>
@@ -192,8 +197,17 @@
     </ion-content>
   </ion-app>
 
+  <style>
+  .rounded{
+    --border-width: 1px;
+    --border-style: solid;
+    --border-color: #CED8DC;
+    --border-radius: 20px;
+  }
+  </style>
+
   <script>
-    var ids = ['item', 'datetime', 'select', 'toggle', 'text', 'placeholder', 'checkbox', 'toggle', 'range'];
+    var ids = ['item', 'datetime', 'select', 'toggle', 'text', 'placeholder', 'checkbox', 'toggle', 'range', 'rounded'];
     var isDisabled = false;
 
     const clickableItem = document.querySelector('#clickableItem')
@@ -233,8 +247,8 @@
     }
 
     function setSomeValue() {
-      const {datetime, select, toggle, text, placeholder, checkbox, range} = getInputs();
-      text.value = placeholder.value = 'Some text';
+      const {datetime, select, toggle, text, placeholder, checkbox, range, rounded} = getInputs();
+      text.value = placeholder.value = rounded.value = 'Some text';
       toggle.checked = checkbox.checked = true;
       datetime.value = '2016-12-09';
       range.value = 20;


### PR DESCRIPTION
resolves issue #22816

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #22816


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added a wrapper around the highlight to apply the same border radius that is applied to the native wrapper
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Since the highlight wrapper overlays the full item, a pointer-events none has been applied. to keep it from interfering with the contained controls.
