### PR TITLE
fix(radio): takes up full height in item

### DIFF
--- a/core/src/components/radio/radio.scss
+++ b/core/src/components/radio/radio.scss
@@ -72,6 +72,7 @@ input {
 
 :host(.in-item:not(.legacy-radio)) {
   width: 100%;
+  height: 100%;
 }
 
 :host(.in-item[slot="start"]:not(.legacy-radio)),


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help: https://ionicframework.com/docs/building/contributing -->

<!-- Some docs updates need to be made in the `ionic-docs` repo, in a separate PR. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#modifying-documentation for details. -->

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. --> 

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->


<!-- Issues are required for both bug fixes and features. -->
Issue URL: resolves https://github.com/ionic-team/ionic-framework/issues/27159


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Radio elements take up the full height when used inside of an item. This aligns with what checkbox and toggle do:

Checkbox: https://github.com/ionic-team/ionic-framework/blob/cb8f07c5530ffc222580a3e3bae8dc85f62c73e5/core/src/components/checkbox/checkbox.scss#L42
Toggle: https://github.com/ionic-team/ionic-framework/blob/cb8f07c5530ffc222580a3e3bae8dc85f62c73e5/core/src/components/toggle/toggle.scss#L43

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `7.0.2-dev.11681223603.14da7831`