### PR TITLE
fix(react-router): symmetric pathname+search url comparison

### DIFF
--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -107,7 +107,8 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
     }
 
     const leavingUrl = leavingLocationInfo.pathname + leavingLocationInfo.search;
-    if (leavingUrl !== location.pathname) {
+    const currentUrl = location.pathname + (location.search || '');
+    if (leavingUrl !== currentUrl) {
       if (!this.incomingRouteParams) {
         if (action === 'REPLACE') {
           this.incomingRouteParams = {

--- a/packages/react-router/src/ReactRouter/IonRouter.tsx
+++ b/packages/react-router/src/ReactRouter/IonRouter.tsx
@@ -84,10 +84,15 @@ class IonRouterInner extends React.PureComponent<IonRouteProps, IonRouteState> {
         this.incomingRouteParams.routeOptions = routeOptions;
         this.props.history.push(routeInfo.pathname + (routeInfo.search || ''));
       } else {
+        /**
+         * The recorded search has to match the URL we push, otherwise
+         * handleHistoryChange sees a URL change where there is none.
+         */
+        const normalizedSearch = search ? '?' + search : '';
         this.incomingRouteParams.pathname = pathname;
-        this.incomingRouteParams.search = search ? '?' + search : undefined;
+        this.incomingRouteParams.search = normalizedSearch;
         this.incomingRouteParams.routeOptions = routeOptions;
-        this.props.history.push(pathname + (search ? '?' + search : ''));
+        this.props.history.push(pathname + normalizedSearch);
       }
     } else {
       this.handleNavigate(pathname, 'push', 'none', undefined, routeOptions, tab);

--- a/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
+++ b/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
@@ -344,6 +344,25 @@ describe('Routing Tests', () => {
     cy.get('div.ion-page[data-pageid=home-details-page-1] [data-testid="details-input"]').should('have.value', '1');
   });
 
+  it('Details 1 with Query Params > pop a same-URL history entry, should stay on details 1', () => {
+    // Regression: popstate over a same-URL entry on a search-bearing route used to trigger a false POP transition.
+    cy.visit(`http://localhost:${port}/routing`);
+    cy.ionNav('ion-item', 'Details 1 with Query Params');
+    cy.ionPageVisible('home-details-page-1');
+    cy.location('search').should('eq', '?hello=there');
+
+    cy.window().then((win) => {
+      win.history.pushState({ marker: true }, '', win.location.href);
+    });
+
+    cy.go('back');
+
+    // No teleport: still on details 1, URL unchanged.
+    cy.ionPageVisible('home-details-page-1');
+    cy.location('pathname').should('eq', '/routing/tabs/home/details/1');
+    cy.location('search').should('eq', '?hello=there');
+  });
+
   /*
     Tests to add:
     Test that lifecycle events fire

--- a/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
+++ b/packages/react-router/test/base/tests/e2e/specs/routing.cy.js
@@ -250,7 +250,7 @@ describe('Routing Tests', () => {
   it('/routing/ > Details 1 > Details 2 > Details 3 > Back > Settings Tab > Home Tab > Should be at details 2 page', () => {
     // fixes an issue where route history was being lost after starting to go back, switching tabs
     // and switching back to the same tab again
-    // for bug https://github.com/ionic-team/ionic-framework/issues/21834
+    // For bug https://github.com/ionic-team/ionic-framework/issues/21834
     cy.visit(`http://localhost:${port}/routing`);
     cy.ionPageVisible('home-page');
     cy.ionNav('ion-item', 'Details 1');
@@ -346,6 +346,7 @@ describe('Routing Tests', () => {
 
   it('Details 1 with Query Params > pop a same-URL history entry, should stay on details 1', () => {
     // Regression: popstate over a same-URL entry on a search-bearing route used to trigger a false POP transition.
+    // For bug https://github.com/ionic-team/ionic-framework/issues/31152
     cy.visit(`http://localhost:${port}/routing`);
     cy.ionNav('ion-item', 'Details 1 with Query Params');
     cy.ionPageVisible('home-details-page-1');
@@ -357,10 +358,49 @@ describe('Routing Tests', () => {
 
     cy.go('back');
 
-    // No teleport: still on details 1, URL unchanged.
+    // Wait for a late teleport, otherwise the assertions pass against the pre-transition state.
+    cy.wait(1000);
+
     cy.ionPageVisible('home-details-page-1');
+    cy.ionPageHidden('home-page');
     cy.location('pathname').should('eq', '/routing/tabs/home/details/1');
     cy.location('search').should('eq', '?hello=there');
+  });
+
+  it('Details 1 > Settings Details 1 > Back > Settings Tab > pop a same-URL history entry, should stay on settings', () => {
+    // Regression: switching to a tab recorded a route with no search, so a popstate over a
+    // same-URL entry used to teleport to the home tab.
+    // For bug https://github.com/ionic-team/ionic-framework/issues/31152
+    cy.visit(`http://localhost:${port}/routing`);
+    cy.ionNav('ion-item', 'Details 1');
+    cy.ionPageVisible('home-details-page-1');
+
+    cy.ionNav('ion-button', 'Go to Settings Details 1');
+    cy.ionPageVisible('settings-details-page-1');
+
+    cy.go('back');
+    cy.ionPageVisible('home-details-page-1');
+
+    cy.ionTabClick('Settings');
+    cy.ionPageVisible('settings-page');
+    cy.location('pathname').should('eq', '/routing/tabs/settings');
+
+    // Let the tab switch finish so the pop doesn't race the transition.
+    cy.wait(1000);
+
+    cy.window().then((win) => {
+      win.history.pushState({ marker: true }, '', win.location.href);
+    });
+
+    cy.go('back');
+
+    // Wait for a late teleport, otherwise the assertions pass against the pre-transition state.
+    cy.wait(1000);
+
+    cy.ionPageVisible('settings-page');
+    cy.ionPageHidden('home-details-page-1');
+    cy.location('pathname').should('eq', '/routing/tabs/settings');
+    cy.location('search').should('eq', '');
   });
 
   /*


### PR DESCRIPTION
Issue number: resolves #31152

## What is the current behavior?

In `IonRouter.handleHistoryChange`, the URL-change guard compares mismatched operands:

```ts
const leavingUrl = leavingLocationInfo.pathname + leavingLocationInfo.search;
if (leavingUrl !== location.pathname) { ... }
```

The left side includes `search`, the right side does not. For any route with a non-empty query string, the comparison is **always** unequal, so the transition block runs on every history event — including no-op popstates over same-URL entries pushed via `window.history.pushState`.

Concretely: when a same-URL history entry on a search-bearing route is popped, `action === 'POP'` is processed and the IRO transitions to `currentRoute.pushedByRoute`. The browser URL doesn't change but the rendered view does — the user gets silently teleported to a different page in the stack.

Minimal repro: on any search-bearing route, run in the console:
```js
window.history.pushState({}, '', window.location.href);
window.history.back();
```
The current behavior swaps the rendered page to the previous entry in `locationHistory` while the URL stays put. Expected: no visible change.

Full repro and analysis in #31152. This is also the root cause behind the symptom reported in #25534 (framed there as a transition-rerender flash).

## What is the new behavior?

The right side of the comparison now also includes `search`, so the block only runs when the URL actually changed:

```ts
const leavingUrl = leavingLocationInfo.pathname + leavingLocationInfo.search;
const currentUrl = location.pathname + (location.search || '');
if (leavingUrl !== currentUrl) { ... }
```

Behavior matrix:
- Search-only navigations (e.g. `routerPush(samePath + newSearch)`): **unchanged** — pathname matches but search differs, block still runs.
- Pathname changes: **unchanged** — pathnames differ, block still runs.
- No-op popstates on search-bearing routes: **fixed** — pathname + search both match, block correctly skipped.

A new Cypress regression test is included (`packages/react-router/test/base/tests/e2e/specs/routing.cy.js`) that pushes a same-URL state on a search-bearing route, calls `history.back()`, and asserts the page does not teleport.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The comparison becomes stricter (skips the block in more cases than before), but only for the cases where the URL didn't actually change. All cases where the URL *did* change are still routed through the existing transition logic unchanged.

## Other information

Happy to iterate on the fix shape if there's a preferred alternative — e.g. gating behind a flag for backward compat, or restructuring the guard differently. The one-line change above is the smallest possible fix that keeps existing behavior for every "real URL change" case.