### PR TITLE
chore(renovate): group playwright npm packages and docker

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,21 +38,16 @@
       ]
     },
     {
-      matchDatasources: ["npm"],
-      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
       groupName: "playwright",
-      matchFileNames: [
-        "core/package.json"
+      matchPackageNames: [
+        "@playwright/test",
+        "@axe-core/playwright",
+        "mcr.microsoft.com/playwright"
       ],
-      "rangeStrategy": "bump"
-    },
-    {
-      matchDatasources: ["docker"],
-      matchPackageNames: ["mcr.microsoft.com/playwright"],
-      groupName: "playwright",
-      matchFileNames: [
-        "core/Dockerfile"
-      ],
+      matchDatasources: ["npm", "docker"],
+      matchFileNames: ["core/package.json", "core/Dockerfile"],
+      allowedVersions: "/^\\d+\\.\\d+\\.\\d+$/",
+      rangeStrategy: "bump",
       versioning: "semver"
     },
     {


### PR DESCRIPTION
Groups all of the Playwright dependencies together so we don't have the Docker one opened on its own like this: https://github.com/ionic-team/ionic-framework/pull/30472