### PR TITLE
chore(renovate): add playwright-core to group

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,7 +38,7 @@
     },
     {
       matchDatasources: ["npm"],
-      matchPackagePatterns: ["@playwright/test", "@axe-core/playwright"],
+      matchPackageNames: ["@playwright/test", "@axe-core/playwright", "playwright-core"],
       groupName: "playwright",
       matchFileNames: [
         "core/package.json"


### PR DESCRIPTION
Issue number: N/A

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

The Renovate `playwright` npm rule only matched `@playwright/test` and `@axe-core/playwright`. As a result, `playwright-core` was not included in the `playwright` group and instead fell into Renovate's default `playwright-monorepo` grouping, opening a separate `renovate/playwright-monorepo` PR alongside the main `renovate/playwright` PR for every Playwright release.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Added `playwright-core` to the npm rule's `matchPackageNames` so it groups with the other Playwright packages.
- Switched the npm rule from `matchPackagePatterns` to `matchPackageNames` since the entries are exact package names, not patterns; the explicit list is clearer for a small, stable set of dependencies.
- All Playwright-related updates (`@playwright/test`, `@axe-core/playwright`, `playwright-core`, and the `mcr.microsoft.com/playwright` Docker image) will now land in a single `renovate/playwright` PR.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

N/A
