### PR TITLE
chore(github-actions): fine tune workflow orchestrator defaults

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -11,10 +11,9 @@ on:
         description: 'Which Ionic release workflow should run?'
         required: true
         type: choice
-        default: nightly
+        default: dev
         options:
           - dev
-          - nightly
           - production
       version:
         description: 'Which version should be published? (Only for production releases)'
@@ -54,7 +53,7 @@ permissions:
 
 jobs:
   run-nightly:
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.release-type == 'nightly') }}
+    if: ${{ github.event_name == 'schedule' }}
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION

Issue number: resolves #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

-  "nightly" was the default choice and was available for manual trigger when running `release-orchestrator`

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Set "dev" as the default choice (changed from "nightly")
- Removed "nightly" from manual workflow_dispatch options (only "dev" and "production" remain)
- Simplified the `run-nightly` condition to only run on schedule (`github.event_name == 'schedule'`)


## Does this introduce a breaking change?

- [ ] Yes
- [-] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

- Manual triggers (workflow_dispatch): Only "dev" (default) and "production" are available
- Scheduled triggers: The nightly build continues to run automatically every Monday–Friday at 6:00 UTC via the schedule trigger
- Trusted Publishers compliance: Maintained — all releases still go through the single orchestrator workflow, ensuring the OIDC token is issued from the whitelisted workflow
