### PR TITLE
fix(spinner): avoid spinner adding scroll due animation types

### DIFF
--- a/core/src/components/spinner/spinner.common.scss
+++ b/core/src/components/spinner/spinner.common.scss
@@ -18,6 +18,8 @@
 
   color: var(--color);
 
+  overflow: hidden;
+
   user-select: none;
 }
 


### PR DESCRIPTION
Issue number: resolves #

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
Now due to spinner elements animations (scale and transforms) when inside a certain contexts such as `ion-col` **spinner** is forcing those elements to have a scroll.

## What is the new behavior?
Now there is no scroll due the mentioned above.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
