### PR TITLE
refactor(button): only check for undefined fill

### DIFF
--- a/core/src/components/button/button.tsx
+++ b/core/src/components/button/button.tsx
@@ -361,11 +361,7 @@ export class Button implements ComponentInterface, AnchorInterface, ButtonInterf
             target,
           };
     let fill = this.fill;
-    /**
-     * We check both undefined and null to
-     * work around https://github.com/ionic-team/stencil/issues/3586.
-     */
-    if (fill == null) {
+    if (fill === undefined) {
       fill = this.inToolbar || this.inListHeader ? 'clear' : 'solid';
     }
 


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
Button checks for undefined and null fill as a result of Stencil bug https://github.com/ionic-team/stencil/issues/3586

## What is the new behavior?
- Removes check for `null` with the release of Stencil v4.38.0
- No test needed as one exists already: https://github.com/ionic-team/ionic-framework/pull/26339/files

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
