### PR TITLE
test(many): update controller tests to use correct import path

### DIFF
--- a/core/src/components/action-sheet/test/a11y/index.html
+++ b/core/src/components/action-sheet/test/a11y/index.html
@@ -11,7 +11,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { actionSheetController } from '../../../../dist/ionic/index.esm.js';
+    import { actionSheetController } from '../../../../../dist/ionic/index.esm.js';
     window.actionSheetController = actionSheetController;
   </script>
 

--- a/core/src/components/action-sheet/test/basic/index.html
+++ b/core/src/components/action-sheet/test/basic/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { actionSheetController } from '../../../../dist/ionic/index.esm.js';
+    import { actionSheetController } from '../../../../../dist/ionic/index.esm.js';
     window.actionSheetController = actionSheetController;
   </script>
 

--- a/core/src/components/action-sheet/test/standalone/index.html
+++ b/core/src/components/action-sheet/test/standalone/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { actionSheetController } from '../../../../dist/ionic/index.esm.js';
+    import { actionSheetController } from '../../../../../dist/ionic/index.esm.js';
     window.actionSheetController = actionSheetController;
   </script>
   <body>

--- a/core/src/components/action-sheet/test/translucent/index.html
+++ b/core/src/components/action-sheet/test/translucent/index.html
@@ -58,7 +58,7 @@
     </style>
   </head>
   <script type="module">
-    import { actionSheetController } from '../../../../dist/ionic/index.esm.js';
+    import { actionSheetController } from '../../../../../dist/ionic/index.esm.js';
     window.actionSheetController = actionSheetController;
   </script>
   <body>

--- a/core/src/components/alert/test/a11y/index.html
+++ b/core/src/components/alert/test/a11y/index.html
@@ -11,7 +11,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { alertController } from '../../../../dist/ionic/index.esm.js';
+    import { alertController } from '../../../../../dist/ionic/index.esm.js';
     window.alertController = alertController;
   </script>
 

--- a/core/src/components/alert/test/basic/index.html
+++ b/core/src/components/alert/test/basic/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { alertController, loadingController } from '../../../../dist/ionic/index.esm.js';
+    import { alertController, loadingController } from '../../../../../dist/ionic/index.esm.js';
     window.alertController = alertController;
     window.loadingController = loadingController;
   </script>

--- a/core/src/components/alert/test/standalone/index.html
+++ b/core/src/components/alert/test/standalone/index.html
@@ -23,7 +23,7 @@
     </style>
   </head>
   <script type="module">
-    import { alertController } from '../../../../dist/ionic/index.esm.js';
+    import { alertController } from '../../../../../dist/ionic/index.esm.js';
     window.alertController = alertController;
   </script>
 

--- a/core/src/components/alert/test/translucent/index.html
+++ b/core/src/components/alert/test/translucent/index.html
@@ -70,7 +70,7 @@
     </style>
   </head>
   <script type="module">
-    import { alertController } from '../../../../dist/ionic/index.esm.js';
+    import { alertController } from '../../../../../dist/ionic/index.esm.js';
     window.alertController = alertController;
   </script>
 

--- a/core/src/components/loading/test/standalone/index.html
+++ b/core/src/components/loading/test/standalone/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { loadingController } from '../../../../dist/ionic/index.esm.js';
+    import { loadingController } from '../../../../../dist/ionic/index.esm.js';
     window.loadingController = loadingController;
   </script>
   <body>

--- a/core/src/components/menu-button/test/async/index.html
+++ b/core/src/components/menu-button/test/async/index.html
@@ -13,7 +13,7 @@
     <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
     <script type="module">
-      import { menuController } from '../../../../dist/ionic/index.esm.js';
+      import { menuController } from '../../../../../dist/ionic/index.esm.js';
       window.menuController = menuController;
     </script>
   </head>

--- a/core/src/components/menu/test/a11y/index.html
+++ b/core/src/components/menu/test/a11y/index.html
@@ -11,7 +11,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { menuController } from '../../../../dist/ionic/index.esm.js';
+    import { menuController } from '../../../../../dist/ionic/index.esm.js';
     window.menuController = menuController;
   </script>
 

