### PR TITLE
test: stabilize top infinite scroll e2e

### DIFF
--- a/core/src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts
+++ b/core/src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts
@@ -3,16 +3,26 @@ import { configs, test } from '@utils/test/playwright';
 
 configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('infinite-scroll: top'), () => {
-    test('should load more items when scrolled to the top', async ({ page, skip }) => {
-      // TODO(FW-6394): remove once flaky issue is resolved
-      skip.browser('webkit', 'Safari is flaky on CI');
-
+    test('should load more items when scrolled to the top', async ({ page }) => {
       await page.goto('/src/components/infinite-scroll/test/top', config);
 
       const ionInfiniteComplete = await page.spyOnEvent('ionInfiniteComplete');
       const content = page.locator('ion-content');
       const items = page.locator('ion-item');
       expect(await items.count()).toBe(30);
+
+      await content.evaluate(async (el: HTMLIonContentElement) => {
+        const scrollEl = await el.getScrollElement();
+        scrollEl.scrollTop = 100;
+      });
+      await expect
+        .poll(async () => {
+          return content.evaluate(async (el: HTMLIonContentElement) => {
+            const scrollEl = await el.getScrollElement();
+            return scrollEl.scrollTop;
+          });
+        })
+        .toBeGreaterThan(0);
 
       await content.evaluate((el: HTMLIonContentElement) => el.scrollToTop(0));
       await ionInfiniteComplete.next();


### PR DESCRIPTION
## Summary
- removes the temporary WebKit skip for the top-positioned infinite scroll e2e
- forces a small non-zero scroll offset before calling `scrollToTop(0)`
- polls until the offset is observed so the subsequent top scroll is not a no-op on Safari CI

Refs #30423.

## Test Plan
- `cd core && npm run build`
- `cd core && npx prettier --check src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts`
- `cd core && npx eslint src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts`
- `cd core && npm run test.e2e -- src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts --project='Mobile Chrome' --workers=1`
- `cd core && npm run test.e2e -- src/components/infinite-scroll/test/top/infinite-scroll.e2e.ts --project='Mobile Safari' --workers=1`
- `git diff --check`

## Notes
- The earlier local browser run was blocked by a missing Playwright headless-shell binary. I re-ran after installing `chromium-headless-shell` and `webkit`; the targeted Mobile Chrome and Mobile Safari e2e runs now pass locally.
- The Vercel check currently requires Ionic team deployment authorization; this PR does not need a contributor-side Vercel action.
