### PR TITLE
chore(workflows): fix release workflow permissions

### DIFF
--- a/.github/workflows/release-orchestrator.yml
+++ b/.github/workflows/release-orchestrator.yml
@@ -71,7 +71,7 @@ jobs:
   run-production:
     if: ${{ github.event_name == 'workflow_dispatch' && inputs.release-type == 'production' }}
     permissions:
-      contents: read
+      contents: write
       id-token: write
     uses: ./.github/workflows/release.yml
     secrets: inherit


### PR DESCRIPTION
The workflow permissions update did not work due to it being nested in a workflow that only had `read` permissions.

You can see a failing run here (scroll down to annotations): [19828029833](https://github.com/ionic-team/ionic-framework/actions/runs/19828029833)

```
Invalid workflow file: .github/workflows/release-orchestrator.yml#L71
The workflow is not valid. .github/workflows/release-orchestrator.yml (Line: 71, Col: 3): Error calling workflow 'ionic-team/ionic-framework/.github/workflows/release.yml@b4e540decc484bd22eb84484a8eb94f19b1790c1'. The nested job 'finalize-release' is requesting 'contents: write', but is only allowed 'contents: read'. .github/workflows/release-orchestrator.yml (Line: 71, Col: 3): Error calling workflow 'ionic-team/ionic-framework/.github/workflows/release.yml@b4e540decc484bd22eb84484a8eb94f19b1790c1'. The nested job 'update-package-lock' is requesting 'contents: write', but is only allowed 'contents: read'.
```

This updates the parent workflow to have `write` permissions. You can see a passing run here: [19828895682](https://github.com/ionic-team/ionic-framework/actions/runs/19828895682)