### PR TITLE
chore(github): do not close issues as stale when they are external bugs

### DIFF
--- a/.github/ionic-issue-bot.yml
+++ b/.github/ionic-issue-bot.yml
@@ -40,7 +40,7 @@ comment:
 
 
         If the requested feature is something you would find useful for your applications, please react to the original post with 👍 (`+1`). If you would like to provide an additional use case for the feature, please post a comment.
-        
+
 
         The team will review this feedback and make a final decision. Any decision will be posted on this thread, but please note that we may ultimately decide not to pursue this feature.
 
@@ -83,6 +83,7 @@ stale:
   exemptLabels:
     - "good first issue"
     - "triage"
+    - "bug: external"
     - "type: bug"
     - "type: feature request"
     - "needs: investigation"


### PR DESCRIPTION
Ionitron keeps closing issues with `bug: external` as stale: https://github.com/ionic-team/ionic-framework/issues/27052#event-21879561018

This PRs adds `bug: external` as an exempt label when closing issues as stale.