### PR TITLE
fix(datetime): prevent hidden-state observer from tearing down ready class on initial entry

### DIFF
--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -135,6 +135,12 @@ export class Datetime implements ComponentInterface {
   private todayParts!: DatetimeParts;
   private defaultParts!: DatetimeParts;
   private loadTimeout: ReturnType<typeof setTimeout> | undefined;
+  /**
+   * Set true only by `visibleCallback`. Lets `hiddenCallback` ignore the
+   * synthetic "not intersecting" entry IntersectionObserver fires on
+   * `observe()` when the host mounts offscreen.
+   */
+  private hasBeenIntersecting = false;
 
   private prevPresentation: string | null = null;
 
@@ -1097,6 +1103,7 @@ export class Datetime implements ComponentInterface {
       this.clearFocusVisible = undefined;
     }
     this.loadTimeoutCleanup();
+    this.hasBeenIntersecting = false;
   }
 
   /**
@@ -1140,8 +1147,23 @@ export class Datetime implements ComponentInterface {
       return;
     }
 
+    this.markReady();
+  };
+
+  private markReady = () => {
+    if (this.el.classList.contains('datetime-ready')) {
+      return;
+    }
     this.initializeListeners();
 
+    /**
+     * TODO FW-2793: Datetime needs a frame to ensure that it
+     * can properly scroll contents into view. As a result
+     * we hide the scrollable content until after that frame
+     * so users do not see the content quickly shifting. The downside
+     * is that the content will pop into view a frame after. Maybe there
+     * is a better way to handle this?
+     */
     writeTask(() => {
       this.el.classList.add('datetime-ready');
     });
@@ -1170,19 +1192,8 @@ export class Datetime implements ComponentInterface {
         return;
       }
 
-      this.initializeListeners();
-
-      /**
-       * TODO FW-2793: Datetime needs a frame to ensure that it
-       * can properly scroll contents into view. As a result
-       * we hide the scrollable content until after that frame
-       * so users do not see the content quickly shifting. The downside
-       * is that the content will pop into view a frame after. Maybe there
-       * is a better way to handle this?
-       */
-      writeTask(() => {
-        this.el.classList.add('datetime-ready');
-      });
+      this.hasBeenIntersecting = true;
+      this.markReady();
     };
     const visibleIO = new IntersectionObserver(visibleCallback, { threshold: 0.01, root: el });
 
@@ -1221,6 +1232,12 @@ export class Datetime implements ComponentInterface {
       if (ev.isIntersecting) {
         return;
       }
+
+      // Ignore the initial "not intersecting" entry IntersectionObserver fires on observe().
+      if (!this.hasBeenIntersecting) {
+        return;
+      }
+      this.hasBeenIntersecting = false;
 
       this.destroyInteractionListeners();
 

--- a/core/src/components/datetime/test/basic/datetime.e2e.ts
+++ b/core/src/components/datetime/test/basic/datetime.e2e.ts
@@ -440,10 +440,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
  */
 configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('datetime: IO fallback'), () => {
-    test('should become ready even if IntersectionObserver never reports visible', async ({ page, skip }, testInfo) => {
-      // TODO(FW-7284): Re-enable on WebKit after determining why it fails
-      skip.browser('webkit', 'Wheel is not available in WebKit');
-
+    test('should become ready even if IntersectionObserver never reports visible', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30706',


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
`ion-datetime` runs two IntersectionObservers: one to detect when the host becomes visible (which adds `datetime-ready`) and one to detect when it becomes hidden (which removes the class and tears down listeners). When the host mounts offscreen, both observers receive an initial "not intersecting" entry on `observe()`. The hidden-state observer treats that initial entry as a real visible-to-hidden transition, queues a `writeTask` to remove `datetime-ready`, and races the layout-based fallback (`ensureReadyIfVisible`) that adds the class after 100ms. On WebKit the remove wins often enough that the e2e test for the fallback (added in #30793 to fix #30706) had to be skipped on Mobile Safari. Anything in production that adds `datetime-ready` outside of a real `isIntersecting: true` event is exposed to the same race.

## What is the new behavior?
A `hasBeenIntersecting` flag is set true only when `visibleCallback` observes `isIntersecting: true`. The hidden-state observer's teardown is gated on this flag, so the synthetic initial "not intersecting" entry is ignored. The flag is reset when the host actually transitions to hidden and on `disconnectedCallback`. The previously duplicated init-listeners + ready-class block is consolidated into a single `markReady` helper. The WebKit skip on the IO-fallback e2e test has been removed.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If yes, please describe the impact and migration path for existing applications below. -->

## Other information
The asymmetry where `ensureReadyIfVisible` (the layout fallback) deliberately does NOT set `hasBeenIntersecting` is load-bearing: the flag must reflect a real observer signal, not a fallback-driven write, otherwise the bug returns. This is called out at the guard site so future cleanups don't undo it.

This test was most likely to fail in docker testing Linux Webkit with `--repeat-each=20` because it was pretty flaky. I was able to force it to fail under these conditions and, after fixing it, it no longer failed.

## Relevant Preview Link:

- https://ionic-framework-git-fw-7284-ionic1.vercel.app/src/components/datetime/test/basic