### PR TITLE
fix(toast): allow input focus while toast is visible

### DIFF
--- a/core/src/components/toast/toast.tsx
+++ b/core/src/components/toast/toast.tsx
@@ -140,7 +140,9 @@ export class Toast implements ComponentInterface, OverlayInterface {
   @Event({ eventName: 'ionToastDidDismiss' }) didDismiss!: EventEmitter<OverlayEventDetail>;
 
   connectedCallback() {
-    prepareOverlay(this.el);
+    prepareOverlay(this.el, {
+      trapKeyboardFocus: false
+    });
   }
 
   /**

--- a/core/src/utils/overlays.ts
+++ b/core/src/utils/overlays.ts
@@ -47,10 +47,16 @@ export const pickerController = /*@__PURE__*/createController<PickerOptions, HTM
 export const popoverController = /*@__PURE__*/createController<PopoverOptions, HTMLIonPopoverElement>('ion-popover', Popover, [{ tagName: 'ion-backdrop', customElement: Backdrop }]);
 export const toastController = /*@__PURE__*/createController<ToastOptions, HTMLIonToastElement>('ion-toast', Toast, [{ tagName: 'ion-ripple-effect', customElement: RippleEffect }]);
 
-export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T) => {
+export interface OverlayListenerOptions {
+  trapKeyboardFocus: boolean;
+}
+
+export const prepareOverlay = <T extends HTMLIonOverlayElement>(el: T, options: OverlayListenerOptions = {
+  trapKeyboardFocus: true
+}) => {
   /* tslint:disable-next-line */
   if (typeof document !== 'undefined') {
-    connectListeners(document);
+    connectListeners(document, options);
   }
   const overlayIndex = lastId++;
   el.overlayIndex = overlayIndex;
@@ -161,8 +167,7 @@ const trapKeyboardFocus = (ev: Event, doc: Document) => {
    * We need to add a listener to the shadow root
    * itself to ensure the focus trap works.
    */
-  if (!lastOverlay || !target
-  ) { return; }
+  if (!lastOverlay || !target) { return; }
 
   const trapScopedFocus = () => {
     /**
@@ -286,10 +291,12 @@ const trapKeyboardFocus = (ev: Event, doc: Document) => {
   }
 };
 
-export const connectListeners = (doc: Document) => {
+const connectListeners = (doc: Document, options: OverlayListenerOptions) => {
   if (lastId === 0) {
     lastId = 1;
-    doc.addEventListener('focus', ev => trapKeyboardFocus(ev, doc), true);
+    if (options.trapKeyboardFocus) {
+      doc.addEventListener('focus', ev => trapKeyboardFocus(ev, doc), true);
+    }
 
     // handle back-button click
     doc.addEventListener('ionBackButton', ev => {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Keyboard focus is trapped when the toast overlay is active. This prevents focusing form controls on the view. 

Issue Number: #24571


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Keyboard focus is not trapped for overlays presented for `IonToast`. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
