### PR TITLE
fix(action-sheet): restore action-sheet-selected class on non-radio buttons

### DIFF
--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -564,10 +564,6 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
           id={buttonId}
           class={{
             ...buttonClass(b),
-            // Only override `action-sheet-selected` when this button participates
-            // in the radio group. For non-radio buttons we let `buttonClass(b)`
-            // own the class so the public `role: 'selected'` API keeps working
-            // (regression from #30769 / issue #31090).
             ...(isRadio && { 'action-sheet-selected': isActiveRadio }),
           }}
           onClick={() => {

--- a/core/src/components/action-sheet/action-sheet.tsx
+++ b/core/src/components/action-sheet/action-sheet.tsx
@@ -564,7 +564,11 @@ export class ActionSheet implements ComponentInterface, OverlayInterface {
           id={buttonId}
           class={{
             ...buttonClass(b),
-            'action-sheet-selected': isActiveRadio,
+            // Only override `action-sheet-selected` when this button participates
+            // in the radio group. For non-radio buttons we let `buttonClass(b)`
+            // own the class so the public `role: 'selected'` API keeps working
+            // (regression from #30769 / issue #31090).
+            ...(isRadio && { 'action-sheet-selected': isActiveRadio }),
           }}
           onClick={() => {
             if (isRadio) {

--- a/core/src/components/action-sheet/test/basic/action-sheet.spec.tsx
+++ b/core/src/components/action-sheet/test/basic/action-sheet.spec.tsx
@@ -59,3 +59,38 @@ describe('action sheet: disabled buttons', () => {
     await expect(cancelButton.hasAttribute('disabled')).toBe(false);
   });
 });
+
+describe('action sheet: role="selected"', () => {
+  // Regression test for https://github.com/ionic-team/ionic-framework/issues/31090
+  // Buttons with `role: "selected"` must render the `action-sheet-selected`
+  // class so that userland CSS targeting the active option keeps working.
+  it('should add the action-sheet-selected class to a button with role="selected"', async () => {
+    const page = await newSpecPage({
+      components: [ActionSheet],
+      template: () => (
+        <ion-action-sheet
+          buttons={[
+            { text: 'Option A' },
+            { text: 'Option B', role: 'selected' },
+            { text: 'Option C' },
+            { text: 'Cancel', role: 'cancel' },
+          ]}
+          overlayIndex={1}
+        ></ion-action-sheet>
+      ),
+    });
+
+    const actionSheet = page.body.querySelector('ion-action-sheet')!;
+
+    await actionSheet.present();
+
+    const buttons = Array.from(actionSheet.querySelectorAll<HTMLButtonElement>('.action-sheet-button'));
+    const selectedButton = buttons.find((btn) => btn.textContent?.trim() === 'Option B');
+
+    await expect(selectedButton).toBeDefined();
+    await expect(selectedButton!.classList.contains('action-sheet-selected')).toBe(true);
+
+    const optionA = buttons.find((btn) => btn.textContent?.trim() === 'Option A');
+    await expect(optionA!.classList.contains('action-sheet-selected')).toBe(false);
+  });
+});

--- a/core/src/components/action-sheet/test/basic/action-sheet.spec.tsx
+++ b/core/src/components/action-sheet/test/basic/action-sheet.spec.tsx
@@ -60,11 +60,9 @@ describe('action sheet: disabled buttons', () => {
   });
 });
 
-describe('action sheet: role="selected"', () => {
-  // Regression test for https://github.com/ionic-team/ionic-framework/issues/31090
-  // Buttons with `role: "selected"` must render the `action-sheet-selected`
-  // class so that userland CSS targeting the active option keeps working.
-  it('should add the action-sheet-selected class to a button with role="selected"', async () => {
+describe('action sheet: selected role', () => {
+  // https://github.com/ionic-team/ionic-framework/issues/31090
+  it('should add the `action-sheet-selected` class to a button with `role="selected"`', async () => {
     const page = await newSpecPage({
       components: [ActionSheet],
       template: () => (


### PR DESCRIPTION
Issue number: resolves #31090

---------

## What is the current behavior?

Buttons configured with `role: "selected"` no longer receive the `action-sheet-selected` CSS class. Userland styling that targets `.action-sheet-selected` (the documented hook for marking the active option — bold text, custom checkmarks, etc.) silently stopped working as of `8.7.12`.

This regressed in #30769 (`fix(select, action-sheet): use radio role for options`). The new render path computes the button's class as:

```tsx
class={{
  ...buttonClass(b),
  'action-sheet-selected': isActiveRadio,
}}
```

`buttonClass(b)` already emits `'action-sheet-selected': true` for `role: "selected"` (via `[action-sheet-${button.role}]]: button.role !== undefined`), but the second key with the same name overrides it. For any non-radio button `isActiveRadio` is `false`, so the class is dropped from the rendered `<button>`.

### Repro

```html
<ion-action-sheet id="sheet" header="Choose"></ion-action-sheet>
<script type="module">
  await customElements.whenDefined("ion-action-sheet");
  const sheet = document.getElementById("sheet");
  sheet.buttons = [
    { text: "Option A" },
    { text: "Option B", role: "selected" },
    { text: "Cancel", role: "cancel" },
  ];
  await sheet.present();
</script>
```

In `8.7.11` the Option B button gets `action-sheet-selected`. In `8.7.12+` it does not.

## What is the new behavior?

- Only override `action-sheet-selected` based on `isActiveRadio` when the button actually participates in the radio group (`b.htmlAttributes?.role === 'radio'`). For non-radio buttons, the class map produced by `buttonClass(b)` is left untouched, so `role: "selected"` keeps emitting `action-sheet-selected` exactly as it has since the component was introduced.
- Adds a spec-test regression covering the `role: "selected"` case.

This preserves the new radio-group behavior introduced in #30769 (when the button is a radio, `action-sheet-selected` follows `activeRadioId`) and restores the documented public API.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- The minified output for the lazy + custom-elements bundles becomes `Object.assign(Object.assign({}, buttonClass(b)), isRadio && {"action-sheet-selected": isActiveRadio})`. When `isRadio` is `false`, `Object.assign(target, false)` is a no-op and the class set by `buttonClass(b)` is preserved.
- Verified in a real consumer app on 8.8.4: with this patch built and installed locally, `role: "selected"` once again renders `class="... action-sheet-selected ..."` on the `<button>`.


Made with [Cursor](https://cursor.com)