### PR TITLE
fix(datetime): use ResizeObserver to reliably detect visibility changes

### DIFF
--- a/core/src/components/datetime-button/test/a11y/datetime-button.e2e.ts
+++ b/core/src/components/datetime-button/test/a11y/datetime-button.e2e.ts
@@ -21,6 +21,7 @@ configs({ directions: ['ltr'], modes: ['ios'] }).forEach(({ title, screenshot, c
       );
 
       const datetimeButton = page.locator('ion-datetime-button');
+      await page.locator('.datetime-ready').waitFor();
 
       await expect(datetimeButton).toHaveScreenshot(screenshot(`datetime-button-scale`));
     });
@@ -40,6 +41,7 @@ configs({ directions: ['ltr'], modes: ['ios'] }).forEach(({ title, screenshot, c
       );
 
       const datetimeButton = page.locator('ion-datetime-button');
+      await page.locator('.datetime-ready').waitFor();
 
       await expect(datetimeButton).toHaveScreenshot(screenshot(`datetime-button-scale-wrap`));
     });

--- a/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
+++ b/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
@@ -24,6 +24,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
       await dateButton.click();
       await ionModalDidPresent.next();
 
+      // Wait for datetime to be ready before taking screenshot
+      await page.locator('ion-datetime.datetime-ready').waitFor();
+
       await expect(page).toHaveScreenshot(screenshot(`datetime-overlay-modal`));
     });
 
@@ -43,6 +46,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
       const dateButton = page.locator('ion-datetime-button #date-button');
       await dateButton.click();
       await ionPopoverDidPresent.next();
+
+      // Wait for datetime to be ready before taking screenshot
+      await page.locator('ion-datetime.datetime-ready').waitFor();
 
       await expect(page).toHaveScreenshot(screenshot(`datetime-overlay-popover`));
     });

--- a/core/src/components/datetime/test/custom/datetime.e2e.ts
+++ b/core/src/components/datetime/test/custom/datetime.e2e.ts
@@ -52,6 +52,7 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
   test.describe(title('datetime: custom focus'), () => {
     test('should focus the selected day and then the day after', async ({ page }) => {
       await page.goto(`/src/components/datetime/test/custom`, config);
+      await page.locator('.datetime-ready').last().waitFor();
 
       const datetime = page.locator('#custom-calendar-days');
 

--- a/core/src/components/datetime/test/first-day-of-week/datetime.e2e.ts
+++ b/core/src/components/datetime/test/first-day-of-week/datetime.e2e.ts
@@ -7,6 +7,7 @@ configs().forEach(({ title, screenshot, config }) => {
       await page.goto('/src/components/datetime/test/first-day-of-week', config);
 
       const datetime = page.locator('ion-datetime');
+      await page.locator('.datetime-ready').waitFor();
       await expect(datetime).toHaveScreenshot(screenshot(`datetime-day-of-week`));
     });
   });

--- a/core/src/components/datetime/test/highlighted-dates/datetime.e2e.ts
+++ b/core/src/components/datetime/test/highlighted-dates/datetime.e2e.ts
@@ -10,6 +10,7 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
       `,
         config
       );
+      await page.locator('.datetime-ready').waitFor();
     });
 
     test('should render highlights correctly when using an array', async ({ page }) => {


### PR DESCRIPTION
Issue number: resolves #30706

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

When `ion-datetime` is rendered inside a modal or popover, it may appear invisible (opacity: 0) because the datetime-ready class is not applied. This occurs because IntersectionObserver doesn't reliably detect visibility changes in some browsers (particularly WebKit/Safari) when the datetime is inside an overlay that is presented after page load.

## What is the new behavior?

The datetime now uses multiple strategies to reliably detect visibility:
1. ResizeObserver - Detects when the element transitions between having dimensions (visible) and zero dimensions (hidden)
2. Overlay event listeners - Listens for didPresent/didDismiss events when datetime is inside a modal or popover
3. Polling fallback - Uses requestAnimationFrame-based polling for browsers where ResizeObserver doesn't fire reliably (WebKit)

The .intersection-tracker element has been removed as it's no longer needed.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Current dev build:
```
8.7.13-dev.11765560568.1a8772e8
```
