### PR TITLE
fix: iOS fade header color missmatch

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -644,6 +644,10 @@ export class Modal implements ComponentInterface, OverlayInterface {
       await waitForMount();
     }
 
+    // Recalculate content dimensions before showing the modal so the initial
+    // paint uses the final content offset and background geometry.
+    await this.recalculateContentDimensions();
+
     writeTask(() => this.el.classList.add('show-modal'));
 
     // Recalculate isSheetModal before safe-area setup because framework
@@ -1515,6 +1519,18 @@ export class Modal implements ComponentInterface, OverlayInterface {
 
     const { contentEl, hasFooter } = this.findContentAndFooter();
     this.applyFullscreenSafeAreaTo(contentEl, hasFooter);
+  }
+
+  /**
+   * Recalculates the inner ion-content dimensions after the modal has mounted so
+   * its offsets and background geometry reflect the modal's final size before it is shown.
+   */
+  private async recalculateContentDimensions(): Promise<void> {
+    const contentEl = this.el.querySelector('ion-content') as HTMLIonContentElement | null;
+
+    if (contentEl) {
+      await contentEl.recalculateDimensions();
+    }
   }
 
   /**

--- a/core/src/components/modal/test/basic/modal.spec.tsx
+++ b/core/src/components/modal/test/basic/modal.spec.tsx
@@ -2,7 +2,7 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
 import { Modal } from '../../modal';
-import { Content } from '../../../content/content'
+import { Content } from '../../../content/content';
 import { FOCUS_TRAP_DISABLE_CLASS } from '@utils/overlays';
 
 describe('modal: htmlAttributes inheritance', () => {
@@ -54,9 +54,7 @@ describe('modal: content dimensions', () => {
 
     const modal = page.body.querySelector('ion-modal')!;
 
-    const recalculateSpy = jest
-      .spyOn(Content.prototype, 'recalculateDimensions')
-      .mockResolvedValue(undefined);
+    const recalculateSpy = jest.spyOn(Content.prototype, 'recalculateDimensions').mockResolvedValue(undefined);
 
     await modal.present();
     await page.waitForChanges();

--- a/core/src/components/modal/test/basic/modal.spec.tsx
+++ b/core/src/components/modal/test/basic/modal.spec.tsx
@@ -2,6 +2,7 @@ import { h } from '@stencil/core';
 import { newSpecPage } from '@stencil/core/testing';
 
 import { Modal } from '../../modal';
+import { Content } from '../../../content/content'
 import { FOCUS_TRAP_DISABLE_CLASS } from '@utils/overlays';
 
 describe('modal: htmlAttributes inheritance', () => {
@@ -37,5 +38,29 @@ describe('modal: focus trap', () => {
     const modal = page.body.querySelector('ion-modal')!;
 
     expect(modal.classList.contains(FOCUS_TRAP_DISABLE_CLASS)).toBe(false);
+  });
+});
+
+describe('modal: content dimensions', () => {
+  it('should recalculate ion-content dimensions before presenting', async () => {
+    const page = await newSpecPage({
+      components: [Content, Modal],
+      template: () => (
+        <ion-modal overlayIndex={1} animated={false}>
+          <ion-content color="dark">Test Content</ion-content>
+        </ion-modal>
+      ),
+    });
+
+    const modal = page.body.querySelector('ion-modal')!;
+
+    const recalculateSpy = jest
+      .spyOn(Content.prototype, 'recalculateDimensions')
+      .mockResolvedValue(undefined);
+
+    await modal.present();
+    await page.waitForChanges();
+
+    expect(recalculateSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Issue number: resolves #30939

---------
## What is the current behavior?
When opening a modal that contains both a fade header and a content element with a color attribute, the fade header will appear without any background, showing a white/black gap that doesn't match the content color when at the top of the page.  

## What is the new behavior?
I added logic to recalculate the ion-content dimensions after the header has finished rendering. This ensures the content size is  correct and fills the background gap behind the fade header.

## Does this introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
