### PR TITLE
fix(select): only emit ionChange when value changes

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -18,6 +18,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Components](#version-9x-components)
   - [Legacy Picker](#version-9x-legacy-picker)
   - [Router Outlet](#version-9x-router-outlet)
+  - [Select](#version-9x-select)
 - [Framework Specific](#version-9x-framework-specific)
   - [React](#version-9x-react)
 
@@ -70,6 +71,12 @@ To disable the gesture on a specific outlet, set `swipeGesture` to `false`:
 ```
 
 The `swipeBackEnabled` config option is still respected as the initial default and does not need to change for apps that set it once at startup.
+
+<h4 id="version-9x-select">Select</h4>
+
+The `ionChange` event on `ion-select` now only fires when the selected value actually changes. Previously, the `alert` and `action-sheet` interfaces emitted `ionChange` every time the overlay was confirmed, even when the user chose the option that was already selected. This aligns the `alert` and `action-sheet` interfaces with the existing behavior of the `popover` and `modal` interfaces, and with the documented contract of `ionChange`.
+
+Apps that relied on `ionChange` firing on every confirmation (for example, to detect overlay dismissal without a value change) should listen for `ionDismiss` instead, or use the `didDismiss` event on the underlying alert or action sheet.
 
 <h2 id="version-9x-framework-specific">Framework Specific</h2>
 

--- a/core/src/components/select/select.tsx
+++ b/core/src/components/select/select.tsx
@@ -282,8 +282,41 @@ export class Select implements ComponentInterface {
   }
 
   private setValue(value?: any | null) {
+    if (this.isValueEqual(this.value, value)) {
+      return;
+    }
     this.value = value;
     this.ionChange.emit({ value });
+  }
+
+  private isValueEqual(currentValue: any, newValue: any): boolean {
+    if (this.multiple) {
+      const currentArr = Array.isArray(currentValue) ? currentValue : [];
+      const newArr = Array.isArray(newValue) ? newValue : [];
+      if (currentArr.length !== newArr.length) {
+        return false;
+      }
+      // Multiset compare: each new value must match a distinct current value.
+      // A plain `every(isOptionSelected)` would accept ['a','a'] as equal to
+      // ['a','b'] when both 'a' and 'b' map to options whose values overlap.
+      const remaining = currentArr.slice();
+      return newArr.every((val: any) => {
+        const idx = remaining.findIndex((c: any) => compareOptions(c, val, this.compareWith));
+        if (idx === -1) {
+          return false;
+        }
+        remaining.splice(idx, 1);
+        return true;
+      });
+    }
+
+    if (currentValue == null && newValue == null) {
+      return true;
+    }
+    if (currentValue == null || newValue == null) {
+      return false;
+    }
+    return compareOptions(currentValue, newValue, this.compareWith);
   }
 
   async connectedCallback() {

--- a/core/src/components/select/test/basic/select.e2e.ts
+++ b/core/src/components/select/test/basic/select.e2e.ts
@@ -981,6 +981,113 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       expect(ionChange).toHaveReceivedEventTimes(1);
     });
 
+    test('should not fire ionChange when confirming the already-selected alert option', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/26789',
+      });
+
+      await page.setContent(
+        `
+        <ion-select aria-label="Fruit" interface="alert" value="apple">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+        </ion-select>
+      `,
+        config
+      );
+
+      const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+      const ionAlertDidDismiss = await page.spyOnEvent('ionAlertDidDismiss');
+      const select = page.locator('ion-select') as E2ELocator;
+      const ionChange = await select.spyOnEvent('ionChange');
+
+      await select.click();
+      await ionAlertDidPresent.next();
+
+      const alert = page.locator('ion-alert');
+      const confirmButton = alert.locator('.alert-button:not(.alert-button-role-cancel)');
+
+      await confirmButton.click();
+      await ionAlertDidDismiss.next();
+
+      expect(ionChange).toHaveReceivedEventTimes(0);
+      await expect(select).toHaveJSProperty('value', 'apple');
+    });
+
+    test('should not fire ionChange when confirming the already-selected alert options (multiple)', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/26789',
+      });
+
+      await page.setContent(
+        `
+        <ion-select aria-label="Fruit" interface="alert" multiple="true">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+        </ion-select>
+      `,
+        config
+      );
+
+      const select = page.locator('ion-select') as E2ELocator;
+      await select.evaluate((el: HTMLIonSelectElement) => (el.value = ['apple', 'banana']));
+
+      const ionAlertDidPresent = await page.spyOnEvent('ionAlertDidPresent');
+      const ionAlertDidDismiss = await page.spyOnEvent('ionAlertDidDismiss');
+      const ionChange = await select.spyOnEvent('ionChange');
+
+      await select.click();
+      await ionAlertDidPresent.next();
+
+      const alert = page.locator('ion-alert');
+      const confirmButton = alert.locator('.alert-button:not(.alert-button-role-cancel)');
+
+      await confirmButton.click();
+      await ionAlertDidDismiss.next();
+
+      expect(ionChange).toHaveReceivedEventTimes(0);
+    });
+
+    test('should not fire ionChange when tapping the already-selected action-sheet option', async ({
+      page,
+    }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/26789',
+      });
+
+      await page.setContent(
+        `
+        <ion-select aria-label="Fruit" interface="action-sheet" value="apple">
+          <ion-select-option value="apple">Apple</ion-select-option>
+          <ion-select-option value="banana">Banana</ion-select-option>
+        </ion-select>
+      `,
+        config
+      );
+
+      const ionActionSheetDidPresent = await page.spyOnEvent('ionActionSheetDidPresent');
+      const ionActionSheetDidDismiss = await page.spyOnEvent('ionActionSheetDidDismiss');
+      const select = page.locator('ion-select') as E2ELocator;
+      const ionChange = await select.spyOnEvent('ionChange');
+
+      await select.click();
+      await ionActionSheetDidPresent.next();
+
+      const actionSheet = page.locator('ion-action-sheet');
+      const selectedButton = actionSheet.locator('.action-sheet-button[aria-checked="true"]');
+
+      await selectedButton.click();
+      await ionActionSheetDidDismiss.next();
+
+      expect(ionChange).toHaveReceivedEventTimes(0);
+      await expect(select).toHaveJSProperty('value', 'apple');
+    });
+
     test('should not fire when programmatically setting a valid value', async ({ page }) => {
       await page.setContent(
         `


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

In certain circumstances, `ion-select` emits `ionChange` every time the overlay is confirmed, even when the user picks the option that was already selected. The `popover` and `modal` interfaces don't have this issue because they delegate selection to `ion-radio-group` / `ion-checkbox`, which already de-dupe. The mismatch is in `select.tsx`: the alert OK handler and each action-sheet button handler call `setValue()` unconditionally, and `setValue()` always emits.

This contradicts the documented behavior ("Emitted when the value has changed") and is inconsistent with `ion-input`, `ion-textarea`, and the other select interfaces.

## What is the new behavior?

`setValue()` now compares the incoming value against the current value and early-returns when they match, so `ionChange` only fires on an actual change. The comparison honors `compareWith` for object values and treats `multiple` arrays as equal when they contain the same elements regardless of order. Behavior across all four interfaces is now consistent.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Apps that relied on `ionChange` firing on every alert/action-sheet confirmation, even without a value change, will need to listen for `ionDismiss` (or the alert/action-sheet's own dismiss event) instead. This aligns alert/action-sheet with how `popover` and `modal` already behave, and with how every other Ionic form control handles `ionChange`.

## Other information

Preview pages (open the alert or action-sheet, click OK or tap the already-selected option, watch the console):
- https://ionic-framework-git-fw-6983-ionic1.vercel.app/src/components/select/test/basic

This goes along with the breaking change documentation in ionic docs, here:
- https://github.com/ionic-team/ionic-docs/pull/4490