### PR TITLE
chore(ci): change condition for success messages

### DIFF
--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -229,7 +229,7 @@ jobs:
   send-success-messages:
     needs: [test-core-clean-build, test-core-lint, test-core-spec, verify-screenshots, verify-test-vue-e2e, verify-test-angular-e2e, verify-test-react-router-e2e, verify-test-react-e2e]
     runs-on: ubuntu-latest
-    if: ${{ !cancelled() && contains(needs.*.result, 'success') }}
+    if: ${{ !cancelled() && !contains(needs.*.result, 'failure') }}
     steps:
       - name: Notify success on Discord
         run: |


### PR DESCRIPTION
For Stencil Nightly alert messages, instead of checking if anything succeeded, check if nothing failed.

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Both a success and failure message was sent when some jobs passed and some failed.
## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Success message should only be sent if nothing failed.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
