### PR TITLE
fix(searchbar): clear timeouts

### DIFF
--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -30,6 +30,8 @@ export class Searchbar implements ComponentInterface {
   private originalIonInput?: EventEmitter<SearchbarInputEventDetail>;
   private inputId = `ion-searchbar-${searchbarIds++}`;
   private inheritedAttributes: Attributes = {};
+  private loadTimeout?: number
+  private clearTimeout?: number
 
   /**
    * The value of the input when the textarea is focused.
@@ -277,6 +279,11 @@ export class Searchbar implements ComponentInterface {
     this.emitStyle();
   }
 
+  disconnectedCallback() {
+    clearTimeout(this.loadTimeout)
+    clearTimeout(this.clearTimeout)
+  }
+
   componentWillLoad() {
     this.inheritedAttributes = {
       ...inheritAttributes(this.el, ['lang', 'dir']),
@@ -288,7 +295,7 @@ export class Searchbar implements ComponentInterface {
     this.positionElements();
     this.debounceChanged();
 
-    setTimeout(() => {
+    this.loadTimeout = setTimeout(() => {
       this.noAnimate = false;
     }, 300);
   }
@@ -358,12 +365,13 @@ export class Searchbar implements ComponentInterface {
    * Clears the input field and triggers the control change.
    */
   private onClearInput = async (shouldFocus?: boolean) => {
+    clearTimeout(this.clearTimeout)
     this.ionClear.emit();
 
     return new Promise<void>((resolve) => {
       // setTimeout() fixes https://github.com/ionic-team/ionic-framework/issues/7527
       // wait for 4 frames
-      setTimeout(() => {
+      this.clearTimeout = setTimeout(() => {
         const value = this.getValue();
         if (value !== '') {
           this.value = '';


### PR DESCRIPTION
Issue number: resolves #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
We have flaky tests in an ionic angular project that root cause are not cleaned up timeouts.
I commented out the timeout in the searchbar componentWillLoad method. and after several runs no flaky tests at all.

My guess -> test runs faster than the 300ms it takes til the timeout runs. Everything is cleaned up, but not the ionic timeouts (i think i saw something similar in the "label" component)

## What is the new behavior?
Timeouts are cleaned on disconnect.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Testrunner is vitest + angular 20 and latest ionic version 8.x
