### PR TITLE
feat(toolbar): add hideOnScroll for header and footer toolbars

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -2785,6 +2785,7 @@ ion-toggle,part,track
 
 ion-toolbar,shadow
 ion-toolbar,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,undefined,false,true
+ion-toolbar,prop,hideOnScroll,boolean,false,false,false
 ion-toolbar,prop,mode,"ios" | "md",undefined,false,false
 ion-toolbar,prop,theme,"ios" | "md" | "ionic",undefined,false,false
 ion-toolbar,prop,titlePlacement,"center" | "end" | "start" | undefined,undefined,false,false

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -1517,7 +1517,7 @@ export namespace Components {
     }
     interface IonHeader {
         /**
-          * Describes the scroll effect that will be applied to the header. Only applies when the theme is `"ios"`.  Typically used for [Collapsible Large Titles](https://ionicframework.com/docs/api/title#collapsible-large-titles)
+          * Describes the scroll effect that will be applied to the header. Only applies when the theme is `"ios"`.  Typically used for [Collapsible Large Titles](https://ionicframework.com/docs/api/title#collapsible-large-titles)  When any child `ion-toolbar` has `hideOnScroll` set to `true`, the collapse behavior is skipped and `hideOnScroll` takes precedence.
          */
         "collapse"?: 'condense' | 'fade';
         /**
@@ -4505,6 +4505,11 @@ export namespace Components {
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
          */
         "color"?: Color;
+        /**
+          * If `true`, the toolbar will be hidden when the user scrolls down and shown when the user scrolls up.  Applies when the toolbar is inside an `ion-header` or `ion-footer` and a sibling `ion-content` exists on the same page. The header slides up and fades; the footer slides down. `ion-content` scroll insets are coordinated per edge so top and bottom toolbars can hide independently.  When the theme is `"ios"`, this takes precedence over `ion-header[collapse="condense" | "fade"]` if both are set on the same header.
+          * @default false
+         */
+        "hideOnScroll": boolean;
         /**
           * The mode determines the platform behaviors of the component.
          */
@@ -7565,7 +7570,7 @@ declare namespace LocalJSX {
     }
     interface IonHeader {
         /**
-          * Describes the scroll effect that will be applied to the header. Only applies when the theme is `"ios"`.  Typically used for [Collapsible Large Titles](https://ionicframework.com/docs/api/title#collapsible-large-titles)
+          * Describes the scroll effect that will be applied to the header. Only applies when the theme is `"ios"`.  Typically used for [Collapsible Large Titles](https://ionicframework.com/docs/api/title#collapsible-large-titles)  When any child `ion-toolbar` has `hideOnScroll` set to `true`, the collapse behavior is skipped and `hideOnScroll` takes precedence.
          */
         "collapse"?: 'condense' | 'fade';
         /**
@@ -10692,6 +10697,11 @@ declare namespace LocalJSX {
          */
         "color"?: Color;
         /**
+          * If `true`, the toolbar will be hidden when the user scrolls down and shown when the user scrolls up.  Applies when the toolbar is inside an `ion-header` or `ion-footer` and a sibling `ion-content` exists on the same page. The header slides up and fades; the footer slides down. `ion-content` scroll insets are coordinated per edge so top and bottom toolbars can hide independently.  When the theme is `"ios"`, this takes precedence over `ion-header[collapse="condense" | "fade"]` if both are set on the same header.
+          * @default false
+         */
+        "hideOnScroll"?: boolean;
+        /**
           * The mode determines the platform behaviors of the component.
          */
         "mode"?: "ios" | "md";
@@ -11506,6 +11516,7 @@ declare namespace LocalJSX {
     interface IonToolbarAttributes {
         "color": Color;
         "titlePlacement": 'start' | 'center' | 'end';
+        "hideOnScroll": boolean;
     }
 
     interface IntrinsicElements {

--- a/core/src/components/content/content.scss
+++ b/core/src/components/content/content.scss
@@ -1,4 +1,4 @@
-@import "../../themes/native/native.globals";
+@use "../../themes/native/native.globals" as globals;
 
 // Content
 // --------------------------------------------------
@@ -19,8 +19,8 @@
    * @prop --offset-top: Offset top of the content
    * @prop --offset-bottom: Offset bottom of the content
    */
-  --background: #{$background-color};
-  --color: #{$text-color};
+  --background: #{globals.$background-color};
+  --color: #{globals.$text-color};
   --padding-top: 0px;
   --padding-bottom: 0px;
   --padding-start: 0px;
@@ -44,7 +44,7 @@
   padding: 0 !important;
   /* stylelint-enable */
 
-  font-family: $font-family-base;
+  font-family: globals.$font-family-base;
 
   contain: size style;
 }
@@ -55,7 +55,7 @@
 }
 
 #background-content {
-  @include position(calc(var(--offset-top) * -1), 0px, calc(var(--offset-bottom) * -1), 0px);
+  @include globals.position(calc(var(--offset-top) * -1), 0px, calc(var(--offset-bottom) * -1), 0px);
 
   position: absolute;
 
@@ -63,8 +63,8 @@
 }
 
 .inner-scroll {
-  @include position(calc(var(--offset-top) * -1), 0px, calc(var(--offset-bottom) * -1), 0px);
-  @include padding(
+  @include globals.position(calc(var(--offset-top) * -1), 0px, calc(var(--offset-bottom) * -1), 0px);
+  @include globals.padding(
     calc(var(--padding-top) + var(--offset-top)),
     var(--padding-end),
     calc(
@@ -143,6 +143,79 @@
 
 .overscroll::after {
   top: -1px;
+}
+
+// Toolbar hide on scroll — ion-content coordination
+// --------------------------------------------------
+// Applied when `ion-toolbar` sets `hideOnScroll` on a page with sibling
+// `ion-content`. Header/footer overlay the viewport; scroll insets use
+// `--toolbar-hide-offset-*` (measured by ion-toolbar) and animatable
+// `--toolbar-hide-inset-*` so padding eases without layout jumps. Top and
+// bottom edges are independent (separate classes and CSS variables).
+
+@property --toolbar-hide-inset-top {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+@property --toolbar-hide-inset-bottom {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 0px;
+}
+
+:host(.content-toolbar-hide-offset-top),
+:host(.content-toolbar-hide-offset-bottom) {
+  #background-content,
+  .inner-scroll {
+    @include globals.position(0, 0, 0, 0);
+  }
+}
+
+// Top inset (header toolbar)
+:host(.content-toolbar-hide-offset-top) {
+  --toolbar-hide-inset-top: var(--toolbar-hide-offset-top, 0px);
+
+  transition: --toolbar-hide-inset-top var(--token-transition-time-300, 300ms)
+    var(--token-transition-curve-quick, cubic-bezier(0, 0, 0.2, 1));
+}
+
+:host(.content-toolbar-hide-offset-top.content-header-scroll-hidden) {
+  --toolbar-hide-inset-top: 0px;
+
+  transition: --toolbar-hide-inset-top var(--token-transition-time-200, 200ms)
+    var(--token-transition-curve-base, cubic-bezier(0.4, 0, 1, 1));
+}
+
+:host(.content-toolbar-hide-offset-top) .inner-scroll {
+  padding-top: calc(var(--padding-top) + var(--toolbar-hide-inset-top, 0px));
+}
+
+:host(.content-toolbar-hide-offset-top) #background-content {
+  padding-top: var(--toolbar-hide-inset-top, 0px);
+}
+
+// Bottom inset (footer toolbar)
+:host(.content-toolbar-hide-offset-bottom) {
+  --toolbar-hide-inset-bottom: var(--toolbar-hide-offset-bottom, 0px);
+
+  transition: --toolbar-hide-inset-bottom var(--token-transition-time-200, 200ms)
+    var(--token-transition-curve-spring, cubic-bezier(0.16, 1, 0.3, 1));
+}
+
+:host(.content-toolbar-hide-offset-bottom.content-footer-scroll-hidden) {
+  --toolbar-hide-inset-bottom: 0px;
+
+  transition: --toolbar-hide-inset-bottom var(--token-transition-time-350, 350ms)
+    var(--token-transition-curve-base, cubic-bezier(0.4, 0, 1, 1));
+}
+
+:host(.content-toolbar-hide-offset-bottom) .inner-scroll {
+  padding-bottom: calc(
+    var(--padding-bottom) + var(--keyboard-offset) + var(--toolbar-hide-inset-bottom, 0px) +
+      var(--internal-content-safe-area-padding-bottom, 0px)
+  );
 }
 
 :host(.content-sizing) {

--- a/core/src/components/footer/footer.scss
+++ b/core/src/components/footer/footer.scss
@@ -1,4 +1,4 @@
-@import "../../themes/native/native.globals";
+@use "../../themes/native/native.globals" as globals;
 
 // Footer
 // --------------------------------------------------
@@ -11,9 +11,28 @@ ion-footer {
 
   width: 100%;
 
-  z-index: $z-index-toolbar;
+  z-index: globals.$z-index-toolbar;
 }
 
 ion-footer.footer-toolbar-padding ion-toolbar:last-of-type {
   padding-bottom: var(--ion-safe-area-bottom, 0);
+}
+
+// Footer Hide on Scroll
+// --------------------------------------------------
+// Added by `ion-toolbar` when `hideOnScroll` is enabled. Overlays `ion-content`.
+
+ion-footer.ion-footer-hide-on-scroll {
+  @include globals.position(null, 0, 0, 0);
+  position: absolute;
+
+  transition: transform var(--token-transition-time-200, 200ms)
+    var(--token-transition-curve-spring, cubic-bezier(0.16, 1, 0.3, 1));
+}
+
+ion-footer.ion-footer-hide-on-scroll.footer-scroll-hidden {
+  transform: translateY(calc(100% + var(--ion-safe-area-bottom, 0)));
+
+  transition: transform var(--token-transition-time-350, 350ms)
+    var(--token-transition-curve-base, cubic-bezier(0.4, 0, 1, 1));
 }

--- a/core/src/components/header/header.common.scss
+++ b/core/src/components/header/header.common.scss
@@ -1,3 +1,5 @@
+@use "../../themes/native/native.globals" as globals;
+
 // Header
 // --------------------------------------------------
 
@@ -12,4 +14,25 @@ ion-header {
 
 ion-header ion-toolbar:first-of-type {
   padding-top: var(--ion-safe-area-top, 0);
+}
+
+// Header Hide on Scroll
+// --------------------------------------------------
+// Added by `ion-toolbar` when `hideOnScroll` is enabled. Overlays `ion-content`.
+
+ion-header.ion-header-hide-on-scroll {
+  @include globals.position(0, 0, null, 0);
+  position: absolute;
+
+  transition: transform var(--token-transition-time-300, 300ms)
+    var(--token-transition-curve-quick, cubic-bezier(0, 0, 0.2, 1));
+
+  z-index: 10;
+}
+
+ion-header.ion-header-hide-on-scroll.header-scroll-hidden {
+  transform: translateY(calc(-100% - var(--ion-safe-area-top, 0)));
+
+  transition: transform var(--token-transition-time-200, 200ms)
+    var(--token-transition-curve-base, cubic-bezier(0.4, 0, 1, 1));
 }

--- a/core/src/components/header/header.tsx
+++ b/core/src/components/header/header.tsx
@@ -45,6 +45,9 @@ export class Header implements ComponentInterface {
    * Only applies when the theme is `"ios"`.
    *
    * Typically used for [Collapsible Large Titles](https://ionicframework.com/docs/api/title#collapsible-large-titles)
+   *
+   * When any child `ion-toolbar` has `hideOnScroll` set to `true`, the collapse
+   * behavior is skipped and `hideOnScroll` takes precedence.
    */
   @Prop() collapse?: 'condense' | 'fade';
 
@@ -80,10 +83,20 @@ export class Header implements ComponentInterface {
     this.destroyCollapsibleHeader();
   }
 
+  private hasHideOnScrollToolbar(): boolean {
+    return Array.from(this.el.querySelectorAll('ion-toolbar')).some((toolbar) => toolbar.hideOnScroll);
+  }
+
   private async checkCollapsibleHeader() {
     const theme = getIonTheme(this);
 
     if (theme !== 'ios') {
+      return;
+    }
+
+    // Destroy the collapsible header when `hideOnScroll` is present.
+    if (this.hasHideOnScrollToolbar()) {
+      this.destroyCollapsibleHeader();
       return;
     }
 

--- a/core/src/components/toolbar/test/hide-on-scroll/index.html
+++ b/core/src/components/toolbar/test/hide-on-scroll/index.html
@@ -1,0 +1,169 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" mode="ionic">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Toolbar - Hide on Scroll</title>
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover"
+    />
+    <script src="../../../../../scripts/testing/scripts.js"></script>
+    <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
+    <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
+    <link rel="stylesheet" href="../../../../../css/ionic.bundle.css" />
+    <link rel="stylesheet" href="../../../../../scripts/testing/styles.css" />
+  </head>
+
+  <body>
+    <template id="header-template">
+      <ion-header id="test-header">
+        <ion-toolbar hide-on-scroll="true">
+          <ion-title>IonToolbar inside IonHeader</ion-title>
+        </ion-toolbar>
+      </ion-header>
+    </template>
+
+    <template id="footer-template">
+      <ion-footer id="test-footer">
+        <ion-toolbar hide-on-scroll="true">
+          <ion-title>IonToolbar inside IonFooter</ion-title>
+        </ion-toolbar>
+      </ion-footer>
+    </template>
+
+    <ion-app>
+      <div class="ion-page">
+        <ion-content>
+          <div class="spacer">
+            <div class="info">
+              <p>Scroll down to hide the toolbars, scroll up to show them.</p>
+              <p><strong>Requirements:</strong></p>
+              <ul>
+                <li><code>hide-on-scroll</code> must be set on <code>ion-toolbar</code></li>
+                <li>Toolbar must be inside an <code>ion-header</code> or <code>ion-footer</code></li>
+                <li>A sibling <code>ion-content</code> must exist for scroll detection</li>
+              </ul>
+            </div>
+            <div class="toolbar-layout">
+              <ion-toggle id="toggle-header" justify="space-between" checked>Header toolbar</ion-toggle>
+              <ion-toggle id="toggle-footer" justify="space-between" checked>Footer toolbar</ion-toggle>
+              <p class="toolbar-layout-hint" id="layout-hint">Header and footer toolbars</p>
+            </div>
+          </div>
+        </ion-content>
+      </div>
+    </ion-app>
+
+    <style>
+      .spacer {
+        position: relative;
+        padding: 16px;
+        height: 2000px;
+        background: linear-gradient(to bottom, #e0f7fa, #80deea, #26c6da, #00acc1, #00838f);
+      }
+
+      .info {
+        max-width: 90%;
+      }
+
+      .info p {
+        margin: 0;
+        margin-bottom: 12px;
+        font-size: 16px;
+        color: #333;
+      }
+
+      .toolbar-layout {
+        margin-top: 32px;
+        max-width: 320px;
+        padding: 16px;
+        border-radius: 12px;
+        background: rgba(255, 255, 255, 0.92);
+      }
+
+      .toolbar-layout ion-toggle {
+        display: block;
+      }
+
+      .toolbar-layout-hint {
+        margin: 4px 0 0;
+        font-size: 14px;
+        color: #555;
+      }
+    </style>
+
+    <script>
+      customElements.whenDefined('ion-toggle').then(() => {
+        const page = document.querySelector('.ion-page');
+        const content = page.querySelector('ion-content');
+        const headerTemplate = document.getElementById('header-template');
+        const footerTemplate = document.getElementById('footer-template');
+        const toggleHeader = document.getElementById('toggle-header');
+        const toggleFooter = document.getElementById('toggle-footer');
+        const layoutHint = document.getElementById('layout-hint');
+
+        const updateLayoutHint = (showHeader, showFooter) => {
+          if (showHeader && showFooter) {
+            layoutHint.textContent = 'Header and footer toolbars';
+          } else if (showHeader) {
+            layoutHint.textContent = 'Header toolbar only';
+          } else if (showFooter) {
+            layoutHint.textContent = 'Footer toolbar only';
+          } else {
+            layoutHint.textContent = 'No toolbars';
+          }
+        };
+
+        const mountHeader = () => {
+          if (document.getElementById('test-header')) {
+            return;
+          }
+
+          const header = headerTemplate.content.firstElementChild.cloneNode(true);
+          page.insertBefore(header, content);
+        };
+
+        const unmountHeader = () => {
+          document.getElementById('test-header')?.remove();
+        };
+
+        const mountFooter = () => {
+          if (document.getElementById('test-footer')) {
+            return;
+          }
+
+          const footer = footerTemplate.content.firstElementChild.cloneNode(true);
+          page.appendChild(footer);
+        };
+
+        const unmountFooter = () => {
+          document.getElementById('test-footer')?.remove();
+        };
+
+        const updateLayout = () => {
+          const showHeader = toggleHeader.checked;
+          const showFooter = toggleFooter.checked;
+
+          if (showHeader) {
+            mountHeader();
+          } else {
+            unmountHeader();
+          }
+
+          if (showFooter) {
+            mountFooter();
+          } else {
+            unmountFooter();
+          }
+
+          updateLayoutHint(showHeader, showFooter);
+        };
+
+        toggleHeader.addEventListener('ionChange', updateLayout);
+        toggleFooter.addEventListener('ionChange', updateLayout);
+
+        updateLayout();
+      });
+    </script>
+  </body>
+</html>

--- a/core/src/components/toolbar/toolbar.common.scss
+++ b/core/src/components/toolbar/toolbar.common.scss
@@ -97,3 +97,28 @@
 
   position: absolute;
 }
+
+// Toolbar: Hide on Scroll
+// --------------------------------------------------
+// Variant A: top (default, inside ion-header)
+//
+// Visible (default + scroll up): single 300ms transition with curve.quick.
+// Hidden  (scroll down): 200ms slide + 300ms fade, both with curve.base.
+
+:host(.toolbar-hide-on-scroll) {
+  transition: transform var(--token-transition-time-300, 300ms)
+      var(--token-transition-curve-quick, cubic-bezier(0, 0, 0.2, 1)),
+    opacity var(--token-transition-time-300, 300ms) var(--token-transition-curve-quick, cubic-bezier(0, 0, 0.2, 1));
+}
+
+:host(.toolbar-hide-on-scroll.toolbar-scroll-hidden) {
+  transition: opacity var(--token-transition-time-300, 300ms)
+    var(--token-transition-curve-base, cubic-bezier(0.4, 0, 1, 1));
+
+  opacity: 0;
+}
+
+// Variant B: bottom (inside ion-footer)
+//
+// The parent ion-footer handles the slide transform. Nothing to do here.
+// --------------------------------------------------

--- a/core/src/components/toolbar/toolbar.tsx
+++ b/core/src/components/toolbar/toolbar.tsx
@@ -1,5 +1,18 @@
 import type { ComponentInterface } from '@stencil/core';
-import { Component, Element, forceUpdate, h, Host, Listen, Prop, Watch } from '@stencil/core';
+import {
+  Component,
+  Element,
+  forceUpdate,
+  h,
+  Host,
+  Listen,
+  Prop,
+  readTask,
+  State,
+  Watch,
+  writeTask,
+} from '@stencil/core';
+import { findIonContent, getScrollElement } from '@utils/content';
 import { createColorClasses, hostContext } from '@utils/theme';
 
 import { getIonTheme } from '../../global/ionic-global';
@@ -29,7 +42,52 @@ import type { Color, CssClassMap, StyleEventDetail } from '../../interface';
   shadow: true,
 })
 export class Toolbar implements ComponentInterface {
+  /** Minimum cumulative downward scroll (px) before hiding the toolbar. */
+  private static readonly HIDE_ON_SCROLL_THRESHOLD = 24;
+
+  /** Debounce interval for container `ResizeObserver` callbacks. */
+  private static readonly CONTAINER_RESIZE_DEBOUNCE_MS = 100;
+
+  /**
+   * Refcount attribute on `ion-header` / `ion-footer` for `*-scroll-hidden` classes.
+   * Store how many hideOnScroll toolbars in the same header/footer are currently hidden.
+   */
+  private static readonly TOOLBAR_HIDE_COUNT_ATTR = 'data-toolbar-hide-count';
+
+  /** Refcount attributes on `ion-content` for offset coordination classes. */
+  private static readonly TOOLBAR_HIDE_OFFSET_TOP_COUNT_ATTR = 'data-toolbar-hide-offset-top-count';
+  private static readonly TOOLBAR_HIDE_OFFSET_BOTTOM_COUNT_ATTR = 'data-toolbar-hide-offset-bottom-count';
+
+  /**
+   * Scroll elements being adjusted programmatically.
+   * Ignored by scroll handlers to prevent hide/show feedback loops.
+   */
+  private static readonly programmaticScrollTargets = new WeakSet<HTMLElement>();
+
+  /**
+   * Shared scroll position per scroll element. Used when multiple toolbars on the
+   * same page listen to one `ion-content` scroll target.
+   */
+  private static readonly scrollLastTopByElement = new WeakMap<HTMLElement, number>();
+
+  /**
+   * One passive scroll listener per scroll element; fans out to every toolbar
+   * with `hideOnScroll` on the same page.
+   */
+  private static readonly scrollListeners = new WeakMap<
+    HTMLElement,
+    { callback: () => void; toolbars: Set<Toolbar> }
+  >();
+
   private childrenStyles = new Map<string, CssClassMap>();
+  private scrollEl?: HTMLElement;
+  private contentEl?: HTMLElement;
+  private cumulativeDownDelta = 0;
+  private containerEl?: HTMLElement;
+  private position: 'top' | 'bottom' = 'top';
+  private hideOnScrollActive = false;
+  private containerResizeObserver?: ResizeObserver;
+  private containerResizeDebounceId?: number;
   private readonly slotClasses = [
     'has-start-content',
     'has-end-content',
@@ -58,6 +116,30 @@ export class Toolbar implements ComponentInterface {
    */
   @Prop() titlePlacement?: 'start' | 'center' | 'end';
 
+  /**
+   * If `true`, the toolbar will be hidden when the user scrolls down
+   * and shown when the user scrolls up.
+   *
+   * Applies when the toolbar is inside an `ion-header` or `ion-footer`
+   * and a sibling `ion-content` exists on the same page. The header
+   * slides up and fades; the footer slides down.
+   * `ion-content` scroll insets are coordinated per edge so top and bottom toolbars can hide
+   * independently.
+   *
+   * When the theme is `"ios"`, this takes precedence over
+   * `ion-header[collapse="condense" | "fade"]` if both are set on the
+   * same header.
+   */
+  @Prop() hideOnScroll = false;
+
+  @State() scrollHidden = false;
+
+  @Watch('hideOnScroll')
+  hideOnScrollChanged() {
+    this.destroyHideOnScroll();
+    void this.setupHideOnScroll();
+  }
+
   componentWillLoad() {
     const buttons = Array.from(this.el.querySelectorAll('ion-buttons'));
 
@@ -83,6 +165,11 @@ export class Toolbar implements ComponentInterface {
   componentDidLoad() {
     this.updateSlotClasses();
     this.updateSlotWidths();
+    void this.setupHideOnScroll();
+  }
+
+  disconnectedCallback() {
+    this.destroyHideOnScroll();
   }
 
   @Watch('titlePlacement')
@@ -266,6 +353,403 @@ export class Toolbar implements ComponentInterface {
     return !!slotNode && slotNode.assignedNodes().length > 0;
   }
 
+  // ---------------------------------------------------------------------------
+  // Hide on scroll
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Locates the page `ion-content` used for scroll detection and inset coordination.
+   */
+  private findPageContent(): HTMLElement | null {
+    if (!this.containerEl) {
+      return null;
+    }
+
+    const pageEl = this.containerEl.closest('ion-page, .ion-page');
+    if (pageEl) {
+      return findIonContent(pageEl);
+    }
+
+    const parent = this.containerEl.parentElement;
+    if (parent) {
+      return findIonContent(parent);
+    }
+
+    return null;
+  }
+
+  /**
+   * Initializes scroll listening and coordinates `ion-content` insets when
+   * `hideOnScroll` is enabled inside `ion-header` or `ion-footer`.
+   */
+  private async setupHideOnScroll() {
+    if (!this.hideOnScroll) {
+      return;
+    }
+
+    const headerEl = this.el.closest('ion-header');
+    const footerEl = this.el.closest('ion-footer');
+
+    if (headerEl) {
+      this.containerEl = headerEl;
+      this.position = 'top';
+    } else if (footerEl) {
+      this.containerEl = footerEl;
+      this.position = 'bottom';
+    } else {
+      return;
+    }
+
+    const contentEl = this.findPageContent();
+
+    if (!contentEl) {
+      return;
+    }
+
+    this.contentEl = contentEl;
+    this.hideOnScrollActive = true;
+
+    const containerClass = this.position === 'top' ? 'ion-header-hide-on-scroll' : 'ion-footer-hide-on-scroll';
+    this.containerEl.classList.add(containerClass);
+
+    this.enableContentOffsetCoordination(true);
+    writeTask(() => this.updateContentOffsetSize());
+    this.observeContainerResize();
+
+    await this.initScrollListener(contentEl);
+  }
+
+  /**
+   * Keeps `--toolbar-hide-offset-*` in sync when the header/footer height changes.
+   */
+  private observeContainerResize() {
+    if (typeof ResizeObserver === 'undefined' || !this.containerEl) {
+      return;
+    }
+
+    this.containerResizeObserver = new ResizeObserver(() => {
+      if (this.containerResizeDebounceId !== undefined) {
+        clearTimeout(this.containerResizeDebounceId);
+      }
+
+      this.containerResizeDebounceId = window.setTimeout(() => {
+        this.containerResizeDebounceId = undefined;
+        writeTask(() => this.updateContentOffsetSize());
+      }, Toolbar.CONTAINER_RESIZE_DEBOUNCE_MS);
+    });
+    this.containerResizeObserver.observe(this.containerEl);
+  }
+
+  /** Get last known `scrollTop` for `scrollEl`. */
+  private static getScrollLastTop(scrollEl: HTMLElement) {
+    let lastScrollTop = Toolbar.scrollLastTopByElement.get(scrollEl);
+    if (lastScrollTop === undefined) {
+      lastScrollTop = scrollEl.scrollTop;
+      Toolbar.scrollLastTopByElement.set(scrollEl, lastScrollTop);
+    }
+    return lastScrollTop;
+  }
+
+  /** Update `scrollTop` after each scroll event for the given scroll element. */
+  private static setScrollLastTop(scrollEl: HTMLElement, scrollTop: number) {
+    Toolbar.scrollLastTopByElement.set(scrollEl, scrollTop);
+  }
+
+  /** Get element with the scrollable content inside `ion-content` and register it to the scroll listener. */
+  private async initScrollListener(contentEl: HTMLElement) {
+    const scrollEl = (this.scrollEl = await getScrollElement(contentEl));
+    this.registerScrollListener(scrollEl);
+  }
+
+  /**
+   * Register a scroll listener per scroll element and notify each toolbar that's active.
+   */
+  private registerScrollListener(scrollEl: HTMLElement) {
+    let entry = Toolbar.scrollListeners.get(scrollEl);
+
+    if (!entry) {
+      Toolbar.setScrollLastTop(scrollEl, scrollEl.scrollTop);
+
+      const callback = () => {
+        readTask(() => {
+          const scrollTop = scrollEl.scrollTop;
+
+          if (Toolbar.programmaticScrollTargets.has(scrollEl)) {
+            Toolbar.setScrollLastTop(scrollEl, scrollTop);
+            return;
+          }
+
+          const lastScrollTop = Toolbar.getScrollLastTop(scrollEl);
+          const deltaY = scrollTop - lastScrollTop;
+          Toolbar.setScrollLastTop(scrollEl, scrollTop);
+
+          Toolbar.scrollListeners.get(scrollEl)?.toolbars.forEach((toolbar) => {
+            toolbar.handleHideOnScrollDelta(deltaY);
+          });
+        });
+      };
+
+      scrollEl.addEventListener('scroll', callback, { passive: true });
+      entry = { callback, toolbars: new Set() };
+      Toolbar.scrollListeners.set(scrollEl, entry);
+    }
+
+    entry.toolbars.add(this);
+  }
+
+  /** Unset the scroll listener for the given scroll element. */
+  private unregisterScrollListener() {
+    if (!this.scrollEl) {
+      return;
+    }
+
+    const entry = Toolbar.scrollListeners.get(this.scrollEl);
+    if (!entry) {
+      return;
+    }
+
+    entry.toolbars.delete(this);
+
+    if (entry.toolbars.size === 0) {
+      this.scrollEl.removeEventListener('scroll', entry.callback);
+      Toolbar.scrollListeners.delete(this.scrollEl);
+      Toolbar.scrollLastTopByElement.delete(this.scrollEl);
+    }
+  }
+
+  /**
+   * Applies scroll delta for this toolbar (called from the shared listener).
+   */
+  private handleHideOnScrollDelta(deltaY: number) {
+    if (!this.hideOnScrollActive) {
+      return;
+    }
+
+    const shouldHide = this.checkScrollStatus(deltaY);
+
+    if (shouldHide !== this.scrollHidden) {
+      writeTask(() => {
+        this.setScrollHidden(shouldHide);
+      });
+    }
+  }
+
+  /**
+   * Remove scroll listeners, classes, and update state.
+   */
+  private destroyHideOnScroll() {
+    this.unregisterScrollListener();
+    this.scrollEl = undefined;
+
+    if (this.scrollHidden) {
+      this.setScrollHidden(false);
+    } else {
+      this.scrollHidden = false;
+    }
+
+    if (this.hideOnScrollActive && this.containerEl) {
+      const containerClass = this.position === 'top' ? 'ion-header-hide-on-scroll' : 'ion-footer-hide-on-scroll';
+      this.containerEl.classList.remove(containerClass);
+      this.containerEl.removeAttribute(Toolbar.TOOLBAR_HIDE_COUNT_ATTR);
+    }
+
+    this.enableContentOffsetCoordination(false);
+
+    if (this.containerResizeObserver) {
+      this.containerResizeObserver.disconnect();
+      this.containerResizeObserver = undefined;
+    }
+
+    if (this.containerResizeDebounceId !== undefined) {
+      clearTimeout(this.containerResizeDebounceId);
+      this.containerResizeDebounceId = undefined;
+    }
+
+    this.contentEl = undefined;
+    this.containerEl = undefined;
+    this.hideOnScrollActive = false;
+    this.cumulativeDownDelta = 0;
+  }
+
+  /**
+   * Update hidden state, scroll insets, and container/content classes.
+   */
+  private setScrollHidden(hidden: boolean) {
+    if (hidden === this.scrollHidden) {
+      return;
+    }
+
+    this.compensateScrollForInsetChange(hidden);
+    this.scrollHidden = hidden;
+    this.updateContainerAndContentClasses(hidden);
+  }
+
+  /**
+   * Adjust scroll position when the inset animates so visible content does not jump.
+   */
+  private compensateScrollForInsetChange(hidden: boolean) {
+    if (!this.scrollEl || !this.containerEl) {
+      return;
+    }
+
+    const insetDelta = this.containerEl.offsetHeight;
+    if (insetDelta <= 0) {
+      return;
+    }
+
+    const scrollEl = this.scrollEl;
+    Toolbar.programmaticScrollTargets.add(scrollEl);
+
+    if (this.position === 'top') {
+      if (hidden) {
+        scrollEl.scrollTop = Math.max(0, scrollEl.scrollTop - insetDelta);
+      } else {
+        scrollEl.scrollTop += insetDelta;
+      }
+      Toolbar.setScrollLastTop(scrollEl, scrollEl.scrollTop);
+    } else if (hidden) {
+      const maxScrollTop = scrollEl.scrollHeight - scrollEl.clientHeight;
+      scrollEl.scrollTop = Math.min(scrollEl.scrollTop, Math.max(0, maxScrollTop));
+      Toolbar.setScrollLastTop(scrollEl, scrollEl.scrollTop);
+    }
+
+    requestAnimationFrame(() => {
+      Toolbar.programmaticScrollTargets.delete(scrollEl);
+    });
+  }
+
+  /**
+   * Turns `ion-content` scroll inset coordination on or off for top/bottom.
+   *
+   * The header/footer overlays the viewport, so content needs extra padding.
+   * Top and bottom are counted separately so a page can have both header and footer
+   * `hideOnScroll` toolbars without one disabling the other.
+   */
+  private enableContentOffsetCoordination(enable: boolean) {
+    if (!this.contentEl || !this.containerEl) {
+      return;
+    }
+
+    const isTop = this.position === 'top';
+    // How many hide-on-scroll toolbars on this top/bottom
+    const countAttr = isTop
+      ? Toolbar.TOOLBAR_HIDE_OFFSET_TOP_COUNT_ATTR
+      : Toolbar.TOOLBAR_HIDE_OFFSET_BOTTOM_COUNT_ATTR;
+    // CSS class for top/bottom ion-content
+    const contentClass = isTop ? 'content-toolbar-hide-offset-top' : 'content-toolbar-hide-offset-bottom';
+    // CSS variable for height from header/footer
+    const offsetVar = isTop ? '--toolbar-hide-offset-top' : '--toolbar-hide-offset-bottom';
+    // CSS class for scroll-hidden state on ion-content
+    const hiddenClass = isTop ? 'content-header-scroll-hidden' : 'content-footer-scroll-hidden';
+
+    // How many hide-on-scroll toolbars on this top/bottom
+    const prevCount = parseInt(this.contentEl.getAttribute(countAttr) || '0', 10);
+    // Increment/decrement the count
+    const newCount = enable ? prevCount + 1 : Math.max(0, prevCount - 1);
+    this.contentEl.setAttribute(countAttr, String(newCount));
+
+    // First toolbar on this top/bottom
+    if (enable && prevCount === 0) {
+      this.contentEl.classList.add(contentClass);
+      this.updateContentOffsetSize();
+    } else if (!enable && newCount === 0) {
+      // Last toolbar on this top/bottom
+      this.contentEl.classList.remove(contentClass, hiddenClass);
+      this.contentEl.style.removeProperty(offsetVar);
+      this.contentEl.removeAttribute(countAttr);
+    }
+  }
+
+  /**
+   * Writes measured header/footer height to CSS variables on `ion-content`.
+   */
+  private updateContentOffsetSize() {
+    if (!this.contentEl || !this.containerEl) {
+      return;
+    }
+
+    const heightPx = this.containerEl.offsetHeight;
+    if (heightPx <= 0) {
+      return;
+    }
+
+    const offsetVar = this.position === 'top' ? '--toolbar-hide-offset-top' : '--toolbar-hide-offset-bottom';
+    const nextValue = `${heightPx}px`;
+    const currentValue = this.contentEl.style.getPropertyValue(offsetVar);
+
+    if (currentValue === nextValue) {
+      return;
+    }
+
+    this.contentEl.style.setProperty(offsetVar, nextValue);
+  }
+
+  /**
+   * Applies scroll-hidden UI for this toolbar's edge (header or footer).
+   *
+   * Uses `data-toolbar-hide-count` on the container so multiple `hideOnScroll`
+   * toolbars in the same header/footer only toggle classes when the last one
+   * hides or when the first one shows.
+   */
+  private updateContainerAndContentClasses(hidden: boolean) {
+    if (!this.hideOnScrollActive || !this.containerEl) {
+      return;
+    }
+
+    // Slide the header/footer off-screen
+    const hiddenClass = this.position === 'top' ? 'header-scroll-hidden' : 'footer-scroll-hidden';
+    // Collapse `ion-content` while hidden
+    const contentClass = this.position === 'top' ? 'content-header-scroll-hidden' : 'content-footer-scroll-hidden';
+    const countAttr = Toolbar.TOOLBAR_HIDE_COUNT_ATTR;
+    const prevCount = parseInt(this.containerEl.getAttribute(countAttr) || '0', 10);
+
+    if (hidden) {
+      const newCount = prevCount + 1;
+      this.containerEl.setAttribute(countAttr, String(newCount));
+
+      // First hidden toolbar on this container: enable hidden styles.
+      if (prevCount === 0) {
+        this.containerEl.classList.add(hiddenClass);
+        if (this.contentEl && !this.contentEl.classList.contains(contentClass)) {
+          this.contentEl.classList.add(contentClass);
+        }
+      }
+    } else {
+      const newCount = Math.max(0, prevCount - 1);
+      this.containerEl.setAttribute(countAttr, String(newCount));
+
+      // Last visible toolbar on this container: restore header/footer and inset.
+      if (newCount === 0) {
+        this.containerEl.classList.remove(hiddenClass);
+        if (this.contentEl?.classList.contains(contentClass)) {
+          this.contentEl.classList.remove(contentClass);
+        }
+        // Re-measure so `--toolbar-hide-offset-*` matches the shown toolbar height.
+        this.updateContentOffsetSize();
+      }
+    }
+  }
+
+  /**
+   * Returns whether the toolbar should be hidden for the current scroll delta.
+   */
+  private checkScrollStatus(deltaY: number): boolean {
+    if (deltaY < 0) {
+      this.cumulativeDownDelta = 0;
+      return false;
+    }
+
+    if (deltaY > 0) {
+      this.cumulativeDownDelta += deltaY;
+
+      if (this.cumulativeDownDelta >= Toolbar.HIDE_ON_SCROLL_THRESHOLD) {
+        return true;
+      }
+    }
+
+    return this.scrollHidden;
+  }
+
   @Listen('ionStyle')
   childrenStyle(ev: CustomEvent<StyleEventDetail>) {
     ev.stopPropagation();
@@ -301,6 +785,7 @@ export class Toolbar implements ComponentInterface {
     });
 
     const titlePlacement = this.getTitlePlacement();
+    const { hideOnScroll, scrollHidden, position } = this;
 
     return (
       <Host
@@ -310,6 +795,9 @@ export class Toolbar implements ComponentInterface {
             'in-toolbar': hostContext('ion-toolbar', this.el),
             [`toolbar-title-placement-${titlePlacement}`]: true,
           }),
+          'toolbar-hide-on-scroll': hideOnScroll,
+          'toolbar-scroll-hidden': scrollHidden,
+          'toolbar-hide-on-scroll-bottom': hideOnScroll && position === 'bottom',
           ...childStyles,
         }}
       >

--- a/core/src/components/toolbar/toolbar.tsx
+++ b/core/src/components/toolbar/toolbar.tsx
@@ -118,7 +118,7 @@ export class Toolbar implements ComponentInterface {
 
   /**
    * If `true`, the toolbar will be hidden when the user scrolls down
-   * and shown when the user scrolls up
+   * and shown when the user scrolls up.
    *
    * Applies when the toolbar is inside an `ion-header` or `ion-footer`
    * and a sibling `ion-content` exists on the same page. The header

--- a/core/src/components/toolbar/toolbar.tsx
+++ b/core/src/components/toolbar/toolbar.tsx
@@ -118,7 +118,7 @@ export class Toolbar implements ComponentInterface {
 
   /**
    * If `true`, the toolbar will be hidden when the user scrolls down
-   * and shown when the user scrolls up.
+   * and shown when the user scrolls up
    *
    * Applies when the toolbar is inside an `ion-header` or `ion-footer`
    * and a sibling `ion-content` exists on the same page. The header

--- a/packages/angular/src/directives/proxies.ts
+++ b/packages/angular/src/directives/proxies.ts
@@ -2658,14 +2658,14 @@ This event will not emit when programmatically setting the `checked` property.
 
 
 @ProxyCmp({
-  inputs: ['color', 'mode', 'theme', 'titlePlacement']
+  inputs: ['color', 'hideOnScroll', 'mode', 'theme', 'titlePlacement']
 })
 @Component({
   selector: 'ion-toolbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['color', 'mode', 'theme', 'titlePlacement'],
+  inputs: ['color', 'hideOnScroll', 'mode', 'theme', 'titlePlacement'],
 })
 export class IonToolbar {
   protected el: HTMLIonToolbarElement;

--- a/packages/angular/standalone/src/directives/proxies.ts
+++ b/packages/angular/standalone/src/directives/proxies.ts
@@ -2323,14 +2323,14 @@ Shorthand for ionToastDidDismiss.
 
 @ProxyCmp({
   defineCustomElementFn: defineIonToolbar,
-  inputs: ['color', 'mode', 'theme', 'titlePlacement']
+  inputs: ['color', 'hideOnScroll', 'mode', 'theme', 'titlePlacement']
 })
 @Component({
   selector: 'ion-toolbar',
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: '<ng-content></ng-content>',
   // eslint-disable-next-line @angular-eslint/no-inputs-metadata-property
-  inputs: ['color', 'mode', 'theme', 'titlePlacement'],
+  inputs: ['color', 'hideOnScroll', 'mode', 'theme', 'titlePlacement'],
   standalone: true
 })
 export class IonToolbar {

--- a/packages/vue/src/proxies.ts
+++ b/packages/vue/src/proxies.ts
@@ -1135,6 +1135,7 @@ export const IonToggle: StencilVueComponent<JSX.IonToggle, JSX.IonToggle["checke
 
 export const IonToolbar: StencilVueComponent<JSX.IonToolbar> = /*@__PURE__*/ defineContainer<JSX.IonToolbar>('ion-toolbar', defineIonToolbar, [
   'color',
-  'titlePlacement'
+  'titlePlacement',
+  'hideOnScroll'
 ]);
 


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

This pull request introduces the new `hideOnScroll` feature for `ion-toolbar`, enabling toolbars in header and footer to automatically hide and show based on scroll direction. 

**Hide on Scroll Feature for Toolbars:**

* Added `hideOnScroll` property to `ion-toolbar`, updating the API documentation and exposing it in Angular and Vue proxies, allowing toolbars to hide on scroll in both headers and footers. [[1]](diffhunk://#diff-5e21becb925e949068c3cbefae90d040401eaf39874bfd1336d93a3cd8d64809R2788) [[2]](diffhunk://#diff-1fd76195dbb521bd6fc15558ddb677c06cd4a94d7541ecdea25409b875ea71daL2661-R2668) [[3]](diffhunk://#diff-23bd4dda0490183f78acea6eb747bfab3091a16ce2e1d4710f4c194669597628L2326-R2333) [[4]](diffhunk://#diff-e8cbb9c3666e073d4a751535b38a9f64291e2643c76108796cf6d1e5799a90d9L1138-R1139)
* Implemented logic in `ion-header` to prioritize `hideOnScroll` over collapsible large titles, and to skip collapse behavior when `hideOnScroll` is present. [[1]](diffhunk://#diff-2310daf8d40f7af1cde67dd4577f96893d660c3b5bdeff03aec1d3aa7aa08fbbR48-R50) [[2]](diffhunk://#diff-2310daf8d40f7af1cde67dd4577f96893d660c3b5bdeff03aec1d3aa7aa08fbbR86-R102)
* Added tests and demo page for the hide-on-scroll toolbar functionality.

**Styling and Layout Enhancements:**

* Introduced new CSS and SCSS for header, footer, toolbar, and content to support smooth hide/show transitions and proper overlay behavior when `hideOnScroll` is active. [[1]](diffhunk://#diff-ca32a7f956c8f0ec26416437c4d92f2a755b928f56e072ce50dcd3f9d380bb86R148-R220) [[2]](diffhunk://#diff-e867ed36d2ac34f224ab75d1adb5cfc81c2912644ac3ec5c4aaab001fcfca7a8L14-R38) [[3]](diffhunk://#diff-955328e924080d4388ac3836fcc637997828f555e4265a9154a5340f72e42f60R18-R38) [[4]](diffhunk://#diff-dbf4ccf7c3209b0b39d7e40f7a569a1f0aa07146b4df5482ab42e852d509ac77R100-R124)

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->
