### PR TITLE
feat(toolbar): added separated variables for size of slots in Toolbar

### DIFF
--- a/core/src/components/toolbar/toolbar.ionic.scss
+++ b/core/src/components/toolbar/toolbar.ionic.scss
@@ -13,6 +13,8 @@
   --padding-start: #{globals.$ion-space-200};
   --padding-end: #{globals.$ion-space-200};
   --min-height: #{globals.$ion-scale-1400};
+  --start-size: var(--start-end-size, 0);
+  --end-size: var(--start-end-size, 0);
 }
 
 .toolbar-container {
@@ -87,7 +89,7 @@
 :host(.show-end) slot[name="end"] {
   display: flex;
 
-  flex: 0 0 var(--start-end-size, 0);
+  flex: 0 0 var(--end-size, 0);
   justify-content: flex-end;
 
   text-align: end;
@@ -97,7 +99,7 @@
 :host(.show-start) slot[name="start"] {
   display: flex;
 
-  flex: 0 0 var(--start-end-size, 0);
+  flex: 0 0 var(--start-size, 0);
 }
 
 :host(.has-primary-content) slot[name="primary"],


### PR DESCRIPTION
Issue number: resolves internal

---------

## What is the current behavior?
For the Ionic theme, the slots on each side of the toolbar have the same size given by the same variable

## What is the new behavior?
Each slot has the size given by a specific variable for that slot that is initialised with the value of the previous variable

## Does this introduce a breaking change?

- [ ] Yes
- [x] No



## Other information


