### PR TITLE
chore(deps): update @types/node

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -30,7 +30,7 @@
         "@stencil/sass": "^3.0.9",
         "@stencil/vue-output-target": "0.10.8",
         "@types/jest": "^29.5.6",
-        "@types/node": "^14.6.0",
+        "@types/node": "^16.18.126",
         "@typescript-eslint/eslint-plugin": "^6.7.2",
         "@typescript-eslint/parser": "^6.7.2",
         "chalk": "^5.3.0",
@@ -2111,10 +2111,11 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "14.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
-      "dev": true
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.0",
@@ -12145,9 +12146,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "14.14.22",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.22.tgz",
-      "integrity": "sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==",
+      "version": "16.18.126",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.126.tgz",
+      "integrity": "sha512-OTcgaiwfGFBKacvfwuHzzn1KLxH/er8mluiy8/uM3sGXHaRe73RrSIj01jow9t4kJEW633Ov+cOexXeiApTyAw==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/core/package.json
+++ b/core/package.json
@@ -52,7 +52,7 @@
     "@stencil/sass": "^3.0.9",
     "@stencil/vue-output-target": "0.10.8",
     "@types/jest": "^29.5.6",
-    "@types/node": "^14.6.0",
+    "@types/node": "^16.18.126",
     "@typescript-eslint/eslint-plugin": "^6.7.2",
     "@typescript-eslint/parser": "^6.7.2",
     "chalk": "^5.3.0",

--- a/packages/angular/package-lock.json
+++ b/packages/angular/package-lock.json
@@ -32,7 +32,7 @@
         "@ionic/eslint-config": "^0.3.0",
         "@ionic/prettier-config": "^2.0.0",
         "@schematics/angular": "^17.0.0",
-        "@types/node": "12.12.5",
+        "@types/node": "20.19.25",
         "@typescript-eslint/eslint-plugin": "^5.0.0",
         "@typescript-eslint/parser": "^5.0.0",
         "eslint": "^8.0.0",
@@ -41,7 +41,7 @@
         "ng-packagr": "^16.0.0",
         "prettier": "^2.4.1",
         "rxjs": "~7.5.0",
-        "typescript": "~4.9.3",
+        "typescript": "~5.0.2",
         "typescript-eslint-language-service": "^5.0.0",
         "zone.js": "~0.13.0"
       },
@@ -2402,9 +2402,14 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "12.12.5",
+      "version": "20.19.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.25.tgz",
+      "integrity": "sha512-ZsJzA5thDQMSQO788d7IocwwQbI8B5OPzmqNvpf3NY/+MHDAS759Wo0gd2WQeXYt5AAAQjzcrTVC6SKCuYgoCQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/resolve": {
       "version": "1.20.2",
@@ -8719,16 +8724,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typescript-eslint-language-service": {
@@ -8755,6 +8761,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unique-filename": {
       "version": "3.0.0",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -78,7 +78,7 @@
     "@ionic/eslint-config": "^0.3.0",
     "@ionic/prettier-config": "^2.0.0",
     "@schematics/angular": "^17.0.0",
-    "@types/node": "12.12.5",
+    "@types/node": "20.19.25",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.0",
@@ -87,7 +87,7 @@
     "ng-packagr": "^16.0.0",
     "prettier": "^2.4.1",
     "rxjs": "~7.5.0",
-    "typescript": "~4.9.3",
+    "typescript": "~5.0.2",
     "typescript-eslint-language-service": "^5.0.0",
     "zone.js": "~0.13.0"
   },


### PR DESCRIPTION
Update node types for compatibility with typescript 5.8 now used in Stencil.

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- Ionic fails to build with Stencil Nightly due to typed array changes in typescript 5.7.
- Angular package fails to build with Stencil Nightly due to type errors with Mixins.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Ionic can build with Stencil Nightly.
- Angular package can build with Stencil Nightly.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
