### PR TITLE
fix(tabs): preserve query params and fragment from tab button href

### DIFF
--- a/packages/angular/common/src/directives/navigation/tabs.ts
+++ b/packages/angular/common/src/directives/navigation/tabs.ts
@@ -10,7 +10,6 @@ import {
   AfterViewInit,
   QueryList,
 } from '@angular/core';
-
 import type { Params } from '@angular/router';
 
 import { NavController } from '../../providers/nav-controller';

--- a/packages/angular/common/src/directives/navigation/tabs.ts
+++ b/packages/angular/common/src/directives/navigation/tabs.ts
@@ -11,9 +11,53 @@ import {
   QueryList,
 } from '@angular/core';
 
+import type { Params } from '@angular/router';
+
 import { NavController } from '../../providers/nav-controller';
 
 import { StackDidChangeEvent, StackWillChangeEvent } from './stack-utils';
+
+/**
+ * Extracts `queryParams` and `fragment` from a tab button's href for use
+ * as Angular `NavigationExtras`. Returns `undefined` when neither is present.
+ */
+const parseHrefExtras = (href: string | undefined): { queryParams?: Params; fragment?: string } | undefined => {
+  if (!href) {
+    return undefined;
+  }
+
+  const hashIndex = href.indexOf('#');
+  // Treat a bare `#` (no fragment text) as no fragment.
+  const fragment = hashIndex >= 0 && hashIndex < href.length - 1 ? href.slice(hashIndex + 1) : undefined;
+  const beforeHash = hashIndex >= 0 ? href.slice(0, hashIndex) : href;
+
+  const queryIndex = beforeHash.indexOf('?');
+  const search = queryIndex >= 0 ? beforeHash.slice(queryIndex + 1) : '';
+
+  let queryParams: Params | undefined;
+  if (search) {
+    const params = new URLSearchParams(search);
+    queryParams = {};
+    for (const key of new Set(params.keys())) {
+      const all = params.getAll(key);
+      queryParams[key] = all.length > 1 ? all : all[0];
+    }
+  }
+
+  if (!queryParams && fragment === undefined) {
+    return undefined;
+  }
+
+  /**
+   * Build the result with only the populated keys so that a spread of the
+   * returned object does not overwrite saved `queryParams`/`fragment` with
+   * `undefined` (which `Object.assign`/spread would copy as a real key).
+   */
+  const extras: { queryParams?: Params; fragment?: string } = {};
+  if (queryParams) extras.queryParams = queryParams;
+  if (fragment !== undefined) extras.fragment = fragment;
+  return extras;
+};
 
 @Directive({
   selector: 'ion-tabs',
@@ -103,23 +147,26 @@ export abstract class IonTabs implements AfterViewInit, AfterContentInit, AfterC
    *
    *   a. Get the saved root view from the router outlet. If the saved root view
    *      matches the tabRootUrl, set the route view to this view including the
-   *      navigation extras.
-   *   b. If the saved root view from the router outlet does
-   *      not match, navigate to the tabRootUrl. No navigation extras are
-   *      included.
+   *      navigation extras. Any `queryParams` or `fragment` declared on the tab
+   *      button's `href` are also forwarded.
+   *   b. If the saved root view from the router outlet does not match, navigate
+   *      to the tabRootUrl, forwarding any `queryParams`/`fragment` declared on
+   *      the tab button's `href`.
    *
    * 2. If the current tab tab is not currently selected, get the last route
    *    view from the router outlet.
    *
    *   a. If the last route view exists, navigate to that view including any
-   *      navigation extras
-   *   b. If the last route view doesn't exist, then navigate
-   *      to the default tabRootUrl
+   *      navigation extras.
+   *   b. If the last route view doesn't exist, then navigate to the default
+   *      tabRootUrl, forwarding any `queryParams`/`fragment` declared on the
+   *      tab button's `href`.
    */
   @HostListener('ionTabButtonClick', ['$event'])
   select(tabOrEvent: string | CustomEvent): Promise<boolean> | undefined {
     const isTabString = typeof tabOrEvent === 'string';
     const tab = isTabString ? tabOrEvent : (tabOrEvent as CustomEvent).detail.tab;
+    const href: string | undefined = isTabString ? undefined : (tabOrEvent as CustomEvent).detail.href;
 
     /**
      * If the tabs are not using the router, then
@@ -135,6 +182,12 @@ export abstract class IonTabs implements AfterViewInit, AfterContentInit, AfterC
 
     const alreadySelected = this.outlet.getActiveStackId() === tab;
     const tabRootUrl = `${this.outlet.tabsPrefix}/${tab}`;
+
+    /**
+     * The href pathname is ignored here; tab routing is driven by `tabsPrefix/tab`.
+     * Only the query and fragment are forwarded as navigation extras.
+     */
+    const hrefExtras = parseHrefExtras(href);
 
     /**
      * If this is a nested tab, prevent the event
@@ -159,6 +212,7 @@ export abstract class IonTabs implements AfterViewInit, AfterContentInit, AfterC
       const navigationExtras = rootView && tabRootUrl === rootView.url && rootView.savedExtras;
       return this.navCtrl.navigateRoot(tabRootUrl, {
         ...navigationExtras,
+        ...hrefExtras,
         animated: true,
         animationDirection: 'back',
       });
@@ -166,10 +220,11 @@ export abstract class IonTabs implements AfterViewInit, AfterContentInit, AfterC
       const lastRoute = this.outlet.getLastRouteView(tab);
       /**
        * If there is a lastRoute, goto that, otherwise goto the fallback url of the
-       * selected tab
+       * selected tab. When falling back to the tab root, honor query params and
+       * fragment declared on the tab button's href.
        */
       const url = lastRoute?.url || tabRootUrl;
-      const navigationExtras = lastRoute?.savedExtras;
+      const navigationExtras = lastRoute?.savedExtras ?? (url === tabRootUrl ? hrefExtras : undefined);
 
       return this.navCtrl.navigateRoot(url, {
         ...navigationExtras,

--- a/packages/angular/test/base/e2e/src/standalone/tabs-search-params.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/tabs-search-params.spec.ts
@@ -56,4 +56,33 @@ test.describe('Tabs: query params on tab button href', () => {
     expect(new URL(page.url()).search).toBe('?foo=bar');
     await expect(page.locator('[data-testid="tab1-foo"]')).toHaveText('bar');
   });
+
+  test('should preserve multiple query params and fragment from tab button href', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab3"]').click();
+    await expect(page.locator('app-tabs-search-params-tab3')).toBeVisible();
+
+    const url = new URL(page.url());
+    expect(url.pathname).toBe('/standalone/tabs-search-params/tab3');
+    expect(url.search).toBe('?x=1&y=2');
+    expect(url.hash).toBe('#section');
+    await expect(page.locator('[data-testid="tab3-x"]')).toHaveText('1');
+    await expect(page.locator('[data-testid="tab3-y"]')).toHaveText('2');
+    await expect(page.locator('[data-testid="tab3-fragment"]')).toHaveText('section');
+  });
+
+  test('should preserve URL-encoded query params from tab button href', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab4"]').click();
+    await expect(page.locator('app-tabs-search-params-tab4')).toBeVisible();
+
+    const url = new URL(page.url());
+    expect(url.pathname).toBe('/standalone/tabs-search-params/tab4');
+    expect(url.searchParams.get('q')).toBe('hello world');
+    await expect(page.locator('[data-testid="tab4-q"]')).toHaveText('hello world');
+  });
 });

--- a/packages/angular/test/base/e2e/src/standalone/tabs-search-params.spec.ts
+++ b/packages/angular/test/base/e2e/src/standalone/tabs-search-params.spec.ts
@@ -1,0 +1,59 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Verifies that query params on an `<ion-tab-button>` href are preserved when
+ * the tab is activated (first visit, switching tabs, switching back, and
+ * re-clicking the already-active tab).
+ *
+ * @see https://github.com/ionic-team/ionic-framework/issues/25470
+ */
+test.describe('Tabs: query params on tab button href', () => {
+  test('should preserve query params on first visit to a tab', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+    expect(new URL(page.url()).pathname).toBe('/standalone/tabs-search-params/tab1');
+    expect(new URL(page.url()).search).toBe('?foo=bar');
+    await expect(page.locator('[data-testid="tab1-foo"]')).toHaveText('bar');
+    await expect(page.locator('ion-tab-button[data-testid="tab1"]')).toHaveClass(/tab-selected/);
+  });
+
+  test('should preserve href query params when switching to a tab for the first time', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab2"]').click();
+    await expect(page.locator('app-tabs-search-params-tab2')).toBeVisible();
+
+    expect(new URL(page.url()).pathname).toBe('/standalone/tabs-search-params/tab2');
+    expect(new URL(page.url()).search).toBe('?baz=qux');
+    await expect(page.locator('[data-testid="tab2-baz"]')).toHaveText('qux');
+    await expect(page.locator('ion-tab-button[data-testid="tab2"]')).toHaveClass(/tab-selected/);
+  });
+
+  test('should preserve query params when switching back to a previously visited tab', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab2"]').click();
+    await expect(page.locator('app-tabs-search-params-tab2')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab1"]').click();
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    expect(new URL(page.url()).pathname).toBe('/standalone/tabs-search-params/tab1');
+    expect(new URL(page.url()).search).toBe('?foo=bar');
+    await expect(page.locator('[data-testid="tab1-foo"]')).toHaveText('bar');
+  });
+
+  test('should preserve query params when re-clicking the already-active tab', async ({ page }) => {
+    await page.goto('/standalone/tabs-search-params/tab1?foo=bar');
+    await expect(page.locator('app-tabs-search-params-tab1')).toBeVisible();
+
+    await page.locator('ion-tab-button[data-testid="tab1"]').click();
+
+    expect(new URL(page.url()).pathname).toBe('/standalone/tabs-search-params/tab1');
+    expect(new URL(page.url()).search).toBe('?foo=bar');
+    await expect(page.locator('[data-testid="tab1-foo"]')).toHaveText('bar');
+  });
+});

