### PR TITLE
fix(item, tab-button): activation behaviour for Ionic theme

### DIFF
--- a/core/src/components/item/item.tsx
+++ b/core/src/components/item/item.tsx
@@ -250,7 +250,7 @@ export class Item implements ComponentInterface, AnchorInterface, ButtonInterfac
     const mode = getIonMode(this);
     const shouldActivate = this.isClickable() || this.hasCover();
     if (theme !== 'ionic') {
-        return shouldActivate;
+      return shouldActivate;
     }
     return mode === 'md' && shouldActivate;
   }

--- a/core/src/components/tab-button/tab-button.tsx
+++ b/core/src/components/tab-button/tab-button.tsx
@@ -167,10 +167,10 @@ export class TabButton implements ComponentInterface, AnchorInterface {
     const theme = getIonTheme(this);
     const mode = getIonMode(this);
     if (theme !== 'ionic') {
-        return true;
+      return true;
     }
     return mode === 'md';
-}
+  }
 
   render() {
     const { disabled, hasIcon, hasLabel, href, rel, target, layout, selected, tab, inheritedAttributes } = this;


### PR DESCRIPTION
Issue number: resolves #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Currently, in the`ion-item` and `tab-button` components under the Ionic theme, activation behaviors (such as ripple effects and clickability) are applied to both `md` and `ios`, but they should only be applied to`md`.

## What is the new behavior?
Activation behavior is now conditional on both theme and mode. The main goal is to ensure that activation only occurs specifically for `md` mode when using the `ionic` theme.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


