### PR TITLE
fix(label): clear timeout

### DIFF
--- a/core/src/components/label/label.tsx
+++ b/core/src/components/label/label.tsx
@@ -18,6 +18,7 @@ import type { Color, StyleEventDetail } from '../../interface';
 })
 export class Label implements ComponentInterface {
   private inRange = false;
+  private loadTimeout?: number
 
   @Element() el!: HTMLElement;
 
@@ -56,10 +57,14 @@ export class Label implements ComponentInterface {
 
   componentDidLoad() {
     if (this.noAnimate) {
-      setTimeout(() => {
+      this.loadTimeout = setTimeout(() => {
         this.noAnimate = false;
       }, 1000);
     }
+  }
+
+  disconnectedCallback() {
+    clearTimeout(this.loadTimeout)
   }
 
   @Watch('color')


### PR DESCRIPTION
- clean up setTimeout in disconnectedCallback
- follow up to #30849
---------

## What is the current behavior?
timeouts are not cleaned up and may lead to unexpected behavior (especially in unit tests).

## What is the new behavior?
Timeouts are cleaned on disconnect.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Testrunner is vitest + angular 20 and latest ionic version 8.x
