### PR TITLE
feat(toggle): change error text color for ionic theme

### DIFF
--- a/core/src/components/toggle/toggle.ionic.scss
+++ b/core/src/components/toggle/toggle.ionic.scss
@@ -65,11 +65,11 @@
 // ----------------------------------------------------------------
 
 .toggle-bottom .error-text {
-  color: globals.$ion-semantics-danger-800;
+  color: globals.$ion-semantics-danger-900;
 }
 
 .toggle-bottom .helper-text {
-  color: globals.$ion-primitives-neutral-800;
+  color: globals.$ion-primitives-neutral-900;
 }
 
 // Toggle Native Wrapper: Focused


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Error text color was `ion-semantics-danger-800`

## What is the new behavior?
Error text color is now `ion-semantics-danger-900`, following design guidelines.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
