### PR TITLE
fix(input): scroll assist no longer fires duplicate click events

### DIFF
--- a/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
+++ b/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
@@ -4,13 +4,6 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('input: scroll assist click events'), () => {
-    test.beforeEach((_, testInfo) => {
-      testInfo.annotations.push({
-        type: 'issue',
-        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
-      });
-    });
-
     const setup = async (page: E2EPage) => {
       const longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(40);
       await page.setContent(
@@ -50,7 +43,11 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
         () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
       );
 
-    test('clicking ion-item padding when scroll is needed should fire one click event', async ({ page }) => {
+    test('clicking ion-item padding when scroll is needed should fire one click event', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
+      });
       await setup(page);
       await positionTargetForScrollAssist(page);
 
@@ -65,7 +62,13 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       expect(onClick).toHaveReceivedEventTimes(1);
     });
 
-    test('clicking ion-input directly when scroll is needed should fire one click event', async ({ page }) => {
+    test('clicking ion-input directly when scroll is needed should fire one click event', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
+      });
       await setup(page);
       await positionTargetForScrollAssist(page);
 
@@ -77,7 +80,11 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       expect(onClick).toHaveReceivedEventTimes(1);
     });
 
-    test('programmatic setFocus when scroll is needed should not fire a click event', async ({ page }) => {
+    test('programmatic setFocus when scroll is needed should not fire a click event', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
+      });
       await setup(page);
       await positionTargetForScrollAssist(page);
 
@@ -91,7 +98,13 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       expect(onClick).toHaveReceivedEventTimes(0);
     });
 
-    test('keyboard focus into input when scroll is needed should not fire a click event', async ({ page }) => {
+    test('keyboard focus into input when scroll is needed should not fire a click event', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
+      });
       await setup(page);
       await positionTargetForScrollAssist(page);
 

--- a/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
+++ b/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
@@ -1,0 +1,111 @@
+import { expect } from '@playwright/test';
+import type { E2EPage } from '@utils/test/playwright';
+import { configs, test } from '@utils/test/playwright';
+
+configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('input: scroll assist click events'), () => {
+    test.beforeEach(({}, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/30412',
+      });
+    });
+
+    const setup = async (page: E2EPage) => {
+      const longText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. '.repeat(40);
+      await page.setContent(
+        `
+        <ion-app>
+          <ion-content>
+            <p style="padding: 16px;">${longText}</p>
+            <ion-item id="target">
+              <ion-input value="George"></ion-input>
+            </ion-item>
+            <p style="padding: 16px;">${longText}</p>
+          </ion-content>
+        </ion-app>
+        `,
+        config
+      );
+    };
+
+    // Position the target near the bottom of the viewport so scroll assist's
+    // `scrollAmount` calculation passes its 4px threshold and the relocate path runs.
+    const positionTargetForScrollAssist = async (page: E2EPage) => {
+      await page.evaluate(async () => {
+        const content = document.querySelector('ion-content') as HTMLIonContentElement;
+        const item = document.querySelector('#target')!;
+        const scrollEl = await content.getScrollElement();
+        const itemRect = item.getBoundingClientRect();
+        const desiredTop = window.innerHeight - itemRect.height - 20;
+        scrollEl.scrollTop += itemRect.top - desiredTop;
+        await new Promise((r) => requestAnimationFrame(() => r(null)));
+      });
+    };
+
+    // Two rAF cycles drain any rAF-scheduled work, including the legacy recovery
+    // click that scroll assist used to fire after relocating the input.
+    const flushAnimationFrames = (page: E2EPage) =>
+      page.evaluate(
+        () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())))
+      );
+
+    test('clicking ion-item padding when scroll is needed should fire one click event', async ({ page }) => {
+      await setup(page);
+      await positionTargetForScrollAssist(page);
+
+      const item = page.locator('#target');
+      const onClick = await page.spyOnEvent('click');
+
+      // `force: true` skips Playwright's auto-scroll-into-view, so the click
+      // lands while the item still requires scroll assist to relocate.
+      await item.click({ position: { x: 5, y: 5 }, force: true });
+      await flushAnimationFrames(page);
+
+      expect(onClick).toHaveReceivedEventTimes(1);
+    });
+
+    test('clicking ion-input directly when scroll is needed should fire one click event', async ({ page }) => {
+      await setup(page);
+      await positionTargetForScrollAssist(page);
+
+      const onClick = await page.spyOnEvent('click');
+      const nativeInput = page.locator('#target ion-input input');
+      await nativeInput.click({ force: true });
+      await flushAnimationFrames(page);
+
+      expect(onClick).toHaveReceivedEventTimes(1);
+    });
+
+    test('programmatic setFocus when scroll is needed should not fire a click event', async ({ page }) => {
+      await setup(page);
+      await positionTargetForScrollAssist(page);
+
+      const onClick = await page.spyOnEvent('click');
+      await page.evaluate(async () => {
+        const input = document.querySelector('#target ion-input') as HTMLIonInputElement;
+        await input.setFocus();
+      });
+      await flushAnimationFrames(page);
+
+      expect(onClick).toHaveReceivedEventTimes(0);
+    });
+
+    test('keyboard focus into input when scroll is needed should not fire a click event', async ({ page }) => {
+      await setup(page);
+      await positionTargetForScrollAssist(page);
+
+      const onClick = await page.spyOnEvent('click');
+
+      // Focus the native input directly without dispatching a click; mimics
+      // tab navigation landing on an offscreen input.
+      await page.evaluate(() => {
+        const native = document.querySelector('#target ion-input input') as HTMLInputElement;
+        native.focus();
+      });
+      await flushAnimationFrames(page);
+
+      expect(onClick).toHaveReceivedEventTimes(0);
+    });
+  });
+});

