### PR TITLE
fix(datetime): days keep in focus after changing the month

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -1035,9 +1035,8 @@ export class Datetime implements ComponentInterface {
           }
 
           const activeEl = this.el.shadowRoot!.activeElement as HTMLElement | null;
-          if (activeEl) {
-            activeEl.blur();
-            calendarBodyRef.focus();
+          if (activeEl && activeEl.classList.contains('calendar-day')) {
+            (activeEl.closest('.calendar-body') as HTMLElement | null)?.focus();
           }
         });
       };


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
In Android native, when a user places a day in focus and then changes the month by dragging the month, the div previous on focus remains in focus in the new month.

## What is the new behavior?
After changing the month, the focus is removed from the active element and placed on the calendar


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
