### PR TITLE
test(picker-internal): fix incorrect usage of test.skip

### DIFF
--- a/core/src/components/picker-internal/test/basic/picker-internal.e2e.ts
+++ b/core/src/components/picker-internal/test/basic/picker-internal.e2e.ts
@@ -14,7 +14,7 @@ test.describe('picker-internal', () => {
 
   test.describe('within overlay:', () => {
     // TODO (FW-1397): Remove this test.skip when the issue is fixed.
-    test.skip('Flaky test', 'Mobile Safari and Chrome on Linux renders the selected option incorrectly');
+    test.skip(true, 'Mobile Safari and Chrome on Linux renders the selected option incorrectly');
 
     test('popover: should not have visual regression', async ({ page }) => {
       await page.goto(`/src/components/picker-internal/test/basic`);


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Build (`npm run build`) was run locally and any changes were pushed
- [x] Lint (`npm run lint`) has passed locally and any fixes were made for failures


## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The `basic` test for `picker-internal` uses a `test.skip` call with improper parameter usage:

![image](https://user-images.githubusercontent.com/90629384/167922060-24f8cb73-63bd-4f5a-b688-84a40f461857.png)

<!-- Issues are required for both bug fixes and features. -->
Issue URL: N/A


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

First parameter changed to a boolean to pass the type check. See: https://playwright.dev/docs/api/class-test#test-skip-3

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
