### PR TITLE
fix(split-pane): inline default literal for when

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -1833,7 +1833,7 @@ ion-spinner,css-prop,--color
 ion-split-pane,shadow
 ion-split-pane,prop,contentId,string | undefined,undefined,false,true
 ion-split-pane,prop,disabled,boolean,false,false,false
-ion-split-pane,prop,when,boolean | string,QUERY['lg'],false,false
+ion-split-pane,prop,when,boolean | string,'(min-width: 992px)',false,false
 ion-split-pane,event,ionSplitPaneVisible,{ visible: boolean; },true
 ion-split-pane,css-prop,--border,ios
 ion-split-pane,css-prop,--border,md

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -3313,7 +3313,7 @@ export namespace Components {
         "isVisible": () => Promise<boolean>;
         /**
           * When the split-pane should be shown. Can be a CSS media query expression, or a shortcut expression. Can also be a boolean expression.
-          * @default QUERY['lg']
+          * @default '(min-width: 992px)'
          */
         "when": string | boolean;
     }
@@ -8683,7 +8683,7 @@ declare namespace LocalJSX {
         "onIonSplitPaneVisible"?: (event: IonSplitPaneCustomEvent<{ visible: boolean }>) => void;
         /**
           * When the split-pane should be shown. Can be a CSS media query expression, or a shortcut expression. Can also be a boolean expression.
-          * @default QUERY['lg']
+          * @default '(min-width: 992px)'
          */
         "when"?: string | boolean;
     }

--- a/core/src/components/split-pane/split-pane.tsx
+++ b/core/src/components/split-pane/split-pane.tsx
@@ -50,7 +50,7 @@ export class SplitPane implements ComponentInterface {
    * Can be a CSS media query expression, or a shortcut expression.
    * Can also be a boolean expression.
    */
-  @Prop() when: string | boolean = QUERY['lg'];
+  @Prop() when: string | boolean = '(min-width: 992px)';
 
   /**
    * Expression to be called when the split-pane visibility has changed


### PR DESCRIPTION
Issue number: resolves N/A

<!-- Surfaces from the failing Stencil Nightly Build #931:
  https://github.com/ionic-team/ionic-framework/actions/runs/26273945131 -->

---------

## What is the current behavior?

`IonSplitPane.when` is initialized to `QUERY['lg']`, where `QUERY` is a local `const` mapping shortcut keys to CSS media query strings.

An upcoming Stencil compiler change ([ionic-team/stencil#6728](https://github.com/ionic-team/stencil/pull/6728)) resolves `@Prop` default initializers that reference identifiers / property accesses / element accesses to their underlying primitive literal when generating `components.d.ts`. Once that change ships, a clean rebuild of `@ionic/core` will produce a `components.d.ts` whose `@default` JSDoc reads `'(min-width: 992px)'` instead of the committed `QUERY['lg']`, failing the `git diff --exit-code` guard in `test-core-clean-build`, `build-angular`, `build-vue`, and `build-react`.

The [Stencil Nightly Build (#931)](https://github.com/ionic-team/ionic-framework/actions/runs/26273945131) — which is pointed at Stencil's `main` — is already failing on exactly this diff:

```diff
-          * @default QUERY['lg']
+          * @default '(min-width: 992px)'
```

## What is the new behavior?

- `core/src/components/split-pane/split-pane.tsx`: inline the literal `'(min-width: 992px)'` as the prop default instead of dereferencing `QUERY['lg']`.
- `core/src/components.d.ts`: regenerate the two `@default` JSDoc lines (one in `Components`, one in `LocalJSX`) to match.

Both the current and upcoming Stencil compiler now emit identical output. Runtime behavior is unchanged: the shortcut lookup `QUERY[query] || query` continues to resolve user-supplied shortcuts (`'lg'`, `'md'`, etc.) via the `QUERY` map at the same place as before.

-
-
-

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

The default value is identical (`'(min-width: 992px)'` is exactly what `QUERY['lg']` evaluated to). Consumers passing the shortcut `'lg'`/`'md'`/etc. to `when` keep working unchanged.

## Other information

- Author note: I'm also the author of the Stencil PR ([ionic-team/stencil#6728](https://github.com/ionic-team/stencil/pull/6728)) that surfaced this drift. This Ionic-side change is forward-compatible — it works against both the current and the new Stencil compiler — so it can land independently of any Stencil release.
- Audit follow-up: a grep across `core/src/components` did not find any other `@Prop` default that uses an identifier / property / element access pattern, so `IonSplitPane` was the only affected component.