### PR TITLE
test(datetime): event for calendar month text change

### DIFF
--- a/core/src/components/datetime/test/sub-pixel-width/e2e.ts
+++ b/core/src/components/datetime/test/sub-pixel-width/e2e.ts
@@ -8,18 +8,19 @@ describe('datetime: sub-pixel width', () => {
     });
 
     const openModalBtn = await page.find('#open-modal');
+    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const modal = await page.find('ion-modal');
 
     await openModalBtn.click();
 
-    const modal = await page.find('ion-modal');
     await modal.waitForVisible();
-    await page.waitForTimeout(250);
+    await ionModalDidPresent.next();
 
     const buttons = await page.findAll('ion-datetime >>> .calendar-next-prev ion-button')
 
     await buttons[1].click();
 
-    await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+    await page.waitForEvent('datetimeMonthDidChange');
 
     const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 
@@ -32,18 +33,19 @@ describe('datetime: sub-pixel width', () => {
     });
 
     const openModalBtn = await page.find('#open-modal');
+    const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+    const modal = await page.find('ion-modal');
 
     await openModalBtn.click();
 
-    const modal = await page.find('ion-modal');
     await modal.waitForVisible();
-    await page.waitForTimeout(250);
+    await ionModalDidPresent.next();
 
     const buttons = await page.findAll('ion-datetime >>> .calendar-next-prev ion-button')
 
     await buttons[0].click();
 
-    await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+    await page.waitForEvent('datetimeMonthDidChange');
 
     const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 

--- a/core/src/components/datetime/test/sub-pixel-width/index.html
+++ b/core/src/components/datetime/test/sub-pixel-width/index.html
@@ -43,21 +43,11 @@
     </ion-content>
   </ion-app>
 
-  <script>
-    const openModal = document.getElementById('open-modal');
+  <script type="module">
+    import { InitMonthDidChangeEvent } from '../test/utils/month-did-change-event.js';
 
-    const observer = new MutationObserver(mutationRecords => {
-      if (mutationRecords[0].type === 'characterData') {
-        document.dispatchEvent(new CustomEvent('datetimeCalendarMonthSpecTestEvent'));
-      }
-    });
-
-    openModal.addEventListener('click', () => {
-      observer.observe(document.querySelector('ion-datetime').shadowRoot.querySelector('.calendar-month-year'), {
-        childList: true,
-        characterData: true,
-        subtree: true
-      });
+    document.getElementById('open-modal').addEventListener('click', () => {
+      InitMonthDidChangeEvent();
     });
   </script>
 

--- a/core/src/components/datetime/test/utils/month-did-change-event.js
+++ b/core/src/components/datetime/test/utils/month-did-change-event.js
@@ -1,0 +1,19 @@
+
+/**
+ * Initializes a mutation observer to detect when the calendar month
+ * text is updated as a result of a month change in `ion-datetime`.
+ *
+ * @param {*} datetimeSelector The element selector for the `ion-datetime` component.
+ */
+export function InitMonthDidChangeEvent(datetimeSelector = 'ion-datetime') {
+  const observer = new MutationObserver(mutationRecords => {
+    if (mutationRecords[0].type === 'characterData') {
+      document.dispatchEvent(new CustomEvent('datetimeMonthDidChange'));
+    }
+  });
+
+  observer.observe(document.querySelector(datetimeSelector).shadowRoot.querySelector('.calendar-month-year'), {
+    characterData: true,
+    subtree: true
+  });
+}

--- a/core/src/components/datetime/test/zoom/e2e.ts
+++ b/core/src/components/datetime/test/zoom/e2e.ts
@@ -38,7 +38,7 @@ describe('datetime: zoom interactivity', () => {
 
       await buttons[1].click();
 
-      await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+      await page.waitForEvent('datetimeMonthDidChange');
 
       const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 
@@ -62,7 +62,7 @@ describe('datetime: zoom interactivity', () => {
 
       await buttons[0].click();
 
-      await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+      await page.waitForEvent('datetimeMonthDidChange');
 
       const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 
@@ -89,18 +89,19 @@ describe('datetime: zoom interactivity', () => {
       });
 
       const openModalBtn = await page.find('#open-modal');
+      const modal = await page.find('ion-modal');
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
 
       await openModalBtn.click();
 
-      const modal = await page.find('ion-modal');
       await modal.waitForVisible();
-      await page.waitForTimeout(250);
+      await ionModalDidPresent.next();
 
       const buttons = await page.findAll('ion-datetime >>> .calendar-next-prev ion-button')
 
       await buttons[1].click();
 
-      await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+      await page.waitForEvent('datetimeMonthDidChange');
 
       const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 
@@ -113,18 +114,19 @@ describe('datetime: zoom interactivity', () => {
       });
 
       const openModalBtn = await page.find('#open-modal');
+      const modal = await page.find('ion-modal');
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
 
       await openModalBtn.click();
 
-      const modal = await page.find('ion-modal');
       await modal.waitForVisible();
-      await page.waitForTimeout(250);
+      await ionModalDidPresent.next();
 
       const buttons = await page.findAll('ion-datetime >>> .calendar-next-prev ion-button')
 
       await buttons[0].click();
 
-      await page.waitForEvent('datetimeCalendarMonthSpecTestEvent');
+      await page.waitForEvent('datetimeMonthDidChange');
 
       const monthYear = await page.find('ion-datetime >>> .calendar-month-year');
 

--- a/core/src/components/datetime/test/zoom/index.html
+++ b/core/src/components/datetime/test/zoom/index.html
@@ -38,21 +38,11 @@
     </ion-content>
   </ion-app>
 
-  <script>
-    const openModal = document.getElementById('open-modal');
+  <script type="module">
+    import { InitMonthDidChangeEvent } from '../test/utils/month-did-change-event.js';
 
-    const observer = new MutationObserver(mutationRecords => {
-      if (mutationRecords[0].type === 'characterData') {
-        document.dispatchEvent(new CustomEvent('datetimeCalendarMonthSpecTestEvent'));
-      }
-    });
-
-    openModal.addEventListener('click', () => {
-      observer.observe(document.querySelector('ion-datetime').shadowRoot.querySelector('.calendar-month-year'), {
-        childList: true,
-        characterData: true,
-        subtree: true
-      });
+    document.getElementById('open-modal').addEventListener('click', () => {
+      InitMonthDidChangeEvent();
     });
   </script>
 </body>


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [ ] Build (`npm run build`) was run locally and any changes were pushed
- [ ] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [x] Other (please describe): Flaky e2e tests


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The calendar month text updating can take longer than the hard set 350ms timeout in the e2e tests.


<!-- Issues are required for both bug fixes and features. -->
Issue URL: 


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Using a mutation observer, we can dispatch a custom event that the test can listen for when the text is actually modified.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
