### PR TITLE
Fix #22358: bug: ios native refresher overlaps content when hiding

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -103,8 +103,14 @@
    * this optimization.
    *
    * See: https://bugs.webkit.org/show_bug.cgi?id=216701
+   *
+   * The z-index must also be greater than the z-index of
+   * ion-refresher.refresher-native (z-index: 1) so that the
+   * scroll content appears above the native iOS refresher spinner
+   * when the user scrolls back up after a pull-to-refresh.
+   * See: https://github.com/ionic-team/ionic-framework/issues/22358
    */
-  z-index: 0;
+  z-index: 2;
 
   will-change: scroll-position;
 }


### PR DESCRIPTION
Fixes #22358

## Summary
This PR fixes: bug: ios native refresher overlaps content when hiding

## Changes
```
core/src/components/content/content.scss | 8 +++++++-
 1 file changed, 7 insertions(+), 1 deletion(-)
```

## Testing
Please review the changes carefully. The fix was verified against the existing test suite.

---
*This PR was created with the assistance of Claude Sonnet 4.6 by Anthropic | effort: low. Happy to make any adjustments!*

By submitting this pull request, I confirm that my contribution is made under the terms of the project's license (contributor license agreement).