### PR TITLE
test(components): scope screenshots to content

### DIFF
--- a/core/src/components/badge/test/basic/badge.e2e.ts
+++ b/core/src/components/badge/test/basic/badge.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ config, screenshot, title }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`badge-basic`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`badge-basic`));
     });
   });
 });

--- a/core/src/components/button/test/basic/button.e2e.ts
+++ b/core/src/components/button/test/basic/button.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ config, screenshot, title }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`button-diff`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`button-diff`));
     });
   });
 });

--- a/core/src/components/button/test/clear/button.e2e.ts
+++ b/core/src/components/button/test/clear/button.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, config, screenshot }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`button-clear`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`button-clear`));
     });
   });
 });

--- a/core/src/components/button/test/expand/button.e2e.ts
+++ b/core/src/components/button/test/expand/button.e2e.ts
@@ -11,7 +11,9 @@ configs({ directions: ['ltr'] }).forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`button-expand`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`button-expand`));
     });
   });
 });

--- a/core/src/components/button/test/icon/button.e2e.ts
+++ b/core/src/components/button/test/icon/button.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`button-icon`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`button-icon`));
     });
   });
 });

--- a/core/src/components/button/test/outline/button.e2e.ts
+++ b/core/src/components/button/test/outline/button.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`button-outline`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`button-outline`));
     });
   });
 });

--- a/core/src/components/list-header/test/basic/list-header.e2e.ts
+++ b/core/src/components/list-header/test/basic/list-header.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`list-header`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`list-header`));
     });
   });
 });

--- a/core/src/components/progress-bar/test/basic/progress-bar.e2e.ts
+++ b/core/src/components/progress-bar/test/basic/progress-bar.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`progress-bar-basic`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`progress-bar-basic`));
     });
   });
 });

--- a/core/src/components/toggle/test/sizes/toggle.e2e.ts
+++ b/core/src/components/toggle/test/sizes/toggle.e2e.ts
@@ -8,7 +8,9 @@ configs().forEach(({ title, screenshot, config }) => {
 
       await page.setIonViewport();
 
-      await expect(page).toHaveScreenshot(screenshot(`toggle-sizes-diff`));
+      const content = page.locator('ion-content');
+
+      await expect(content).toHaveScreenshot(screenshot(`toggle-sizes-diff`));
     });
   });
 });


### PR DESCRIPTION
Issue number: resolves #30422

---------

## What is the current behavior?
Several screenshot tests capture the full page even though the ion-toolbar in the header is only present to label the test page. As a result, visual changes to ion-toolbar force unrelated screenshot updates.

## What is the new behavior?
This scopes an initial batch of screenshot assertions to ion-content so the toolbar is no longer included in screenshots where its appearance is not being tested.

- update badge basic screenshot coverage
- update several button screenshot tests
- update list-header, progress-bar, and toggle sizes screenshot tests

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Added no new test cases; this updates existing screenshot assertions to better target the component under test.
- px eslint passed for the touched files.
- Playwright screenshot tests were not run locally because the required Playwright browser binaries are not installed in this environment.