### PR TITLE
fix(vue-router): sync URL with display on browser back after tab switch

### DIFF
--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -326,6 +326,30 @@ export const createIonRouter = (
               routeInfo,
               delta
             );
+            if (
+              prevRouteInfo &&
+              prevRouteInfo.pathname &&
+              prevRouteInfo.pathname !== location.path &&
+              (routeInfo.tab || prevRouteInfo.tab)
+            ) {
+              /**
+               * Browser POP destination differs from the within-tab back
+               * target (e.g. user is on a re-activated tab child and the
+               * browser's linear predecessor is in a different tab). Sync
+               * URL with the displayed page via router.replace so the back
+               * stack stays consistent with what the user sees, matching
+               * handleNavigateBack's non-linear path.
+               */
+              handleNavigate(
+                prevRouteInfo.pathname +
+                  (prevRouteInfo.search ? "?" + prevRouteInfo.search : ""),
+                "pop",
+                "back",
+                undefined,
+                prevRouteInfo.tab
+              );
+              return;
+            }
             incomingRouteParams = {
               ...prevRouteInfo,
               routerAction: "pop",

--- a/packages/vue/test/base/tests/e2e/playwright/tabs.spec.ts
+++ b/packages/vue/test/base/tests/e2e/playwright/tabs.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from './utils/test-base';
+import { ionPageVisible, ionPageHidden, ionPageDoesNotExist, tabClick } from './utils/test-utils';
+
+test.describe('Tabs', () => {
+  test('browser back from preserved child page should sync URL and display', async ({ page }) => {
+    // After navigating into a tab's child, switching tabs, then switching back
+    // (which re-activates the preserved child page), pressing the browser back
+    // button must leave URL and displayed page in sync.
+    await page.goto('/tabs/tab1');
+    await ionPageVisible(page, 'tab1');
+
+    await page.locator('div.ion-page[data-pageid=tab1] #child-one').click();
+    await ionPageHidden(page, 'tab1');
+    await ionPageVisible(page, 'tab1childone');
+
+    await tabClick(page, 'tab2');
+    await ionPageHidden(page, 'tab1childone');
+    await ionPageVisible(page, 'tab2');
+
+    await tabClick(page, 'tab1');
+    await ionPageHidden(page, 'tab2');
+    await ionPageVisible(page, 'tab1childone');
+
+    await page.goBack();
+
+    await ionPageDoesNotExist(page, 'tab1childone');
+    await ionPageVisible(page, 'tab1');
+    await expect(page).toHaveURL(/\/tabs\/tab1(\?|$)/);
+    await expect(page.locator('ion-tab-button#tab-button-tab1')).toHaveClass(/tab-selected/);
+
+    // After the URL sync, tab navigation should still work: switching to
+    // tab2 and back to tab1 must restore the tab1 root cleanly.
+    await tabClick(page, 'tab2');
+    await ionPageVisible(page, 'tab2');
+
+    await tabClick(page, 'tab1');
+    await ionPageVisible(page, 'tab1');
+  });
+});


### PR DESCRIPTION
Issue number: resolves #25141

---------

## What is the current behavior?

Navigate from `/tabs/tab1` into `/tabs/tab1/childone`, click Tab 2, then click Tab 1 again. Tab 1's child page is re-activated. Press the browser back button and the URL becomes `/tabs/tab2`, but `ion-router-outlet` still shows `tab1`. URL and displayed page are out of sync.

The pop branch in `handleHistoryChange` doesn't notice that the browser's linear predecessor and the in-tab back target are different, so the new routeInfo grabs its pathname from `location.path` while the outlet renders the incorrect view

## What is the new behavior?

When the pop destination differs from the in-tab back target and either side is in a tab context, the router calls `handleNavigate` to replace the URL with the in-tab predecessor's pathname. The outlet keeps rendering the in-tab page and the URL now matches what you see

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Companion to the React Router 6 fix in [#30831](https://github.com/ionic-team/ionic-framework/pull/30831), which fixed the problem in Ionic React Router