### PR TITLE
chore(vercel): use absolute hrefs in preview dir indexes

### DIFF
--- a/core/scripts/vercel-build.sh
+++ b/core/scripts/vercel-build.sh
@@ -62,6 +62,12 @@ generate_dir_index() {
   # Skip if an index.html already exists (it's an actual test page)
   [ -f "${dir}/index.html" ] && return
 
+  # Absolute hrefs based on url_path. Vercel does not redirect to add trailing
+  # slashes, so a relative href like "basic/" from a URL without a trailing
+  # slash resolves against the parent directory and breaks navigation.
+  local parent_path="${url_path%/}"
+  parent_path="${parent_path%/*}/"
+
   local entries=""
   for child in "${dir}"/*/; do
     [ -d "${child}" ] || continue
@@ -70,7 +76,7 @@ generate_dir_index() {
     case "${name}" in *-snapshots|.*) continue ;; esac
     # Only include if there's at least one index.html somewhere underneath
     find "${child}" -name "index.html" -print -quit | grep -q . || continue
-    entries="${entries}<a href=\"${name}/\">${name}/</a>\n"
+    entries="${entries}<a href=\"${url_path}${name}/\">${name}/</a>\n"
   done
 
   [ -z "${entries}" ] && return
@@ -92,7 +98,7 @@ generate_dir_index() {
 </head>
 <body>
   <h1>Index of ${url_path}</h1>
-  <a class="up" href="../">../</a>
+  <a class="up" href="${parent_path}">../</a>
 $(echo -e "${entries}")
 </body>
 </html>


### PR DESCRIPTION
Issue number: internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?

`generate_dir_index` in `core/scripts/vercel-build.sh` writes child links like `<a href="basic/">` and an up-link `<a href="../">`. Vercel doesn't 308-redirect to add a trailing slash, so visiting a preview directory URL like `/src/components/progress-bar/test` (no slash) returns the index page but the browser resolves `basic/` against the parent directory. That path doesn't exist, and Vercel's fallback serves the root landing page, so navigation looks like it "circles back" to the preview home instead of opening the test scenario.

## What is the new behavior?

The dir-index generator now emits absolute hrefs based on the directory's `url_path`, including the `../` up-link. Trailing-slash quirks no longer affect navigation between component test scenarios on Vercel previews.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Test page:

- https://ionic-framework-git-fix-vercel-preview-links-ionic1.vercel.app/src/components/progress-bar/test

Versus the broken version on main:

- https://ionic-framework-git-main-ionic1.vercel.app/src/components/progress-bar/test