### PR TITLE
docs(contributing): improve Angular testing documentation and fix broken contributing link

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -293,7 +293,7 @@ npm install file:/~/ionic-vue-router-7.0.1.tgz
 3. If a new test is needed, the easiest way is to copy the `basic/` directory from the component's `test/` directory, rename it, and edit the content in both the `index.html` and `e2e.ts` file (see [Screenshot Tests](#screenshot-tests) for more information on this file).
 4. The `preview/` directory is used in the documentation as a demo. Only update this test if there is a bug in the test or if the API has a change that hasn't been updated in the test.
 
-See [Ionic's E2E testing guide](../core/src/utils/test/playwright/docs/README.md) for information regarding the tools you can use to test Ionic.
+See [Ionic's E2E testing guide](/core/src/utils/test/playwright/docs/README.md) for information regarding the tools you can use to test Ionic.
 
 ##### Screenshot Tests
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -293,7 +293,7 @@ npm install file:/~/ionic-vue-router-7.0.1.tgz
 3. If a new test is needed, the easiest way is to copy the `basic/` directory from the component's `test/` directory, rename it, and edit the content in both the `index.html` and `e2e.ts` file (see [Screenshot Tests](#screenshot-tests) for more information on this file).
 4. The `preview/` directory is used in the documentation as a demo. Only update this test if there is a bug in the test or if the API has a change that hasn't been updated in the test.
 
-See [Ionic's E2E testing guide](/core/src/utils/test/playwright/docs/README.md) for information regarding the tools you can use to test Ionic.
+Refer to [Ionic's E2E testing guide](/core/src/utils/test/playwright/docs/README.md) for information regarding the tools you can use to test Ionic.
 
 ##### Screenshot Tests
 

--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -6,15 +6,19 @@ Ionic Framework supports multiple versions of Angular. As a result, we need to v
 
 The Angular test app supports syncing your locally built changes for validation. This allows you to test local changes like `core` without having to publish a new version of the package.
 
+0. In the root directory, run `npm unlink *` to remove any previous links you have built.
 1. Build the `core` directory.
 2. Navigate to `packages/angular` and run `npm run sync`.
 3. Build `packages/angular` using `npm run build`.
-4. [Build the Angular test app](#test-app-build-structure).
-5. Navigate to the built test app directory (e.g. `packages/angular/test/build/ng14`).
-6. Install dependencies using `npm install`.
-7. Sync your local changes using `npm run sync`.
+4. Navigate to `packages/angular-server` and run `npm install` and `npm run build`.
+5. [Build the Angular test app](#test-app-build-structure) using `./build.sh`.
+6. Navigate to the built test app directory (e.g. `packages/angular/test/build/ng14`).
+7. Install dependencies using `npm install`.
+8. Sync your local changes using `npm run sync`.
 
 From here you can either build the application or start a local dev server. When re-syncing changes, you will need to [wipe or disable the application cache](#application-cache).
+
+If this is your first time running Playwright tests in the repository, install the [Playwright browser dependencies](/docs/core/testing/usage-instructions.md#installing-dependencies)
 
 > [!NOTE]
 > Syncing is required to verify that the minimal supported Angular version is still compatible with the latest Ionic Framework changes.

--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -6,12 +6,14 @@ Ionic Framework supports multiple versions of Angular. As a result, we need to v
 
 The Angular test app supports syncing your locally built changes for validation. This allows you to test local changes like `core` without having to publish a new version of the package.
 
-0. In the root directory, run `npm unlink *` to remove any previous links you have built.
+> [!TIP]
+> In the root directory, run `npm unlink *` to remove any previous links you have built.
+
 1. Build the `core` directory.
 2. Navigate to `packages/angular` and run `npm run sync`.
 3. Build `packages/angular` using `npm run build`.
-4. Navigate to `packages/angular-server` and run `npm install` and `npm run build`.
-5. [Build the Angular test app](#test-app-build-structure) using `./build.sh`.
+4. Navigate to `packages/angular-server` and run `npm install && npm run build`.
+5. [Build the Angular test app](#test-app-build-structure).
 6. Navigate to the built test app directory (e.g. `packages/angular/test/build/ng14`).
 7. Install dependencies using `npm install`.
 8. Sync your local changes using `npm run sync`.

--- a/docs/angular/testing.md
+++ b/docs/angular/testing.md
@@ -20,8 +20,6 @@ The Angular test app supports syncing your locally built changes for validation.
 
 From here you can either build the application or start a local dev server. When re-syncing changes, you will need to [wipe or disable the application cache](#application-cache).
 
-If this is your first time running Playwright tests in the repository, install the [Playwright browser dependencies](/docs/core/testing/usage-instructions.md#installing-dependencies)
-
 > [!NOTE]
 > Syncing is required to verify that the minimal supported Angular version is still compatible with the latest Ionic Framework changes.
 > For example, Ionic Framework 8 supports Angular 16, but the latest version of Ionic Framework may not be compatible with Angular 16. Syncing allows you to verify that the latest changes are still compatible with the minimal supported version.


### PR DESCRIPTION
Issue number: resolves #31251

---------

## What is the current behavior?

While working on e2e tests in the angular directory, I encountered a few documentation issues that made the local development workflow more difficult to follow.

- The **"See Ionic's E2E testing guide"** link in `CONTRIBUTING.md` resolves to a 404 when viewed from GitHub's **Contributing** tab because the relative path is not resolved correctly.
  - Broken link: https://github.com/ionic-team/ionic-framework/blob/core/src/utils/test/playwright/docs/README.md
  - Intended destination: https://github.com/ionic-team/ionic-framework/blob/main/core/src/utils/test/playwright/docs/README.md

- The Angular testing guide (`docs/angular/testing.md`) omits several steps that are necessary to successfully test local framework changes, including:
  - Removing existing `npm link` relationships before starting a new sync cycle.
  - Building `packages/angular-server`.
  - Installing Playwright browser dependencies before running Playwright tests for the first time.

These omissions made it difficult to reproduce and validate additions to Angular tests I was adding as part of a separate PR.

## What is the new behavior?

This PR does the following:

- Fixes the broken link to the Ionic E2E testing guide in `CONTRIBUTING.md` by using a repository-root-relative path.
- Updating `docs/angular/testing.md` to document the complete workflow for syncing local Angular framework changes.
- Documents that `packages/angular-server` should be built as part of the local testing workflow.
- Documents that contributors should remove previous `npm link` relationships before beginning a new sync cycle.
- Clarifies the recommended workflow for syncing local package changes.
- Documents the Playwright browser installation step required before running Playwright tests for the first time.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information