### PR TITLE
test(infinite-scroll): stabilize top scroll test

### DIFF
--- a/core/src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts
+++ b/core/src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts
@@ -3,10 +3,7 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('infinite-scroll: top'), () => {
-    test('should load more items when scrolled to the top', async ({ page, skip }) => {
-      // TODO(FW-6394): remove once flaky issue is resolved
-      skip.browser('webkit', 'Safari is flaky on CI');
-
+    test('should load more items when scrolled to the top', async ({ page }) => {
       await page.goto('/src/components/infinite-scroll/test/top', config);
 
       const ionInfiniteComplete = await page.spyOnEvent('ionInfiniteComplete');
@@ -14,10 +11,20 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       const items = page.locator('ion-item');
       expect(await items.count()).toBe(30);
 
+      await content.evaluate((el: HTMLIonContentElement) => el.scrollToBottom(0));
+      await page.waitForFunction(async () => {
+        const contentEl = document.querySelector('ion-content') as HTMLIonContentElement | null;
+        if (contentEl == null) {
+          return false;
+        }
+
+        const scrollEl = await contentEl.getScrollElement();
+        return scrollEl.scrollTop > 0;
+      });
+
       await content.evaluate((el: HTMLIonContentElement) => el.scrollToTop(0));
       await ionInfiniteComplete.next();
-
-      expect(await items.count()).toBe(60);
+      await expect(items).toHaveCount(60);
     });
   });
 });


### PR DESCRIPTION
﻿Issue number: resolves #30423

---------

## What is the current behavior?
The top-positioned infinite scroll test is flaky on CI with Safari and is currently skipped for WebKit. The test assumes a specific initial scroll state, which makes it timing-sensitive.

## What is the new behavior?
The test now uses a deterministic scroll sequence by scrolling to the bottom first, waiting for the content to actually be offset, and then scrolling back to the top before waiting for `ionInfiniteComplete`.

- remove the WebKit skip
- ensure the test starts from a known scrolled state
- keep the existing item-count assertion after loading more content

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Verified locally with `npx playwright test src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts --project="Mobile Chrome"`
- Verified locally with `npx playwright test src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts --project="Mobile Safari"`
- `npx eslint src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts` passed
