### PR TITLE
fix(many): clear timeouts

### DIFF
--- a/core/src/components/content/content.tsx
+++ b/core/src/components/content/content.tsx
@@ -188,6 +188,11 @@ export class Content implements ComponentInterface {
       this.tabsElement = null;
       this.tabsLoadCallback = undefined;
     }
+
+    if (this.resizeTimeout) {
+      clearTimeout(this.resizeTimeout);
+      this.resizeTimeout = null;
+    }
   }
 
   /**

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -124,6 +124,7 @@ export class Datetime implements ComponentInterface {
   private maxParts?: any;
   private todayParts!: DatetimeParts;
   private defaultParts!: DatetimeParts;
+  private loadTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private prevPresentation: string | null = null;
 
@@ -1077,6 +1078,9 @@ export class Datetime implements ComponentInterface {
       this.clearFocusVisible();
       this.clearFocusVisible = undefined;
     }
+    if (this.loadTimeout) {
+      clearTimeout(this.loadTimeout);
+    }
   }
 
   /**
@@ -1175,7 +1179,7 @@ export class Datetime implements ComponentInterface {
      *
      * We schedule this after everything has had a chance to run.
      */
-    setTimeout(() => {
+    this.loadTimeout = setTimeout(() => {
       this.ensureReadyIfVisible();
     }, 100);
 

--- a/core/src/components/fab-list/fab-list.tsx
+++ b/core/src/components/fab-list/fab-list.tsx
@@ -10,6 +10,7 @@ import { getIonMode } from '../../global/ionic-global';
 })
 export class FabList implements ComponentInterface {
   @Element() el!: HTMLIonFabElement;
+  private activateTimeouts: ReturnType<typeof setTimeout>[] = [];
 
   /**
    * If `true`, the fab list will show all fab buttons in the list.
@@ -18,12 +19,15 @@ export class FabList implements ComponentInterface {
 
   @Watch('activated')
   protected activatedChanged(activated: boolean) {
+    this.activateTimeouts.forEach(clearTimeout);
+    this.activateTimeouts = [];
+
     const fabs = Array.from(this.el.querySelectorAll('ion-fab-button'));
 
     // if showing the fabs add a timeout, else show immediately
     const timeout = activated ? 30 : 0;
     fabs.forEach((fab, i) => {
-      setTimeout(() => (fab.show = activated), i * timeout);
+      this.activateTimeouts.push(setTimeout(() => (fab.show = activated), i * timeout));
     });
   }
 
@@ -31,6 +35,11 @@ export class FabList implements ComponentInterface {
    * The side the fab list will show on relative to the main fab button.
    */
   @Prop() side: 'start' | 'end' | 'top' | 'bottom' = 'bottom';
+
+  disconnectedCallback() {
+    this.activateTimeouts.forEach(clearTimeout);
+    this.activateTimeouts = [];
+  }
 
   render() {
     const mode = getIonMode(this);

--- a/core/src/components/img/img.tsx
+++ b/core/src/components/img/img.tsx
@@ -16,6 +16,7 @@ import { getIonMode } from '../../global/ionic-global';
 export class Img implements ComponentInterface {
   private io?: IntersectionObserver;
   private inheritedAttributes: Attributes = {};
+  private loadTimeout: ReturnType<typeof setTimeout> | undefined;
 
   @Element() el!: HTMLElement;
 
@@ -56,7 +57,17 @@ export class Img implements ComponentInterface {
     this.addIO();
   }
 
+  disconnectedCallback() {
+    if (this.loadTimeout) {
+      clearTimeout(this.loadTimeout);
+    }
+  }
+
   private addIO() {
+    if (this.loadTimeout) {
+      clearTimeout(this.loadTimeout);
+      this.loadTimeout = undefined;
+    }
     if (this.src === undefined) {
       return;
     }
@@ -82,7 +93,7 @@ export class Img implements ComponentInterface {
       this.io.observe(this.el);
     } else {
       // fall back to setTimeout for Safari and IE
-      setTimeout(() => this.load(), 200);
+      this.loadTimeout = setTimeout(() => this.load(), 200);
     }
   }
 

--- a/core/src/components/label/label.tsx
+++ b/core/src/components/label/label.tsx
@@ -18,6 +18,7 @@ import type { Color, StyleEventDetail } from '../../interface';
 })
 export class Label implements ComponentInterface {
   private inRange = false;
+  private loadTimeout: ReturnType<typeof setTimeout> | undefined;
 
   @Element() el!: HTMLElement;
 
@@ -56,9 +57,15 @@ export class Label implements ComponentInterface {
 
   componentDidLoad() {
     if (this.noAnimate) {
-      setTimeout(() => {
+      this.loadTimeout = setTimeout(() => {
         this.noAnimate = false;
       }, 1000);
+    }
+  }
+
+  disconnectedCallback() {
+    if (this.loadTimeout) {
+      clearTimeout(this.loadTimeout);
     }
   }
 


### PR DESCRIPTION
Issue number: resolves #30860

## What is the current behavior?
We have flaky tests in an ionic angular project that root cause are not cleaned up timeouts.
I commented out the timeout in the searchbar componentWillLoad method. and after several runs no flaky tests at all.

My guess -> test runs faster than the 300ms it takes til the timeout runs. Everything is cleaned up, but not the ionic timeouts (i think i saw something similar in other components)

## What is the new behavior?
Timeouts are cleaned on disconnect.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Testrunner is vitest + angular 20 and latest ionic version 8.x
