### PR TITLE
style(segment-button): add and update color to slotted children for improved styling consistency

### DIFF
--- a/core/src/components/segment-button/segment-button.ionic.scss
+++ b/core/src/components/segment-button/segment-button.ionic.scss
@@ -10,7 +10,7 @@
    */
   --background: none;
   --background-checked: var(--background);
-  --color: #{globals.$ion-primitives-neutral-1000};
+  --color: #{globals.$ion-primitives-neutral-1200};
   --color-checked: #{globals.$ion-semantics-primary-base};
   --color-disabled: #{globals.$ion-primitives-neutral-500};
   --border-width: #{globals.$ion-border-size-025};


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
- Previously in iOS, when using something different than the `ion-label` to add a text inside the `segment-button`, the default color attributed to it was blue.
<img width="357" height="103" alt="image" src="https://github.com/user-attachments/assets/2196e548-f0b7-4e7f-b093-e58c88b2a6cb" />

- In Android, the expected color is not attributed either, but it defaults to black instead of blue.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
- Now, all the slotted elements will respect the color defined by the `color` CSS variable.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