--- a/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
+++ b/core/src/components/input/test/item/scroll-assist-double-click.e2e.ts
@@ -4,7 +4,7 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('input: scroll assist click events'), () => {
-    test.beforeEach(({}, testInfo) => {
+    test.beforeEach((_, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',
         description: 'https://github.com/ionic-team/ionic-framework/issues/30412',

--- a/core/src/utils/input-shims/hacks/scroll-assist.ts
+++ b/core/src/utils/input-shims/hacks/scroll-assist.ts
@@ -2,7 +2,6 @@ import type { KeyboardResizeOptions } from '@capacitor/keyboard';
 import { win } from '@utils/browser';
 
 import { getScrollElement, scrollByPoint } from '../../content';
-import { raf } from '../../helpers';
 import { KeyboardResize } from '../../native/keyboard';
 
 import { relocateInput, SCROLL_AMOUNT_PADDING } from './common';
@@ -252,13 +251,6 @@ const jsSetFocus = async (
   // at this point the native text input still does not have focus
   relocateInput(componentEl, inputEl, true, scrollData.inputSafeY, disableClonedInput);
   setManualFocus(inputEl);
-
-  /**
-   * Relocating/Focusing input causes the
-   * click event to be cancelled, so
-   * manually fire one here.
-   */
-  raf(() => componentEl.click());
 
   /**
    * If enabled, we can add scroll padding to


### PR DESCRIPTION
Issue number: resolves #30412

---------
## What is the current behavior?

When a user listener bound to `ion-input` or `ion-item` receives a tap that requires scroll assist to scroll the input into view, the click handler fires twice. Programmatic `setFocus()` and keyboard focus into an offscreen input also dispatch a phantom click event the developer didn't request.

The cause is `scroll-assist.ts`: after `relocateInput` moves the native input, a RAF-scheduled `componentEl.click()` re-emits a click on the host. That recovery was added in #22845 (Feb 2021) to fix #21871, when scroll assist drove focus from its own touchstart/touchend listeners and `relocateInput` ran during the in-flight click event's lifecycle.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The RAF recovery click is removed. #25848 (Sep 2022) restructured scroll assist to react to `focusin` rather than drive focus from touch events, so `relocateInput` now runs strictly after the click event has finished propagating. Combined with `ion-input`'s click capture handler and `ion-item`'s click-on-padding handler from #30373 (April 2025), the click is always dispatched on the component host before scroll assist runs. Re-firing it produced duplicate clicks for user interactions and phantom clicks for programmatic and keyboard focus.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information


Regression coverage in `core/src/components/input/test/item/scroll-assist-double-click.e2e.ts` covers four cases on iOS Mobile Safari and Mobile Chrome: padding click, direct input click, programmatic `setFocus()`, and keyboard focus. The first two assert one click event; the last two assert zero. All four fail without this change and pass with it.

Preview:
  - https://ionic-framework-git-fw-6540-ionic1.vercel.app/src/utils/input-shims/hacks/test?ionic:mode=ios