--- a/core/src/components/menu/test/basic/index.html
+++ b/core/src/components/menu/test/basic/index.html
@@ -30,7 +30,7 @@
     </style>
   </head>
   <script type="module">
-    import { menuController } from '../../../../dist/ionic/index.esm.js';
+    import { menuController } from '../../../../../dist/ionic/index.esm.js';
     window.menuController = menuController;
   </script>
 

--- a/core/src/components/menu/test/multiple/index.html
+++ b/core/src/components/menu/test/multiple/index.html
@@ -13,7 +13,7 @@
     <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
     <script type="module">
-      import { menuController } from '../../../../dist/ionic/index.esm.js';
+      import { menuController } from '../../../../../dist/ionic/index.esm.js';
       window.menuController = menuController;
     </script>
   </head>

--- a/core/src/components/menu/test/safe-area/index.html
+++ b/core/src/components/menu/test/safe-area/index.html
@@ -13,7 +13,7 @@
     <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
     <script type="module">
-      import { menuController } from '../../../../dist/ionic/index.esm.js';
+      import { menuController } from '../../../../../dist/ionic/index.esm.js';
       window.menuController = menuController;
     </script>
     <style>

--- a/core/src/components/modal/test/can-dismiss/index.html
+++ b/core/src/components/modal/test/can-dismiss/index.html
@@ -20,7 +20,7 @@
     </style>
   </head>
   <script type="module">
-    import { modalController, actionSheetController } from '../../../../dist/ionic/index.esm.js';
+    import { modalController, actionSheetController } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
     window.actionSheetController = actionSheetController;
   </script>

--- a/core/src/components/modal/test/card/index.html
+++ b/core/src/components/modal/test/card/index.html
@@ -26,7 +26,7 @@
     </style>
   </head>
   <script type="module">
-    import { modalController } from '../../../../dist/ionic/index.esm.js';
+    import { modalController } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
   </script>
 

--- a/core/src/components/modal/test/host-elements/index.html
+++ b/core/src/components/modal/test/host-elements/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { modalController } from '../../../../dist/ionic/index.esm.js';
+    import { modalController } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
   </script>
   <body>

--- a/core/src/components/modal/test/spec/index.html
+++ b/core/src/components/modal/test/spec/index.html
@@ -40,7 +40,7 @@
     </style>
   </head>
   <script type="module">
-    import { modalController, createAnimation } from '../../../../dist/ionic/index.esm.js';
+    import { modalController, createAnimation } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
     window.createAnimation = createAnimation;
   </script>

--- a/core/src/components/modal/test/standalone/index.html
+++ b/core/src/components/modal/test/standalone/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { modalController } from '../../../../dist/ionic/index.esm.js';
+    import { modalController } from '../../../../../dist/ionic/index.esm.js';
     window.modalController = modalController;
   </script>
   <body>

--- a/core/src/components/picker-legacy-column/test/standalone/index.html
+++ b/core/src/components/picker-legacy-column/test/standalone/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { pickerController } from '../../../../dist/ionic/index.esm.js';
+    import { pickerController } from '../../../../../dist/ionic/index.esm.js';
     window.pickerController = pickerController;
   </script>
 

--- a/core/src/components/picker-legacy/test/basic/index.html
+++ b/core/src/components/picker-legacy/test/basic/index.html
@@ -29,7 +29,7 @@
     </style>
   </head>
   <script type="module">
-    import { pickerController } from '../../../../dist/ionic/index.esm.js';
+    import { pickerController } from '../../../../../dist/ionic/index.esm.js';
     window.pickerController = pickerController;
   </script>
 

--- a/core/src/components/popover/test/adjustment/index.html
+++ b/core/src/components/popover/test/adjustment/index.html
@@ -13,7 +13,7 @@
     <script nomodule src="../../../../../dist/ionic/ionic.js"></script>
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
     <script type="module">
-      import { popoverController } from '../../../../dist/ionic/index.esm.js';
+      import { popoverController } from '../../../../../dist/ionic/index.esm.js';
       window.popoverController = popoverController;
     </script>
   </head>

