### PR TITLE
feat(modal): default handleBehavior to "cycle" for sheet modals

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -19,6 +19,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
 - [Components](#version-9x-components)
   - [Input](#version-9x-input)
   - [Legacy Picker](#version-9x-legacy-picker)
+  - [Modal](#version-9x-modal)
   - [Router Outlet](#version-9x-router-outlet)
   - [Searchbar](#version-9x-searchbar)
   - [Select](#version-9x-select)
@@ -72,6 +73,16 @@ The string form no longer behaves the same way. Because an HTML attribute coerce
    - Usages such as `ion-picker-legacy` or `IonPickerLegacy` should be changed to `ion-picker` and `IonPicker`, respectively.
 - Remove any usages of `pickerController`. If using React, remove any usages of the `useIonPicker` hook. These controller-based APIs have been removed. Use the inline picker component instead.
 - Remove any usages of the `PickerOptions`, `PickerButton`, `PickerColumn`, and `PickerColumnOption` type exports. These types were associated with the legacy picker and have been removed.
+
+<h4 id="version-9x-modal">Modal</h4>
+
+The `handleBehavior` property on `ion-modal` now defaults to `"cycle"` instead of `"none"`. For sheet modals that display a handle, this means the handle is now focusable and activating it (by click, keyboard, or screen reader) cycles the sheet through its available breakpoints. This matches the native iOS sheet behavior and keeps sheet modals operable for assistive technology users by default.
+
+Sheet modals that relied on the handle being inert should set `handleBehavior="none"` to restore the previous behavior:
+
+```html
+<ion-modal handle-behavior="none"></ion-modal>
+```
 
 <h4 id="version-9x-router-outlet">Router Outlet</h4>
 

--- a/core/api.txt
+++ b/core/api.txt
@@ -1167,7 +1167,7 @@ ion-modal,prop,enterAnimation,((baseEl: any, opts?: any) => Animation) | undefin
 ion-modal,prop,expandToScroll,boolean,true,false,false
 ion-modal,prop,focusTrap,boolean,true,false,false
 ion-modal,prop,handle,boolean | undefined,undefined,false,false
-ion-modal,prop,handleBehavior,"cycle" | "none" | undefined,'none',false,false
+ion-modal,prop,handleBehavior,"cycle" | "none" | undefined,'cycle',false,false
 ion-modal,prop,htmlAttributes,undefined | { [key: string]: any; },undefined,false,false
 ion-modal,prop,initialBreakpoint,number | undefined,undefined,false,false
 ion-modal,prop,isOpen,boolean,false,false,false

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2003,8 +2003,8 @@ export namespace Components {
          */
         "handle"?: boolean;
         /**
-          * The interaction behavior for the sheet modal when the handle is pressed.  Defaults to `"none"`, which  means the modal will not change size or position when the handle is pressed. Set to `"cycle"` to let the modal cycle between available breakpoints when pressed.  Handle behavior is unavailable when the `handle` property is set to `false` or when the `breakpoints` property is not set (using a fullscreen or card modal).
-          * @default 'none'
+          * The interaction behavior for the sheet modal when the handle is pressed.  Handle behavior is unavailable when the `handle` property is set to `false` or when the `breakpoints` property is not set (using a fullscreen or card modal).  Set to `"cycle"` to make the handle focusable and let the sheet modal cycle between available breakpoints when pressed. This keeps the sheet operable with assistive technology.  Set to `"none"` to make the handle purely decorative when pressed and removed from the tab order.  Defaults to `"cycle"`.
+          * @default 'cycle'
          */
         "handleBehavior"?: ModalHandleBehavior;
         /**
@@ -7152,8 +7152,8 @@ declare namespace LocalJSX {
          */
         "handle"?: boolean;
         /**
-          * The interaction behavior for the sheet modal when the handle is pressed.  Defaults to `"none"`, which  means the modal will not change size or position when the handle is pressed. Set to `"cycle"` to let the modal cycle between available breakpoints when pressed.  Handle behavior is unavailable when the `handle` property is set to `false` or when the `breakpoints` property is not set (using a fullscreen or card modal).
-          * @default 'none'
+          * The interaction behavior for the sheet modal when the handle is pressed.  Handle behavior is unavailable when the `handle` property is set to `false` or when the `breakpoints` property is not set (using a fullscreen or card modal).  Set to `"cycle"` to make the handle focusable and let the sheet modal cycle between available breakpoints when pressed. This keeps the sheet operable with assistive technology.  Set to `"none"` to make the handle purely decorative when pressed and removed from the tab order.  Defaults to `"cycle"`.
+          * @default 'cycle'
          */
         "handleBehavior"?: ModalHandleBehavior;
         /**

--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -202,13 +202,20 @@ export class Modal implements ComponentInterface, OverlayInterface {
   /**
    * The interaction behavior for the sheet modal when the handle is pressed.
    *
-   * Defaults to `"none"`, which  means the modal will not change size or position when the handle is pressed.
-   * Set to `"cycle"` to let the modal cycle between available breakpoints when pressed.
+   * Handle behavior is unavailable when the `handle` property is set to
+   * `false` or when the `breakpoints` property is not set (using a
+   * fullscreen or card modal).
    *
-   * Handle behavior is unavailable when the `handle` property is set to `false` or
-   * when the `breakpoints` property is not set (using a fullscreen or card modal).
+   * Set to `"cycle"` to make the handle focusable and let the sheet modal
+   * cycle between available breakpoints when pressed. This keeps the sheet
+   * operable with assistive technology.
+   *
+   * Set to `"none"` to make the handle purely decorative when pressed and
+   * removed from the tab order.
+   *
+   * Defaults to `"cycle"`.
    */
-  @Prop() handleBehavior?: ModalHandleBehavior = 'none';
+  @Prop() handleBehavior?: ModalHandleBehavior = 'cycle';
 
   /**
    * The component to display inside of the modal.

--- a/core/src/components/modal/test/sheet/index.html
+++ b/core/src/components/modal/test/sheet/index.html
@@ -133,6 +133,12 @@
           >
             Present Sheet Modal (HandleBehavior: Cycle)
           </button>
+          <button
+            id="handle-behavior-none-modal"
+            onclick="presentModal({ handleBehavior: 'none', initialBreakpoint: 0.25, breakpoints: [0, 0.25, 0.5, 0.75, 1] })"
+          >
+            Present Sheet Modal (HandleBehavior: None)
+          </button>
           <button id="custom-handle-modal" onclick="presentModal({ cssClass: 'custom-handle' })">
             Present Sheet Modal (Custom Handle)
           </button>

--- a/core/src/components/modal/test/sheet/modal.e2e.ts
+++ b/core/src/components/modal/test/sheet/modal.e2e.ts
@@ -264,7 +264,7 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
       const modal = page.locator('ion-modal');
 
-      await page.click('#sheet-modal');
+      await page.click('#handle-behavior-none-modal');
       await ionModalDidPresent.next();
 
       const handle = page.locator('ion-modal .modal-handle');


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`handleBehavior` on `ion-modal` defaults to `"none"`. For sheet modals that show a handle, the handle is purely decorative: it is not focusable, it is skipped in the tab order, and activating it does nothing. Keyboard and screen reader users cannot resize the sheet unless the developer explicitly opts in with `handleBehavior="cycle"`.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- `handleBehavior` now defaults to `"cycle"`.
- Sheet modal handles are focusable by default and activating them (click, keyboard, or screen reader) cycles the sheet through its available breakpoints. This mirrors native iOS sheet behavior and keeps the sheet operable with assistive technology out of the box.
- Rewrote the `handleBehavior` property documentation to lead with what each value does and how `"cycle"` helps accessibility, improving findability and learnability.
- Developers can opt out with `handleBehavior="none"` to restore the previous decorative handle.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

This changes the default interaction and focus behavior of sheet modals that use a handle. The handle becomes focusable and enters the tab order, and activating it now cycles breakpoints where it previously did nothing. Sheet modals that relied on the handle being inert should set `handle-behavior="none"`:

```html
<ion-modal handle-behavior="none"></ion-modal>
```

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Preview
- [Modal: sheet](https://ionic-framework-git-fw-6657-ionic1.vercel.app/src/components/modal/test/sheet/)
