### PR TITLE
bugfix locationHistory incorrect when history pop

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -307,7 +307,7 @@ export const createIonRouter = (
     }
 
     const leavingUrl =
-      leavingLocationInfo.pathname + leavingLocationInfo.search;
+      leavingLocationInfo.pathname + leavingLocationInfo.search ? '+' : '' + leavingLocationInfo.search;
     if (leavingUrl !== location.fullPath) {
       if (!incomingRouteParams) {
         if (action === "replace") {
@@ -473,6 +473,8 @@ export const createIonRouter = (
           delta === undefined
         ) {
           locationHistory.clearHistory(routeInfo);
+          locationHistory.add(routeInfo);
+        }else{
           locationHistory.add(routeInfo);
         }
       } else {


### PR DESCRIPTION
Issue number: resolves #29721

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
1. The routing stack of locationHistory is missing in certain situations, for example, when entering the application from a non-home page, the routing stack is incomplete. At the same time, when the iPhone gesture is used to back off, the routing stack cannot be completed.
2. #29721 Looks like the same problem.https://stackblitz.com/edit/vitejs-vite-vphseq?file=README.md
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- After fixing this bug: https://stackblitz.com/edit/vitejs-vite-z86rpn?file=README.md
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  3. Update the BREAKING.md file with the breaking change.
  4. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information
no
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