--- a/core/src/components/popover/test/basic/index.html
+++ b/core/src/components/popover/test/basic/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { popoverController } from '../../../../dist/ionic/index.esm.js';
+    import { popoverController } from '../../../../../dist/ionic/index.esm.js';
     window.popoverController = popoverController;
   </script>
 

--- a/core/src/components/popover/test/size/index.html
+++ b/core/src/components/popover/test/size/index.html
@@ -41,7 +41,7 @@
     </style>
   </head>
   <script type="module">
-    import { popoverController } from '../../../../dist/ionic/index.esm.js';
+    import { popoverController } from '../../../../../dist/ionic/index.esm.js';
     window.popoverController = popoverController;
   </script>
 

--- a/core/src/components/popover/test/standalone/index.html
+++ b/core/src/components/popover/test/standalone/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { popoverController } from '../../../../dist/ionic/index.esm.js';
+    import { popoverController } from '../../../../../dist/ionic/index.esm.js';
     window.popoverController = popoverController;
   </script>
   <body>

--- a/core/src/components/toast/test/a11y/index.html
+++ b/core/src/components/toast/test/a11y/index.html
@@ -10,7 +10,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { toastController } from '../../../../dist/ionic/index.esm.js';
+    import { toastController } from '../../../../../dist/ionic/index.esm.js';
     window.toastController = toastController;
   </script>
 

--- a/core/src/components/toast/test/a11y/toast.e2e.ts
+++ b/core/src/components/toast/test/a11y/toast.e2e.ts
@@ -34,7 +34,7 @@ configs({ directions: ['ltr'], palettes: ['dark', 'light'] }).forEach(({ title, 
       await page.setContent(
         `
           <script type="module">
-            import { toastController } from '../../../../dist/ionic/index.esm.js';
+            import { toastController } from '../../../../../dist/ionic/index.esm.js';
             window.toastController = toastController;
           </script>
 

--- a/core/src/components/toast/test/basic/index.html
+++ b/core/src/components/toast/test/basic/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { toastController } from '../../../../dist/ionic/index.esm.js';
+    import { toastController } from '../../../../../dist/ionic/index.esm.js';
     window.toastController = toastController;
   </script>
   <body>

--- a/core/src/components/toast/test/buttons/index.html
+++ b/core/src/components/toast/test/buttons/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { toastController } from '../../../../dist/ionic/index.esm.js';
+    import { toastController } from '../../../../../dist/ionic/index.esm.js';
     window.toastController = toastController;
   </script>
   <body>

--- a/core/src/components/toast/test/layout/index.html
+++ b/core/src/components/toast/test/layout/index.html
@@ -14,7 +14,7 @@
     <script type="module" src="../../../../../dist/ionic/ionic.esm.js"></script>
   </head>
   <script type="module">
-    import { toastController } from '../../../../dist/ionic/index.esm.js';
+    import { toastController } from '../../../../../dist/ionic/index.esm.js';
     window.toastController = toastController;
   </script>
 

--- a/core/src/components/toast/test/standalone/index.html
+++ b/core/src/components/toast/test/standalone/index.html
@@ -21,7 +21,7 @@
     </style>
   </head>
   <script type="module">
-    import { toastController } from '../../../../dist/ionic/index.esm.js';
+    import { toastController } from '../../../../../dist/ionic/index.esm.js';
     window.toastController = toastController;
   </script>
   <body>


### PR DESCRIPTION
Many of the controller tests are using the wrong path to import the overlay controllers. This results in those tests not working in Vercel.

To reproduce the issue:

1. Open the [Action Sheet (main)](https://ionic-framework-git-main-ionic1.vercel.app/src/components/action-sheet/test/basic) preview
2. Attempt to open any Action Sheet
3. See the Action Sheet does not open and there is the following console error: `ReferenceError: actionSheetController is not defined`

To see it working:

1. Open the [Action Sheet (branch)](https://ionic-framework-git-test-vercel-controllers-ionic1.vercel.app/src/components/action-sheet/test/basic) preview
2. Attempt to open any Action Sheet
3. See the Action Sheet opens without any errors

This should be able to reproduce on any of the updated tests.