### PR TITLE
docs(stencil): document `externalRuntime: false`  in config

### DIFF
--- a/core/stencil.config.ts
+++ b/core/stencil.config.ts
@@ -227,6 +227,11 @@ export const config: Config = {
         warn: true
       }],
       includeGlobalScripts: false,
+      /**
+       * External Runtime uses default runtime settings instead of this file's definitions. Disabling it enables
+       * `experimentalSlotFixes` to be applied and prevents `@stencil/core/internal/client` from being imported, which
+       * contains a dynamic import that caused a warning in Angular.
+      */
       externalRuntime: false,
     },
     {


### PR DESCRIPTION

## Does this introduce a breaking change?

- [ ] Yes
- [X] No
