### PR TITLE
fix(checkbox): show labels after page navigation

### DIFF
--- a/core/src/components/checkbox/checkbox.tsx
+++ b/core/src/components/checkbox/checkbox.tsx
@@ -154,11 +154,11 @@ export class Checkbox implements ComponentInterface {
     if (Build.isBrowser && typeof MutationObserver !== 'undefined') {
       this.validationObserver = new MutationObserver((mutations) => {
         // Watch for label content changes
-        if (mutations.some((mutation) => mutation.type === 'characterData')) {
+        if (mutations.some((mutation) => mutation.type === 'characterData' || mutation.type === 'childList')) {
           this.hasLabelContent = this.el.textContent !== '';
         }
         // Watch for class changes to update validation state.
-        if (mutations.some((mutation) => mutation.type === 'attributes')) {
+        if (mutations.some((mutation) => mutation.type === 'attributes' && mutation.target === el)) {
           const newIsInvalid = checkInvalidState(el);
           if (this.isInvalid !== newIsInvalid) {
             this.isInvalid = newIsInvalid;
@@ -191,6 +191,7 @@ export class Checkbox implements ComponentInterface {
         attributes: true,
         attributeFilter: ['class'],
         characterData: true,
+        childList: true,
         subtree: true,
       });
     }


### PR DESCRIPTION
Issue number: resolves #31052

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
After a page navigation, ion-checkbox's `onslotchange` event fires before the element's `textContent` has been updated. It is called again after `textContent` becomes readable on Safari, but is not called again after the `textContent` becomes readable on Chrome and Firefox. 

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Uses `MutationObserver` instead of `onslotchange` and fires specifically on character data changes. This ensures `hasLabelContent` is up to date.
- `MutationObserver` does not fire on load, so `hasLabelContent` is initialized in `connectedCallback`

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
