### PR TITLE
fix(searchbar): fix search icon sometimes being offset incorrectly

### DIFF
--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -32,6 +32,7 @@ export class Searchbar implements ComponentInterface {
   private inheritedAttributes: Attributes = {};
   private loadTimeout: ReturnType<typeof setTimeout> | undefined;
   private clearTimeout: ReturnType<typeof setTimeout> | undefined;
+  private searchIconResizeObserver?: ResizeObserver;
 
   /**
    * The value of the input when the textarea is focused.
@@ -302,6 +303,7 @@ export class Searchbar implements ComponentInterface {
     if (this.clearTimeout) {
       clearTimeout(this.clearTimeout);
     }
+    this.searchIconResizeObserver?.disconnect();
   }
 
   private emitStyle() {
@@ -547,13 +549,14 @@ export class Searchbar implements ComponentInterface {
          * If it is zero, set up a ResizeObserver and call this function when it observes a width greater than 0.
          */
         if (iconWidth === 0) {
-          const observer = new ResizeObserver((entries) => {
+          this.searchIconResizeObserver?.disconnect();
+          this.searchIconResizeObserver = new ResizeObserver((entries) => {
             if (entries[0].contentRect.width > 0) {
-              observer.disconnect();
+              this.searchIconResizeObserver?.disconnect();
               this.positionPlaceholder();
             }
           });
-          observer.observe(iconEl);
+          this.searchIconResizeObserver?.observe(iconEl);
           return;
         }
 

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -506,7 +506,7 @@ export class Searchbar implements ComponentInterface {
   /**
    * Positions the input placeholder
    */
-  private positionPlaceholder() {
+  private positionPlaceholder(numTries = 0) {
     const inputEl = this.nativeInput;
     if (!inputEl) {
       return;
@@ -539,7 +539,17 @@ export class Searchbar implements ComponentInterface {
          * such as Dynamic Type on iOS as well as 8px
          * of padding.
          */
-        const iconLeft = 'calc(50% - ' + (textWidth / 2 + iconEl.clientWidth + 8) + 'px)';
+        const iconWidth = iconEl.clientWidth;
+        if (iconWidth == 0 && numTries < 10) {
+          /*
+           * fix for https://github.com/ionic-team/ionic-framework/issues/30434
+           * iconEl.clientWidth can very briefly be 0 when this is called from componentDidLoad
+           * this will try again until it is nonzero
+           */
+          this.positionPlaceholder(numTries + 1);
+          return;
+        }
+        const iconLeft = 'calc(50% - ' + (textWidth / 2 + iconWidth + 8) + 'px)';
 
         // Set the input padding start and icon margin start
         if (rtl) {

--- a/core/src/components/searchbar/searchbar.tsx
+++ b/core/src/components/searchbar/searchbar.tsx
@@ -506,7 +506,7 @@ export class Searchbar implements ComponentInterface {
   /**
    * Positions the input placeholder
    */
-  private positionPlaceholder(numTries = 0) {
+  private positionPlaceholder() {
     const inputEl = this.nativeInput;
     if (!inputEl) {
       return;
@@ -540,15 +540,23 @@ export class Searchbar implements ComponentInterface {
          * of padding.
          */
         const iconWidth = iconEl.clientWidth;
-        if (iconWidth == 0 && numTries < 10) {
-          /*
-           * fix for https://github.com/ionic-team/ionic-framework/issues/30434
-           * iconEl.clientWidth can very briefly be 0 when this is called from componentDidLoad
-           * this will try again until it is nonzero
-           */
-          this.positionPlaceholder(numTries + 1);
+
+        /**
+         * Fix for https://github.com/ionic-team/ionic-framework/issues/30434:
+         * iconEl.clientWidth can very briefly be 0 when this is called from componentDidLoad.
+         * If it is zero, set up a ResizeObserver and call this function when it observes a width greater than 0.
+         */
+        if (iconWidth === 0) {
+          const observer = new ResizeObserver((entries) => {
+            if (entries[0].contentRect.width > 0) {
+              observer.disconnect();
+              this.positionPlaceholder();
+            }
+          });
+          observer.observe(iconEl);
           return;
         }
+
         const iconLeft = 'calc(50% - ' + (textWidth / 2 + iconWidth + 8) + 'px)';
 
         // Set the input padding start and icon margin start


### PR DESCRIPTION
Issue number: resolves #30434

---------
## What is the current behavior?
The search icon in an ion-searchbar is sometimes positioned incorrectly.

## What is the new behavior?
If the `positionPlaceholder` function in `searchbar.tsx` detects that `iconEl.clientWidth` is 0, it will use a `ResizeObserver` to wait until the element has a width > 0, then run `positionPlaceholder` again.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No
