### PR TITLE
refactor(content, modal): update prefix for internal safe area variable

### DIFF
--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -64,7 +64,7 @@
 
 .inner-scroll {
   @include position(calc(var(--offset-top) * -1), 0px,calc(var(--offset-bottom) * -1), 0px);
-  @include padding(calc(var(--padding-top) + var(--offset-top)), var(--padding-end), calc(var(--padding-bottom) + var(--keyboard-offset) + var(--offset-bottom) + var(--ion-content-safe-area-padding-bottom, 0px)), var(--padding-start));
+  @include padding(calc(var(--padding-top) + var(--offset-top)), var(--padding-end), calc(var(--padding-bottom) + var(--keyboard-offset) + var(--offset-bottom) + var(--internal-content-safe-area-padding-bottom, 0px)), var(--padding-start));
 
   position: absolute;
 

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -1517,12 +1517,12 @@ export class Modal implements ComponentInterface, OverlayInterface {
   }
 
   /**
-   * Sets --ion-content-safe-area-padding-bottom on the given ion-content
+   * Sets --internal-content-safe-area-padding-bottom on the given ion-content
    * when no footer is present, so ion-content's .inner-scroll includes
    * safe-area-bottom in its scroll padding. This keeps the modal background
    * edge-to-edge while ensuring content scrolls clear of the system nav bar.
    *
-   * --ion-content-safe-area-padding-bottom is an internal CSS property used
+   * --internal-content-safe-area-padding-bottom is an internal CSS property used
    * only by this code path. It is not part of ion-content's public API and
    * should not be set by consumers. The default of 0px makes it a no-op
    * when unset, which is the expected state for ion-content used outside of
@@ -1534,17 +1534,17 @@ export class Modal implements ComponentInterface, OverlayInterface {
     // padding. Custom modals with raw HTML are developer-controlled.
     if (!contentEl || hasFooter) return;
 
-    contentEl.style.setProperty('--ion-content-safe-area-padding-bottom', 'var(--ion-safe-area-bottom, 0px)');
+    contentEl.style.setProperty('--internal-content-safe-area-padding-bottom', 'var(--ion-safe-area-bottom, 0px)');
   }
 
   /**
-   * Removes the internal --ion-content-safe-area-padding-bottom property
+   * Removes the internal --internal-content-safe-area-padding-bottom property
    * from an already-located ion-content. Callers do their own
    * findContentAndFooter() so they can also read hasFooter if needed.
    */
   private clearContentSafeAreaPadding(contentEl: HTMLElement | null): void {
     if (!contentEl) return;
-    contentEl.style.removeProperty('--ion-content-safe-area-padding-bottom');
+    contentEl.style.removeProperty('--internal-content-safe-area-padding-bottom');
   }
 
   /**

--- a/core/src/components/modal/test/safe-area/modal.e2e.ts
+++ b/core/src/components/modal/test/safe-area/modal.e2e.ts
@@ -132,11 +132,11 @@ configs({ modes: ['ios', 'md'], directions: ['ltr'] }).forEach(({ title, config 
       expect(wrapperPaddingBottom).toBe('');
       expect(wrapperHeight).toBe('');
 
-      // ion-content should have --ion-content-safe-area-padding-bottom set so its
+      // ion-content should have --internal-content-safe-area-padding-bottom set so its
       // .inner-scroll element includes safe-area in its bottom padding.
       const content = modal.locator('ion-content');
       const safeAreaPadding = await content.evaluate((el: HTMLElement) => {
-        return el.style.getPropertyValue('--ion-content-safe-area-padding-bottom');
+        return el.style.getPropertyValue('--internal-content-safe-area-padding-bottom');
       });
       expect(safeAreaPadding).toBe('var(--ion-safe-area-bottom, 0px)');
     });


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

We've decided to use `internal` as the prefix for internal CSS variables and `ion` for public variables. We recently introduced a new internal variable for the safe area that doesn't have the correct prefix.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Updated `--ion-content-safe-area-padding-bottom` to `--internal-content-safe-area-padding-bottom`

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A