### PR TITLE
test(scripts): update palette query

### DIFF
--- a/core/scripts/testing/scripts.js
+++ b/core/scripts/testing/scripts.js
@@ -67,8 +67,8 @@
   let paletteName = paletteQuery?.[1] || paletteHash?.[1] || highContrastDarkClass || darkClass || highContrastClass || 'light';
 
   if (!validPalettes.includes(paletteName)) {
+    console.warn(`Invalid palette name: '${paletteName}'. Falling back to 'light' palette.`);
     paletteName = 'light';
-    console.warn(`Invalid palette name: ${paletteName}. Falling back to 'light' palette.`);
   }
 
   if (paletteName !== 'light') {


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`high-contrast` and `high-contrast-dark` palettes were not working when requested through a URL query or hash for a test page. This was due to the `match` not accepting hyphens so it would only save `high` which is not a valid palette.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated `match` to accept hyphens
- Added an error if an invalid palette is provided
- Added a palette fallback if an invalid palette is provided
- Added a class check for high contrast and high contrast dark

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

How to test:
1. Verify that `?palette=high-contrast`, `?palette=high-contrast-dark`, `#palette=high-contrast`, and `#palette=high-contrast-dark` render correctly (I recommend using [button basic page](https://ionic-framework-git-scripts-ionic1.vercel.app/src/components/button/test/basic/))
