### PR TITLE
fix(nav-controller): reset direction state when navigation is canceled

### DIFF
--- a/packages/angular/common/src/providers/nav-controller.ts
+++ b/packages/angular/common/src/providers/nav-controller.ts
@@ -1,6 +1,14 @@
 import { Location } from '@angular/common';
 import { Injectable, Optional } from '@angular/core';
-import { NavigationExtras, Router, UrlSerializer, UrlTree, NavigationStart, NavigationCancel, NavigationError } from '@angular/router';
+import {
+  NavigationExtras,
+  Router,
+  UrlSerializer,
+  UrlTree,
+  NavigationStart,
+  NavigationCancel,
+  NavigationError,
+} from '@angular/router';
 import type { AnimationBuilder, NavDirection, RouterDirection } from '@ionic/core/components';
 
 import { IonRouterOutlet } from '../directives/navigation/router-outlet';


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
When a CanDeactivate guard cancels a back navigation (like when it's initiated by ion-back-button), the NavController’s explicit direction state (back) is never consumed because consumeTransition() is not called for canceled navigations. This stale direction leaks into the next forward navigation, causing it to be incorrectly treated as a back/root navigation. 

## What is the new behavior?
The NavController now listens for NavigationCancel and NavigationError router events and resets direction, animated, and animationBuilder back to their defaults. This ensures stale state from a canceled navigation does not affect subsequent navigations. The reset puts the NavController into 'auto' mode, which correctly uses guessDirection for the next navigation.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Current dev build:
```
8.7.18-dev.11771020096.1ca03a6d
```