### PR TITLE
chore(ci): use latest stencil react-output-target in nightly

### DIFF
--- a/.github/workflows/actions/build-core-stencil-prerelease/action.yml
+++ b/.github/workflows/actions/build-core-stencil-prerelease/action.yml
@@ -33,6 +33,10 @@ runs:
       run: npm run build -- --ci --debug --verbose
       working-directory: ./core
       shell: bash
+    - name: 🏗️ Lint
+      run: npm run lint
+      working-directory: ./packages/react
+      shell: bash
     - uses: ./.github/workflows/actions/upload-archive
       with:
         name: ionic-core

--- a/.github/workflows/actions/build-core-stencil-prerelease/action.yml
+++ b/.github/workflows/actions/build-core-stencil-prerelease/action.yml
@@ -17,7 +17,7 @@ runs:
       with:
         node-version: 24.x
 
-    - name: 🕸️ Install Dependencies
+    - name: 🕸️ Install Core Dependencies
       run: npm ci
       working-directory: ./core
       shell: bash
@@ -33,7 +33,11 @@ runs:
       run: npm run build -- --ci --debug --verbose
       working-directory: ./core
       shell: bash
-    - name: 🏗️ Lint
+    - name: 🕸️ Install React Package Dependencies
+      run: npm ci
+      working-directory: ./packages/react
+      shell: bash
+    - name: 🏗️ Lint React Package
       run: npm run lint
       working-directory: ./packages/react
       shell: bash

--- a/.github/workflows/actions/build-core-stencil-prerelease/action.yml
+++ b/.github/workflows/actions/build-core-stencil-prerelease/action.yml
@@ -1,8 +1,12 @@
 name: 'Build Ionic Core with Stencil Prerelease'
 description: 'Build Ionic Core with a Prerelease Build of Stencil'
 inputs:
-  stencil-version:
+  stencil-core-version:
     description: 'The NPM tag of @stencil/core to install.'
+    type: string
+    required: true
+  stencil-react-output-target-version:
+    description: 'The NPM tag of @stencil/react-output-target to install.'
     type: string
     required: true
 runs:
@@ -17,9 +21,13 @@ runs:
       run: npm ci
       working-directory: ./core
       shell: bash
-    - name: 📦 Install Stencil ${{ inputs.stencil-version }}
+    - name: 📦 Install Stencil Core ${{ inputs.stencil-core-version }}
       working-directory: ./core
-      run: npm i @stencil/core@${{ inputs.stencil-version }}
+      run: npm i @stencil/core@${{ inputs.stencil-core-version }}
+      shell: bash
+    - name: 📦 Install Stencil React Output Target ${{ inputs.stencil-react-output-target-version }}
+      working-directory: ./core
+      run: npm i @stencil/react-output-target@${{ inputs.stencil-react-output-target-version }}
       shell: bash
     - name: 🏗️ Build Core
       run: npm run build -- --ci --debug --verbose
@@ -29,4 +37,4 @@ runs:
       with:
         name: ionic-core
         output: core/CoreBuild.zip
-        paths: core/dist core/components core/css core/hydrate core/loader core/src/components.d.ts core/package.json
+        paths: core/dist core/components core/css core/hydrate core/loader core/src/components.d.ts core/package.json packages/react/src/components/components.ts

--- a/.github/workflows/actions/build-react/action.yml
+++ b/.github/workflows/actions/build-react/action.yml
@@ -31,16 +31,14 @@ runs:
       run: npm run test.spec
       shell: bash
       working-directory: ./packages/react
-    - name: Clean core package.json
-      run: git checkout ./package.json
-      shell: bash
-      working-directory: ./core
-    - name: 🔍 Check Diff
-      run: git diff --exit-code
-      shell: bash
-      working-directory: ./packages/react
     - uses: ./.github/workflows/actions/upload-archive
       with:
         name: ionic-react
         output: packages/react/ReactBuild.zip
-        paths: packages/react/dist packages/react/css
+        paths: packages/react/dist packages/react/css packages/react/package.json
+    - name: Clean package.json updates
+      run: git checkout ./core/package.json ./packages/react/package.json
+      shell: bash
+    - name: 🔍 Check Diff
+      run: git diff --exit-code
+      shell: bash

--- a/.github/workflows/actions/build-vue/action.yml
+++ b/.github/workflows/actions/build-vue/action.yml
@@ -27,7 +27,7 @@ runs:
       run: npm run build
       shell: bash
       working-directory: ./packages/vue
-    - name: Clean core package.json
+    - name: Clean package.json updates
       run: git checkout ./core/package.json ./packages/react/package.json
       shell: bash
     - name: 🔍 Check Diff

--- a/.github/workflows/actions/build-vue/action.yml
+++ b/.github/workflows/actions/build-vue/action.yml
@@ -28,13 +28,11 @@ runs:
       shell: bash
       working-directory: ./packages/vue
     - name: Clean core package.json
-      run: git checkout ./package.json
+      run: git checkout ./core/package.json ./packages/react/package.json
       shell: bash
-      working-directory: ./core
     - name: 🔍 Check Diff
       run: git diff --exit-code
       shell: bash
-      working-directory: ./packages/vue
     - uses: ./.github/workflows/actions/upload-archive
       with:
         name: ionic-vue

--- a/.github/workflows/actions/test-core-clean-build/action.yml
+++ b/.github/workflows/actions/test-core-clean-build/action.yml
@@ -13,9 +13,8 @@ runs:
         path: ./core
         filename: CoreBuild.zip
     - name: Clean core package.json