--- a/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
+++ b/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
@@ -55,6 +55,15 @@ export const routes: Routes = [
         ]
       },
       { path: 'tabs-basic', loadComponent: () => import('../tabs-basic/tabs-basic.component').then(c => c.TabsBasicComponent) },
+      { path: 'tabs-search-params', redirectTo: '/standalone/tabs-search-params/tab1?foo=bar', pathMatch: 'full' },
+      {
+        path: 'tabs-search-params',
+        loadComponent: () => import('../tabs-search-params/tabs-search-params.component').then(c => c.TabsSearchParamsComponent),
+        children: [
+          { path: 'tab1', loadComponent: () => import('../tabs-search-params/tab1.component').then(c => c.TabsSearchParamsTab1Component) },
+          { path: 'tab2', loadComponent: () => import('../tabs-search-params/tab2.component').then(c => c.TabsSearchParamsTab2Component) }
+        ]
+      },
       {
         path: 'validation',
         children: [

--- a/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
+++ b/packages/angular/test/base/src/app/standalone/app-standalone/app.routes.ts
@@ -61,7 +61,9 @@ export const routes: Routes = [
         loadComponent: () => import('../tabs-search-params/tabs-search-params.component').then(c => c.TabsSearchParamsComponent),
         children: [
           { path: 'tab1', loadComponent: () => import('../tabs-search-params/tab1.component').then(c => c.TabsSearchParamsTab1Component) },
-          { path: 'tab2', loadComponent: () => import('../tabs-search-params/tab2.component').then(c => c.TabsSearchParamsTab2Component) }
+          { path: 'tab2', loadComponent: () => import('../tabs-search-params/tab2.component').then(c => c.TabsSearchParamsTab2Component) },
+          { path: 'tab3', loadComponent: () => import('../tabs-search-params/tab3.component').then(c => c.TabsSearchParamsTab3Component) },
+          { path: 'tab4', loadComponent: () => import('../tabs-search-params/tab4.component').then(c => c.TabsSearchParamsTab4Component) }
         ]
       },
       {

--- a/packages/angular/test/base/src/app/standalone/home-page/home-page.component.html
+++ b/packages/angular/test/base/src/app/standalone/home-page/home-page.component.html
@@ -79,6 +79,11 @@
         Tabs Basic Test
       </ion-label>
     </ion-item>
+    <ion-item routerLink="/standalone/tabs-search-params">
+      <ion-label>
+        Tabs Search Params Test
+      </ion-label>
+    </ion-item>
   </ion-list>
 
   <ion-list>

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tab1.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tab1.component.ts
@@ -1,0 +1,24 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-tabs-search-params-tab1',
+  template: `
+    <p>Tab 1</p>
+    <p data-testid="tab1-query">{{ queryString$ | async }}</p>
+    <p data-testid="tab1-foo">{{ foo$ | async }}</p>
+  `,
+  standalone: true,
+  imports: [AsyncPipe],
+})
+export class TabsSearchParamsTab1Component {
+  queryString$ = this.route.queryParamMap.pipe(
+    map((m) => m.keys.map((k) => `${k}=${m.get(k)}`).join('&'))
+  );
+
+  foo$ = this.route.queryParamMap.pipe(map((m) => m.get('foo') ?? ''));
+
+  constructor(private route: ActivatedRoute) {}
+}

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tab2.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tab2.component.ts
@@ -1,0 +1,24 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-tabs-search-params-tab2',
+  template: `
+    <p>Tab 2</p>
+    <p data-testid="tab2-query">{{ queryString$ | async }}</p>
+    <p data-testid="tab2-baz">{{ baz$ | async }}</p>
+  `,
+  standalone: true,
+  imports: [AsyncPipe],
+})
+export class TabsSearchParamsTab2Component {
+  queryString$ = this.route.queryParamMap.pipe(
+    map((m) => m.keys.map((k) => `${k}=${m.get(k)}`).join('&'))
+  );
+
+  baz$ = this.route.queryParamMap.pipe(map((m) => m.get('baz') ?? ''));
+
+  constructor(private route: ActivatedRoute) {}
+}

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tab3.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tab3.component.ts
@@ -1,0 +1,23 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-tabs-search-params-tab3',
+  template: `
+    <p>Tab 3</p>
+    <p data-testid="tab3-x">{{ x$ | async }}</p>
+    <p data-testid="tab3-y">{{ y$ | async }}</p>
+    <p data-testid="tab3-fragment">{{ fragment$ | async }}</p>
+  `,
+  standalone: true,
+  imports: [AsyncPipe],
+})
+export class TabsSearchParamsTab3Component {
+  x$ = this.route.queryParamMap.pipe(map((m) => m.get('x') ?? ''));
+  y$ = this.route.queryParamMap.pipe(map((m) => m.get('y') ?? ''));
+  fragment$ = this.route.fragment.pipe(map((f) => f ?? ''));
+
+  constructor(private route: ActivatedRoute) {}
+}

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tab4.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tab4.component.ts
@@ -1,0 +1,19 @@
+import { AsyncPipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
+import { map } from 'rxjs/operators';
+
+@Component({
+  selector: 'app-tabs-search-params-tab4',
+  template: `
+    <p>Tab 4</p>
+    <p data-testid="tab4-q">{{ q$ | async }}</p>
+  `,
+  standalone: true,
+  imports: [AsyncPipe],
+})
+export class TabsSearchParamsTab4Component {
+  q$ = this.route.queryParamMap.pipe(map((m) => m.get('q') ?? ''));
+
+  constructor(private route: ActivatedRoute) {}
+}

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tabs-search-params.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tabs-search-params.component.ts
@@ -26,6 +26,22 @@ addIcons({ square, triangle });
           <ion-icon name="square"></ion-icon>
           <ion-label>Tab 2</ion-label>
         </ion-tab-button>
+        <ion-tab-button
+          tab="tab3"
+          href="/standalone/tabs-search-params/tab3?x=1&y=2#section"
+          data-testid="tab3"
+        >
+          <ion-icon name="triangle"></ion-icon>
+          <ion-label>Tab 3</ion-label>
+        </ion-tab-button>
+        <ion-tab-button
+          tab="tab4"
+          href="/standalone/tabs-search-params/tab4?q=hello%20world"
+          data-testid="tab4"
+        >
+          <ion-icon name="square"></ion-icon>
+          <ion-label>Tab 4</ion-label>
+        </ion-tab-button>
       </ion-tab-bar>
     </ion-tabs>
   `,

--- a/packages/angular/test/base/src/app/standalone/tabs-search-params/tabs-search-params.component.ts
+++ b/packages/angular/test/base/src/app/standalone/tabs-search-params/tabs-search-params.component.ts
@@ -1,0 +1,35 @@
+import { Component } from '@angular/core';
+import { IonIcon, IonLabel, IonTabBar, IonTabButton, IonTabs } from '@ionic/angular/standalone';
+import { addIcons } from 'ionicons';
+import { square, triangle } from 'ionicons/icons';
+
+addIcons({ square, triangle });
+
+@Component({
+  selector: 'app-tabs-search-params',
+  template: `
+    <ion-tabs>
+      <ion-tab-bar slot="bottom">
+        <ion-tab-button
+          tab="tab1"
+          href="/standalone/tabs-search-params/tab1?foo=bar"
+          data-testid="tab1"
+        >
+          <ion-icon name="triangle"></ion-icon>
+          <ion-label>Tab 1</ion-label>
+        </ion-tab-button>
+        <ion-tab-button
+          tab="tab2"
+          href="/standalone/tabs-search-params/tab2?baz=qux"
+          data-testid="tab2"
+        >
+          <ion-icon name="square"></ion-icon>
+          <ion-label>Tab 2</ion-label>
+        </ion-tab-button>
+      </ion-tab-bar>
+    </ion-tabs>
+  `,
+  standalone: true,
+  imports: [IonIcon, IonLabel, IonTabBar, IonTabButton, IonTabs],
+})
+export class TabsSearchParamsComponent {}

--- a/packages/vue-router/src/router.ts
+++ b/packages/vue-router/src/router.ts
@@ -534,7 +534,18 @@ export const createIonRouter = (
     if (!path) return;
 
     const routeInfo = locationHistory.getCurrentRouteInfoForTab(tab);
-    const [pathname] = path.split("?");
+    /**
+     * Strip the fragment before parsing the query so that a `#frag` on the
+     * href cannot leak into the last query value or corrupt the pathname.
+     */
+    const hashIndex = path.indexOf("#");
+    const beforeHash = hashIndex >= 0 ? path.slice(0, hashIndex) : path;
+    const hrefHash =
+      hashIndex >= 0 && hashIndex < path.length - 1
+        ? path.slice(hashIndex)
+        : "";
+    const [pathname, search] = beforeHash.split("?");
+    const hrefSearch = search ? `?${search}` : "";
 
     if (routeInfo) {
       incomingRouteParams = {
@@ -550,17 +561,29 @@ export const createIonRouter = (
        * for the route info to be incorrect
        * as the tab you want is not the
        * tab you are on.
+       *
+       * If the incoming href carries its own query string, prefer that over
+       * the previously-saved search so query params on the tab button href
+       * are honored when re-selecting the tab.
        */
+      const effectiveSearch = hrefSearch || routeInfo.search;
+      const push = {
+        query: parseQuery(effectiveSearch),
+        ...(hrefHash ? { hash: hrefHash } : {}),
+      };
       if (routeInfo.pathname === pathname) {
-        router.push({
-          path: routeInfo.pathname,
-          query: parseQuery(routeInfo.search),
-        });
+        router.push({ path: routeInfo.pathname, ...push });
       } else {
-        router.push({ path: pathname, query: parseQuery(routeInfo.search) });
+        router.push({ path: pathname, ...push });
       }
     } else {
-      handleNavigate(pathname, "push", "none", undefined, tab);
+      handleNavigate(
+        pathname + hrefSearch + hrefHash,
+        "push",
+        "none",
+        undefined,
+        tab
+      );
     }
   };
 

--- a/packages/vue/src/components/IonTabBar.ts
+++ b/packages/vue/src/components/IonTabBar.ts
@@ -34,8 +34,16 @@ const matchesTab = (pathname: string, href: string | undefined): boolean => {
     return false;
   }
 
+  /**
+   * Compare pathnames only; an href like "/tabs/home?foo=bar#section" must
+   * still match a pathname of "/tabs/home". Strip the fragment first so a
+   * "#frag" containing "?" cannot leak into the pathname.
+   */
+  const hrefPathname = href.split("#")[0].split("?")[0];
   const normalizedHref =
-    href.endsWith("/") && href !== "/" ? href.slice(0, -1) : href;
+    hrefPathname.endsWith("/") && hrefPathname !== "/"
+      ? hrefPathname.slice(0, -1)
+      : hrefPathname;
   return (
     pathname === normalizedHref || pathname.startsWith(normalizedHref + "/")
   );

--- a/packages/vue/test/base/src/router/index.ts
+++ b/packages/vue/test/base/src/router/index.ts
@@ -180,6 +180,14 @@ const routes: Array<RouteRecordRaw> = [
       {
         path: 'tab2',
         component: () => import('@/views/tabs-search-params/Tab2.vue')
+      },
+      {
+        path: 'tab3',
+        component: () => import('@/views/tabs-search-params/Tab3.vue')
+      },
+      {
+        path: 'tab4',
+        component: () => import('@/views/tabs-search-params/Tab4.vue')
       }
     ]
   },

--- a/packages/vue/test/base/src/router/index.ts
+++ b/packages/vue/test/base/src/router/index.ts
@@ -166,6 +166,24 @@ const routes: Array<RouteRecordRaw> = [
     component: () => import('@/views/TabsBasic.vue')
   },
   {
+    path: '/tabs-search-params/',
+    component: () => import('@/views/tabs-search-params/TabsSearchParams.vue'),
+    children: [
+      {
+        path: '',
+        redirect: '/tabs-search-params/tab1?foo=bar'
+      },
+      {
+        path: 'tab1',
+        component: () => import('@/views/tabs-search-params/Tab1.vue')
+      },
+      {
+        path: 'tab2',
+        component: () => import('@/views/tabs-search-params/Tab2.vue')
+      }
+    ]
+  },
+  {
     path: '/tabs-similar-prefixes/',
     component: () => import('@/views/tabs-similar-prefixes/TabsSimilarPrefixes.vue'),
     children: [

--- a/packages/vue/test/base/src/views/Home.vue
+++ b/packages/vue/test/base/src/views/Home.vue
@@ -53,6 +53,9 @@
         <ion-item router-link="/tabs-similar-prefixes" id="tabs-similar-prefixes">
           <ion-label>Tabs with Similar Route Prefixes</ion-label>
         </ion-item>
+        <ion-item router-link="/tabs-search-params" id="tabs-search-params">
+          <ion-label>Tabs with Search Params on Href</ion-label>
+        </ion-item>
         <ion-item router-link="/lifecycle" id="lifecycle">
           <ion-label>Lifecycle</ion-label>
         </ion-item>

--- a/packages/vue/test/base/src/views/tabs-search-params/Tab1.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/Tab1.vue
@@ -1,0 +1,31 @@
+<template>
+  <ion-page data-pageid="tabs-search-params-tab1">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Tab 1</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div data-testid="tab1-query">{{ queryString }}</div>
+      <div data-testid="tab1-foo">{{ foo }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { computed, defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+
+export default defineComponent({
+  components: { IonContent, IonHeader, IonPage, IonTitle, IonToolbar },
+  setup() {
+    const route = useRoute();
+    const queryString = computed(() =>
+      new URLSearchParams(route.query as Record<string, string>).toString()
+    );
+    const foo = computed(() => (route.query.foo as string) ?? '');
+    return { queryString, foo };
+  },
+});
+</script>

--- a/packages/vue/test/base/src/views/tabs-search-params/Tab2.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/Tab2.vue
@@ -1,0 +1,31 @@
+<template>
+  <ion-page data-pageid="tabs-search-params-tab2">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Tab 2</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div data-testid="tab2-query">{{ queryString }}</div>
+      <div data-testid="tab2-baz">{{ baz }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { computed, defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+
+export default defineComponent({
+  components: { IonContent, IonHeader, IonPage, IonTitle, IonToolbar },
+  setup() {
+    const route = useRoute();
+    const queryString = computed(() =>
+      new URLSearchParams(route.query as Record<string, string>).toString()
+    );
+    const baz = computed(() => (route.query.baz as string) ?? '');
+    return { queryString, baz };
+  },
+});
+</script>

--- a/packages/vue/test/base/src/views/tabs-search-params/Tab3.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/Tab3.vue
@@ -1,0 +1,31 @@
+<template>
+  <ion-page data-pageid="tabs-search-params-tab3">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Tab 3</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div data-testid="tab3-x">{{ x }}</div>
+      <div data-testid="tab3-y">{{ y }}</div>
+      <div data-testid="tab3-hash">{{ hash }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { computed, defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+
+export default defineComponent({
+  components: { IonContent, IonHeader, IonPage, IonTitle, IonToolbar },
+  setup() {
+    const route = useRoute();
+    const x = computed(() => (route.query.x as string) ?? '');
+    const y = computed(() => (route.query.y as string) ?? '');
+    const hash = computed(() => route.hash ?? '');
+    return { x, y, hash };
+  },
+});
+</script>

--- a/packages/vue/test/base/src/views/tabs-search-params/Tab4.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/Tab4.vue
@@ -1,0 +1,27 @@
+<template>
+  <ion-page data-pageid="tabs-search-params-tab4">
+    <ion-header>
+      <ion-toolbar>
+        <ion-title>Tab 4</ion-title>
+      </ion-toolbar>
+    </ion-header>
+    <ion-content>
+      <div data-testid="tab4-q">{{ q }}</div>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import { IonContent, IonHeader, IonPage, IonTitle, IonToolbar } from '@ionic/vue';
+import { computed, defineComponent } from 'vue';
+import { useRoute } from 'vue-router';
+
+export default defineComponent({
+  components: { IonContent, IonHeader, IonPage, IonTitle, IonToolbar },
+  setup() {
+    const route = useRoute();
+    const q = computed(() => (route.query.q as string) ?? '');
+    return { q };
+  },
+});
+</script>

--- a/packages/vue/test/base/src/views/tabs-search-params/TabsSearchParams.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/TabsSearchParams.vue
@@ -1,0 +1,58 @@
+<template>
+  <ion-page data-pageid="tabs-search-params">
+    <ion-content>
+      <ion-tabs id="tabs-search-params">
+        <ion-router-outlet></ion-router-outlet>
+        <ion-tab-bar slot="bottom">
+          <ion-tab-button
+            tab="tab1"
+            href="/tabs-search-params/tab1?foo=bar"
+            data-testid="tab1"
+          >
+            <ion-icon :icon="triangle" />
+            <ion-label>Tab 1</ion-label>
+          </ion-tab-button>
+          <ion-tab-button
+            tab="tab2"
+            href="/tabs-search-params/tab2?baz=qux"
+            data-testid="tab2"
+          >
+            <ion-icon :icon="square" />
+            <ion-label>Tab 2</ion-label>
+          </ion-tab-button>
+        </ion-tab-bar>
+      </ion-tabs>
+    </ion-content>
+  </ion-page>
+</template>
+
+<script lang="ts">
+import {
+  IonContent,
+  IonIcon,
+  IonLabel,
+  IonPage,
+  IonRouterOutlet,
+  IonTabBar,
+  IonTabButton,
+  IonTabs,
+} from '@ionic/vue';
+import { square, triangle } from 'ionicons/icons';
+import { defineComponent } from 'vue';
+
+export default defineComponent({
+  components: {
+    IonContent,
+    IonIcon,
+    IonLabel,
+    IonPage,
+    IonRouterOutlet,
+    IonTabBar,
+    IonTabButton,
+    IonTabs,
+  },
+  setup() {
+    return { square, triangle };
+  },
+});
+</script>

--- a/packages/vue/test/base/src/views/tabs-search-params/TabsSearchParams.vue
+++ b/packages/vue/test/base/src/views/tabs-search-params/TabsSearchParams.vue
@@ -20,6 +20,22 @@
             <ion-icon :icon="square" />
             <ion-label>Tab 2</ion-label>
           </ion-tab-button>
+          <ion-tab-button
+            tab="tab3"
+            href="/tabs-search-params/tab3?x=1&y=2#section"
+            data-testid="tab3"
+          >
+            <ion-icon :icon="triangle" />
+            <ion-label>Tab 3</ion-label>
+          </ion-tab-button>
+          <ion-tab-button
+            tab="tab4"
+            href="/tabs-search-params/tab4?q=hello%20world"
+            data-testid="tab4"
+          >
+            <ion-icon :icon="square" />
+            <ion-label>Tab 4</ion-label>
+          </ion-tab-button>
         </ion-tab-bar>
       </ion-tabs>
     </ion-content>

--- a/packages/vue/test/base/tests/e2e/specs/tabs-search-params.cy.js
+++ b/packages/vue/test/base/tests/e2e/specs/tabs-search-params.cy.js
@@ -54,4 +54,30 @@ describe('Tabs: query params on tab button href', () => {
     cy.location('search').should('eq', '?foo=bar');
     cy.get('[data-testid="tab1-foo"]').should('have.text', 'bar');
   });
+
+  it('should preserve multiple query params and fragment from tab button href', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.get('ion-tab-button[data-testid="tab3"]').click();
+    cy.ionPageVisible('tabs-search-params-tab3');
+
+    cy.location('pathname').should('eq', '/tabs-search-params/tab3');
+    cy.location('search').should('eq', '?x=1&y=2');
+    cy.location('hash').should('eq', '#section');
+    cy.get('[data-testid="tab3-x"]').should('have.text', '1');
+    cy.get('[data-testid="tab3-y"]').should('have.text', '2');
+  });
+
+  it('should preserve URL-encoded query params from tab button href', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.get('ion-tab-button[data-testid="tab4"]').click();
+    cy.ionPageVisible('tabs-search-params-tab4');
+
+    cy.location('pathname').should('eq', '/tabs-search-params/tab4');
+    cy.location('search').should('eq', '?q=hello%20world');
+    cy.get('[data-testid="tab4-q"]').should('have.text', 'hello world');
+  });
 });

--- a/packages/vue/test/base/tests/e2e/specs/tabs-search-params.cy.js
+++ b/packages/vue/test/base/tests/e2e/specs/tabs-search-params.cy.js
@@ -1,0 +1,57 @@
+/**
+ * Verifies that query params set on an IonTabButton href are preserved when
+ * the tab is activated (first visit, switching tabs, switching back, and
+ * re-clicking the already-active tab).
+ *
+ * @see https://github.com/ionic-team/ionic-framework/issues/25470
+ */
+describe('Tabs: query params on tab button href', () => {
+  it('should preserve query params on first visit to a tab', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+
+    cy.ionPageVisible('tabs-search-params-tab1');
+    cy.location('pathname').should('eq', '/tabs-search-params/tab1');
+    cy.location('search').should('eq', '?foo=bar');
+    cy.get('[data-testid="tab1-foo"]').should('have.text', 'bar');
+    cy.get('ion-tab-button[data-testid="tab1"]').should('have.class', 'tab-selected');
+  });
+
+  it('should preserve href query params when switching to a tab for the first time', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.get('ion-tab-button[data-testid="tab2"]').click();
+    cy.ionPageVisible('tabs-search-params-tab2');
+
+    cy.location('pathname').should('eq', '/tabs-search-params/tab2');
+    cy.location('search').should('eq', '?baz=qux');
+    cy.get('[data-testid="tab2-baz"]').should('have.text', 'qux');
+    cy.get('ion-tab-button[data-testid="tab2"]').should('have.class', 'tab-selected');
+  });
+
+  it('should preserve query params when switching back to a previously visited tab', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.get('ion-tab-button[data-testid="tab2"]').click();
+    cy.ionPageVisible('tabs-search-params-tab2');
+
+    cy.get('ion-tab-button[data-testid="tab1"]').click();
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.location('pathname').should('eq', '/tabs-search-params/tab1');
+    cy.location('search').should('eq', '?foo=bar');
+    cy.get('[data-testid="tab1-foo"]').should('have.text', 'bar');
+  });
+
+  it('should preserve query params when re-clicking the already-active tab', () => {
+    cy.visit('/tabs-search-params/tab1?foo=bar');
+    cy.ionPageVisible('tabs-search-params-tab1');
+
+    cy.get('ion-tab-button[data-testid="tab1"]').click();
+
+    cy.location('pathname').should('eq', '/tabs-search-params/tab1');
+    cy.location('search').should('eq', '?foo=bar');
+    cy.get('[data-testid="tab1-foo"]').should('have.text', 'bar');
+  });
+});


### PR DESCRIPTION
Issue number: resolves #25470

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
When an `<ion-tab-button>` declares an `href` with a query string or fragment, activating the tab drops both. In Angular, `IonTabs.select` navigates to `tabsPrefix/tab` and never reads the button's `href`. In Vue, the router splits the path on `?` and discards everything after it, and `IonTabBar` compares the raw href against the pathname so a tab with query params never shows as selected. In React, this issue has been fixed as part of the RR6 migration.

## What is the new behavior?
Tab activation forwards the `href`'s query and fragment as navigation extras. A saved view's previously-captured extras still win when re-selecting a tab with prior history, so mid-stack state isn't clobbered. `IonTabBar`'s selection check now compares pathnames only, so a tab with a query string still highlights when its pathname is active.

Added Playwright coverage in `@ionic/angular` and Cypress coverage in `@ionic/vue` for first visit, switching tabs, switching back, and re-clicking the active tab. The Vue tests will cause a conflict on merging into major-9.0, but I volunteer to fix that issue when it comes up.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

Preview pages:
- Angular: https://ionic-framework-git-fw-7146-ionic1.vercel.app/angular/standalone/tabs-search-params/tab1?foo=bar
- Vue: https://ionic-framework-git-fw-7146-ionic1.vercel.app/vue/tabs-search-params/tab1?foo=bar
- React: This was fixed in the RR6 migration in V9. Unfortunately this won't be coming to 8.8 at this time.