### PR TITLE
fix(angular RouterLinkDelegateDirective): Make routerLink respect target and keyboard modifiers

### DIFF
--- a/packages/angular/common/src/directives/navigation/router-link-delegate.ts
+++ b/packages/angular/common/src/directives/navigation/router-link-delegate.ts
@@ -49,6 +49,29 @@ export class RouterLinkDelegateDirective implements OnInit, OnChanges {
    */
   @HostListener('click', ['$event'])
   onClick(ev: UIEvent): void {
+    /**
+     * Using a target different from _self will
+     * open another browser tab.
+     * Therefore, use default
+     * behaviour of this event.
+     */
+    if (this.elementRef.nativeElement.target === undefined || this.elementRef.nativeElement.target !== '_self') {
+      return;
+    }
+
+    /**
+     * Using a keyboard modifier will
+     * open another browser tab.
+     * Therefore, use default
+     * behaviour of this event.
+     */
+    if (
+      (ev instanceof MouseEvent || ev instanceof TouchEvent)
+      && (ev.altKey || ev.ctrlKey || ev.metaKey || ev.shiftKey)
+    ) {
+      return;
+    }
+
     this.navCtrl.setDirection(this.routerDirection, undefined, undefined, this.routerAnimation);
 
     /**


### PR DESCRIPTION
Issue number: resolves #26394

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
This fixes using routerLink in combination with a target different than _self. It also fixes a bug where CTRL + click or shift + click does not work like expected in combination with routerLink in Angular.

## What is the new behavior?
When using a target other than _self and keyboard modifiers we are now stopping execution of navigating by routeDirection. This is not needed because the app will reload either way. 

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/.github/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