-      run: git checkout ./package.json
+      run: git checkout ./core/package.json ./packages/react/package.json
       shell: bash
-      working-directory: ./core
     - name: 🔍 Check Diff
       run: |
         git diff --exit-code || {

--- a/.github/workflows/actions/test-core-clean-build/action.yml
+++ b/.github/workflows/actions/test-core-clean-build/action.yml
@@ -12,7 +12,7 @@ runs:
         name: ionic-core
         path: ./core
         filename: CoreBuild.zip
-    - name: Clean core package.json
+    - name: Clean package.json updates
       run: git checkout ./core/package.json ./packages/react/package.json
       shell: bash
     - name: 🔍 Check Diff

--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -9,11 +9,16 @@ on:
     - cron: '00 06 * * 1-5'
   workflow_dispatch:
     inputs:
-      npm_release_tag:
+      npm_release_tag_core:
         required: true
         type: string
-        description: What version should be pulled from NPM?
+        description: What stencil/core version should be pulled from NPM?
         default: nightly
+      npm_release_tag_react_output_target:
+        required: true
+        type: string
+        description: What stencil/react-output-target version should be pulled from NPM?
+        default: latest
 
 # When pushing a new commit we should
 # cancel the previous test run to not
@@ -29,7 +34,9 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/build-core-stencil-prerelease
         with:
-          stencil-version: ${{ inputs.npm_release_tag || 'nightly' }}
+          stencil-core-version: ${{ inputs.npm_release_tag_core || 'nightly' }}
+          stencil-react-output-target-version: ${{ inputs.npm_release_tag_react_output_target || 'latest' }}
+
 
   test-core-clean-build:
     needs: [build-core-with-stencil-nightly]
@@ -173,6 +180,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - name: Install Stencil React Output Target
+      working-directory: ./packages/react
+      run: npm i @stencil/react-output-target/${{ inputs.npm_release_tag_react_output_target }}
+      shell: bash
     - uses: ./.github/workflows/actions/build-react
 
   build-react-router:

--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Stencil React Output Target
       working-directory: ./packages/react
-      run: npm i @stencil/react-output-target/${{ inputs.npm_release_tag_react_output_target }}
+      run: npm i @stencil/react-output-target@${{ inputs.npm_release_tag_react_output_target }}
       shell: bash
     - uses: ./.github/workflows/actions/build-react
 

--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -182,7 +182,7 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - name: Install Stencil React Output Target
       working-directory: ./packages/react
-      run: npm i @stencil/react-output-target@${{ inputs.npm_release_tag_react_output_target }}
+      run: npm i @stencil/react-output-target@${{ inputs.npm_release_tag_react_output_target || 'latest' }}
       shell: bash
     - uses: ./.github/workflows/actions/build-react
 

--- a/.github/workflows/stencil-nightly.yml
+++ b/.github/workflows/stencil-nightly.yml
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/workflows/actions/test-core-spec
         with:
-          stencil-version: ${{ inputs.npm_release_tag || 'nightly' }}
+          stencil-version: ${{ inputs.npm_release_tag_core || 'nightly' }}
 
   test-core-screenshot:
     strategy:

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -99,7 +99,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.2.tgz",
       "integrity": "sha512-BBt3opiCOxUr9euZ5/ro/Xv8/V7yJ5bjYMqG/C1YAo8MIKAnumZalCN+msbci3Pigy4lIQfPUpfMM27HMGaYEA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.24.7",
@@ -808,7 +807,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
       "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -1747,7 +1745,6 @@
       "resolved": "https://registry.npmjs.org/@stencil/core/-/core-4.43.0.tgz",
       "integrity": "sha512-6Uj2Z3lzLuufYAE7asZ6NLKgSwsB9uxl84Eh34PASnUjfj32GkrP4DtKK7fNeh1WFGGyffsTDka3gwtl+4reUg==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "stencil": "bin/stencil"
       },
@@ -2262,7 +2259,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -2493,7 +2489,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -2655,7 +2650,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "dev": true,
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3285,7 +3279,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001646",
         "electron-to-chromium": "^1.5.4",
@@ -4570,7 +4563,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.32.0.tgz",
       "integrity": "sha512-VHZ8gX+EDfz+97jGcgyGCyRia/dPOd6Xh9yPv8Bl1+SoaIwD+a/vlrOmGRUyOYu7MwUhc7CxqeaDZU13S4+EpA==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -6868,7 +6860,6 @@
       "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -10059,7 +10050,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
       "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -10273,7 +10263,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10286,7 +10275,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -10584,7 +10572,6 @@
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.3.0.tgz",
       "integrity": "sha512-scIi1NrKLDIYSPK66jjECtII7vIgdAMFmFo8h6qm++I6nN9qDSV35Ku6erzGVqYjx+lj+j5wkusRMr++8SyDZg==",
       "dev": true,
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -11612,7 +11599,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.5.4.tgz",
       "integrity": "sha512-Mtq29sKDAEYP7aljRgtPOpTvOfbwRWlS6dPRzwjdE+C0R4brX/GUyhHSecbHMFLNBLcJIPt9nl9yG5TZ1weH+Q==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION


<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->
Stencil nightly build uses the Stencil react-output-target version specified in Ionic's `package.json`s.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Install latest Stencil react-output-target in nightly build.
- Run `npm run lint` in `packages/react` to format generated `compontents.ts`. Otherwise it will be reported by `git diff`.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
