### PR TITLE
chore(deps): unpin @stencil/react-output-target to ^1.5.2

### DIFF
--- a/core/package-lock.json
+++ b/core/package-lock.json
@@ -25,7 +25,7 @@
         "@rollup/plugin-node-resolve": "^8.4.0",
         "@rollup/plugin-virtual": "^2.0.3",
         "@stencil/angular-output-target": "^0.10.0",
-        "@stencil/react-output-target": "1.5.0",
+        "@stencil/react-output-target": "^1.5.2",
         "@stencil/sass": "^3.0.9",
         "@stencil/vue-output-target": "0.10.8",
         "@types/jest": "^29.5.6",
@@ -1831,9 +1831,9 @@
       }
     },
     "node_modules/@stencil/react-output-target": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-1.5.0.tgz",
-      "integrity": "sha512-0xu0ZKhDpnat1d5nM4wEQvLReqYtYVdekb6SCyvdwTm2/0KEU4+eKSurpzVVX7U/qjAOL8P8RK78J2Y32FH2sg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-1.5.2.tgz",
+      "integrity": "sha512-NnzwjHwoHtD/O7uDA7oi/bUCd4McwvWOPrmD5/QJP3h1QoXTGw0hobpCdl5R04zB1xwrP8d4JUaR16DaTD+aAQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/core/package.json
+++ b/core/package.json
@@ -50,7 +50,7 @@
     "@rollup/plugin-node-resolve": "^8.4.0",
     "@rollup/plugin-virtual": "^2.0.3",
     "@stencil/angular-output-target": "^0.10.0",
-    "@stencil/react-output-target": "1.5.0",
+    "@stencil/react-output-target": "^1.5.2",
     "@stencil/sass": "^3.0.9",
     "@stencil/vue-output-target": "0.10.8",
     "@types/jest": "^29.5.6",

--- a/packages/react/package-lock.json
+++ b/packages/react/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@ionic/core": "^8.8.3",
-        "@stencil/react-output-target": "1.5.0",
+        "@stencil/react-output-target": "^1.5.2",
         "ionicons": "^8.0.13",
         "tslib": "*"
       },
@@ -1868,9 +1868,9 @@
       ]
     },
     "node_modules/@stencil/react-output-target": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-1.5.0.tgz",
-      "integrity": "sha512-0xu0ZKhDpnat1d5nM4wEQvLReqYtYVdekb6SCyvdwTm2/0KEU4+eKSurpzVVX7U/qjAOL8P8RK78J2Y32FH2sg==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@stencil/react-output-target/-/react-output-target-1.5.2.tgz",
+      "integrity": "sha512-NnzwjHwoHtD/O7uDA7oi/bUCd4McwvWOPrmD5/QJP3h1QoXTGw0hobpCdl5R04zB1xwrP8d4JUaR16DaTD+aAQ==",
       "license": "MIT",
       "dependencies": {
         "@lit/react": "^1.0.7",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -41,7 +41,7 @@
   ],
   "dependencies": {
     "@ionic/core": "^8.8.3",
-    "@stencil/react-output-target": "1.5.0",
+    "@stencil/react-output-target": "^1.5.2",
     "ionicons": "^8.0.13",
     "tslib": "*"
   },


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
`@stencil/react-output-target` is pinned to exactly `1.5.0` in `core/package.json` and `packages/react/package.json`. This was a defensive pin after `1.5.1` shipped a regression that dropped the `Partial<C>` wrapper from `StencilProps`, which broke everything in our react apps by [requiring all props to be defined](https://github.com/ionic-team/ionic-framework/actions/runs/25007199736/job/73233599812?pr=30831). Exact-pinning meant we couldn't pick up future patches in the `1.5.x` line.

## What is the new behavior?
Both `package.json` ranges move to `^1.5.2`. Upstream fully reverted [PR #788](https://github.com/stenciljs/output-targets/pull/788) in [`1.5.2`](https://github.com/stenciljs/output-targets/blob/main/packages/react/CHANGELOG.md), so the generator emits `Components.${tag}` again and the runtime restores `Partial<C>`. Regenerating `packages/react/src/components/components.ts` against the `1.5.2` generator and running prettier produces a file byte-identical to the one committed under `1.5.0`, so the published shape is unchanged.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

The original break, the upstream conversation, and the rationale for staying on the `1.5.x` line (rather than taking the new "errors on truly required props" behavior) are all in the [PR #788 thread](https://github.com/stenciljs/output-targets/pull/788).