### PR TITLE
fix(vue-router): prevent out-of-bounds index when popping across tabs

### DIFF
--- a/packages/vue-router/src/viewStacks.ts
+++ b/packages/vue-router/src/viewStacks.ts
@@ -196,8 +196,15 @@ export const createViewStacks = (router: Router) => {
     if (!viewStack) return;
 
     const startIndex = viewStack.findIndex((v) => v === viewItem);
+    if (startIndex === -1) return;
 
-    for (let i = startIndex + 1; i < startIndex - delta; i++) {
+    // delta from popstate reflects browser history depth, which can exceed
+    // the outlet's view stack when tab switches build up history without
+    // adding new view items. Clamp to the stack length so we never index
+    // past the end of the array.
+    const endIndex = Math.min(viewStack.length, startIndex - delta);
+
+    for (let i = startIndex + 1; i < endIndex; i++) {
       const viewItem = viewStack[i];
       viewItem.mount = false;
       viewItem.ionPageElement = undefined;
@@ -233,8 +240,11 @@ export const createViewStacks = (router: Router) => {
     if (!viewStack) return;
 
     const startIndex = viewStack.findIndex((v) => v === viewItem);
+    if (startIndex === -1) return;
 
-    for (let i = startIndex + 1; i < startIndex + delta; i++) {
+    const endIndex = Math.min(viewStack.length, startIndex + delta);
+
+    for (let i = startIndex + 1; i < endIndex; i++) {
       viewStack[i].mount = true;
     }
   };

--- a/packages/vue/test/base/tests/unit/tabs-single-outlet.spec.ts
+++ b/packages/vue/test/base/tests/unit/tabs-single-outlet.spec.ts
@@ -1,0 +1,144 @@
+import { enableAutoUnmount, mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRouter, createWebHistory } from '@ionic/vue-router';
+import {
+  IonicVue,
+  IonApp,
+  IonRouterOutlet,
+  IonPage,
+  IonTabs,
+  IonTabBar,
+  IonTabButton,
+  IonLabel,
+} from '@ionic/vue';
+import { waitForRouter } from './utils';
+
+enableAutoUnmount(afterEach);
+
+/**
+ * Reproduces the apps-without-an-outer-outlet shape: <ion-tabs> mounted at
+ * the root of the app, with the inner <ion-router-outlet> as the ONLY outlet
+ * in the viewStacks. With this shape, `usingLinearNavigation` (size === 1) is
+ * true, so unmountLeavingViews / mountIntermediaryViews are invoked when
+ * router.go(-N) crosses tabs. Several visits across tabs can grow the
+ * popstate delta beyond the inner outlet's stack length, exposing
+ * out-of-bounds reads in those helpers.
+ */
+
+const makeTabPage = (id: string) => ({
+  template: `<ion-page :data-pageid="'${id}'"></ion-page>`,
+  components: { IonPage },
+});
+
+const Tab1 = makeTabPage('tab1');
+const Tab1Sub = makeTabPage('tab1sub');
+const Tab2 = makeTabPage('tab2');
+const Tab2Sub = makeTabPage('tab2sub');
+const Tab3 = makeTabPage('tab3');
+const Tab3Sub = makeTabPage('tab3sub');
+
+const TabsApp = {
+  components: {
+    IonApp,
+    IonTabs,
+    IonTabBar,
+    IonTabButton,
+    IonLabel,
+    IonRouterOutlet,
+  },
+  template: `
+    <ion-app>
+      <ion-tabs>
+        <ion-router-outlet />
+        <ion-tab-bar slot="bottom">
+          <ion-tab-button tab="tab1" href="/tab1"><ion-label>Tab 1</ion-label></ion-tab-button>
+          <ion-tab-button tab="tab2" href="/tab2"><ion-label>Tab 2</ion-label></ion-tab-button>
+          <ion-tab-button tab="tab3" href="/tab3"><ion-label>Tab 3</ion-label></ion-tab-button>
+        </ion-tab-bar>
+      </ion-tabs>
+    </ion-app>
+  `,
+};
+
+const buildRouter = () =>
+  createRouter({
+    history: createWebHistory(process.env.BASE_URL),
+    routes: [
+      { path: '/', redirect: '/tab1' },
+      { path: '/tab1', component: Tab1 },
+      { path: '/tab1/sub', component: Tab1Sub },
+      { path: '/tab2', component: Tab2 },
+      { path: '/tab2/sub', component: Tab2Sub },
+      { path: '/tab3', component: Tab3 },
+      { path: '/tab3/sub', component: Tab3Sub },
+    ],
+  });
+
+describe('ion-tabs at root (single outlet)', () => {
+  it('does not throw when navigating across tabs and sub-pages', async () => {
+    const router = buildRouter();
+
+    // Capture both Vue runtime errors and unhandled promise rejections.
+    // `unmountLeavingViews` runs inside a Vue reactive effect, so a throw
+    // ends up as a Promise rejection rather than a synchronous error.
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errors: unknown[] = [];
+    const onWindowUnhandled = (event: { reason?: unknown; preventDefault?: () => void }) => {
+      errors.push(event.reason ?? event);
+      event.preventDefault?.();
+    };
+    const onProcessUnhandled = (reason: unknown) => {
+      errors.push(reason);
+    };
+    (globalThis as any).addEventListener('unhandledrejection', onWindowUnhandled);
+    (process as any).on('unhandledRejection', onProcessUnhandled);
+
+    try {
+      router.push('/tab1');
+      await router.isReady();
+
+      mount(TabsApp, {
+        global: {
+          plugins: [router, IonicVue],
+          config: {
+            errorHandler: (err: unknown) => {
+              errors.push(err);
+            },
+          },
+        },
+      });
+      await waitForRouter();
+
+      // Build up browser history across tabs and sub-pages, the way the
+      // customer's repro does. Each push adds a history entry while reusing
+      // any existing view item for the destination route.
+      router.push('/tab1/sub'); await waitForRouter();
+      router.push('/tab2');     await waitForRouter();
+      router.push('/tab3');     await waitForRouter();
+      router.push('/tab3/sub'); await waitForRouter();
+      router.push('/tab2');     await waitForRouter();
+      router.push('/tab1/sub'); await waitForRouter();
+
+      // Now: history position is large (7+), but the inner outlet's view stack
+      // only ever held [tab1, tab1sub, tab2, tab3, tab3sub] at most. Jump back
+      // to /tab1 with a delta that exceeds the stack-above-startIndex count.
+      router.go(-6);
+      await waitForRouter();
+
+      // Give any pending microtasks/promise rejections a chance to flush.
+      await waitForRouter();
+    } finally {
+      consoleErrorSpy.mockRestore();
+      (globalThis as any).removeEventListener('unhandledrejection', onWindowUnhandled);
+      (process as any).off('unhandledRejection', onProcessUnhandled);
+    }
+
+    // Any error thrown during the navigation above is a regression for this
+    // scenario; the original bug surfaced as a TypeError from indexing past
+    // the end of the inner outlet's view stack.
+    expect(
+      errors,
+      `errors: ${errors.map((e) => (e instanceof Error ? e.stack : String(e))).join('\n')}`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Issue number: resolves #29413

---------

## What is the current behavior?

In `viewStacks.ts`, `unmountLeavingViews` and `mountIntermediaryViews` walk the outlet's view stack using `startIndex - delta` (or `startIndex + delta`) as the loop end, with no bound on `viewStack.length`. `delta` comes from the popstate event's history delta. Apps that mount `<ion-tabs>` at the root with no outer `<ion-router-outlet>` only have one outlet registered, so `usingLinearNavigation` is true and these helpers actually run. Each tab switch adds a browser history entry but reuses existing view items, so `|delta|` can easily exceed the stack depth above the entering view. The loop then reads `viewStack[i]` as `undefined` and throws `TypeError: viewItem is undefined` from `viewItem.mount = false`. The navigation aborts mid-transition, which is what surfaces the secondary `enteringEl is undefined` warning and leaves that route stuck

## What is the new behavior?

Both helpers bail when the entering view item isn't in the stack (`startIndex === -1`) and clamp the loop end to `Math.min(viewStack.length, ...)`, so a delta that overruns the stack stops at the last real view item instead of indexing past the end. A new Vitest spec at `packages/vue/test/base/tests/unit/tabs-single-outlet.spec.ts` mounts `<ion-tabs>` as the app root with flat routes, builds up history across tabs and sub-pages, then calls `router.go(-6)`. Without the fix the spec catches the unhandled `TypeError` from `viewStacks.ts`

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

Current dev build:
```
8.8.7-dev.11778707797.1723d277
```