### PR TITLE
chore(git): improve Ionitron to stop closing issues that have the 'needs: investigation' label

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -132,8 +132,6 @@ noReproduction:
   maxIssuesPerRun: 100
   label: "ionitron: needs reproduction"
   responseLabel: triage
-  exemptLabels:
-    - "needs: investigation"
   exemptProjects: true
   exemptMilestones: true
   message: >


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- Currently, `Ionitron` is closing issues when they have the `needs: investigation` label.
- We might want to use the duplicate ticket as our source of truth since a community member has made a [suggestion](https://github.com/ionic-team/ionic-framework/issues/30380#issuecomment-2848626887) that could fix it.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- The `ionic-issue-bot.yml` file was changed to stop closing issues that have the `needs: investigation` label
- To prevent `Ionitron` from closing issues with the `needs: investigation` label, we've added this label to the `exemptLabels` list under the `stale`, `noReply`, and `noReproduction` sections. 
- This tells the bot not to close issues with that label, even if they meet the criteria for being stale or lacking a reply/reproduction.


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
- _N.A._
