### PR TITLE
fix(input-otp): correctly handle autofill by splitting the values into all inputs

### DIFF
--- a/core/src/components/input-otp/input-otp.tsx
+++ b/core/src/components/input-otp/input-otp.tsx
@@ -774,7 +774,6 @@ export class InputOTP implements ComponentInterface {
                   type="text"
                   autoCapitalize={autocapitalize}
                   inputmode={inputmode}
-                  maxLength={1}
                   pattern={pattern}
                   disabled={disabled}
                   readOnly={readonly}

--- a/core/src/components/input-otp/test/basic/input-otp.e2e.ts
+++ b/core/src/components/input-otp/test/basic/input-otp.e2e.ts
@@ -344,7 +344,10 @@ configs({ modes: ['ios'] }).forEach(({ title, config }) => {
       const firstInput = page.locator('ion-input-otp input').first();
       await firstInput.focus();
 
-      await page.keyboard.type('أبجد123');
+      // We need to type the numbers separately because the browser
+      // does not properly handle the script text when mixed with numbers
+      await page.keyboard.type('123');
+      await page.keyboard.type('أبجد');
 
       // Because Arabic is a right-to-left script, JavaScript's handling of RTL text
       // causes the array values to be reversed while input boxes maintain LTR order.


### PR DESCRIPTION
Issue number: N/A

---------

## What is the current behavior?
When filling the Input OTP from inside of a Capacitor app or using autofill in the browser, the entire value is being inserted into the 1st input box so it is only getting the 1st character.

## What is the new behavior?
Detect when the value is longer than one in the `onInput` handler and split it up across all inputs.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Dev build: `8.5.7-dev.11748895007.1c98a49b`
