### PR TITLE
feat(datetime, datetime-button, picker-column, picker-column-option): improve styling flexibility by removing default color prop

### DIFF
--- a/core/api.txt
+++ b/core/api.txt
@@ -513,7 +513,7 @@ ion-content,part,scroll
 ion-datetime,shadow
 ion-datetime,prop,cancelText,string,'Cancel',false,false
 ion-datetime,prop,clearText,string,'Clear',false,false
-ion-datetime,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,'primary',false,false
+ion-datetime,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,undefined,false,false
 ion-datetime,prop,dayValues,number | number[] | string | undefined,undefined,false,false
 ion-datetime,prop,disabled,boolean,false,false,false
 ion-datetime,prop,doneText,string,'Done',false,false
@@ -582,7 +582,7 @@ ion-datetime,part,wheel-item
 ion-datetime,part,wheel-item active
 
 ion-datetime-button,shadow
-ion-datetime-button,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,'primary',false,true
+ion-datetime-button,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,undefined,false,true
 ion-datetime-button,prop,datetime,string | undefined,undefined,false,false
 ion-datetime-button,prop,disabled,boolean,false,false,true
 ion-datetime-button,prop,mode,"ios" | "md",undefined,false,false
@@ -1269,7 +1269,7 @@ ion-picker,css-prop,--highlight-border-radius,ios
 ion-picker,css-prop,--highlight-border-radius,md
 
 ion-picker-column,shadow
-ion-picker-column,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,'primary',false,true
+ion-picker-column,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,undefined,false,true
 ion-picker-column,prop,disabled,boolean,false,false,false
 ion-picker-column,prop,mode,"ios" | "md",undefined,false,false
 ion-picker-column,prop,value,number | string | undefined,undefined,false,false
@@ -1277,7 +1277,7 @@ ion-picker-column,method,setFocus,setFocus() => Promise<void>
 ion-picker-column,event,ionChange,PickerColumnChangeEventDetail,true
 
 ion-picker-column-option,shadow
-ion-picker-column-option,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,'primary',false,true
+ion-picker-column-option,prop,color,"danger" | "dark" | "light" | "medium" | "primary" | "secondary" | "success" | "tertiary" | "warning" | string & Record<never, never> | undefined,undefined,false,true
 ion-picker-column-option,prop,disabled,boolean,false,false,false
 ion-picker-column-option,prop,value,any,undefined,false,false
 

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -928,7 +928,6 @@ export namespace Components {
         "clearText": string;
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -1080,7 +1079,6 @@ export namespace Components {
     interface IonDatetimeButton {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -2244,7 +2242,6 @@ export namespace Components {
     interface IonPickerColumn {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -2278,7 +2275,6 @@ export namespace Components {
     interface IonPickerColumnOption {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -6061,7 +6057,6 @@ declare namespace LocalJSX {
         "clearText"?: string;
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -6227,7 +6222,6 @@ declare namespace LocalJSX {
     interface IonDatetimeButton {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -7353,7 +7347,6 @@ declare namespace LocalJSX {
     interface IonPickerColumn {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**
@@ -7382,7 +7375,6 @@ declare namespace LocalJSX {
     interface IonPickerColumnOption {
         /**
           * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
-          * @default 'primary'
          */
         "color"?: Color;
         /**

--- a/core/src/components/datetime-button/datetime-button.scss
+++ b/core/src/components/datetime-button/datetime-button.scss
@@ -39,7 +39,12 @@
 
 :host(.time-active) #time-button,
 :host(.date-active) #date-button {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color.time-active) #time-button,
+:host(.ion-color.date-active) #date-button {
+  color: #{current-color(base)};
 }
 
 :host(.datetime-button-disabled) {

--- a/core/src/components/datetime-button/datetime-button.scss
+++ b/core/src/components/datetime-button/datetime-button.scss
@@ -39,12 +39,12 @@
 
 :host(.time-active) #time-button,
 :host(.date-active) #date-button {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color.time-active) #time-button,
 :host(.ion-color.date-active) #date-button {
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 :host(.datetime-button-disabled) {

--- a/core/src/components/datetime-button/datetime-button.tsx
+++ b/core/src/components/datetime-button/datetime-button.tsx
@@ -45,7 +45,7 @@ export class DatetimeButton implements ComponentInterface {
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
    * For more information on colors, see [theming](/docs/theming/basics).
    */
-  @Prop({ reflect: true }) color?: Color = 'primary';
+  @Prop({ reflect: true }) color?: Color;
 
   /**
    * If `true`, the user cannot interact with the button.

--- a/core/src/components/datetime/datetime.ios.scss
+++ b/core/src/components/datetime/datetime.ios.scss
@@ -53,12 +53,12 @@
 
 :host .calendar-action-buttons .calendar-month-year-toggle ion-icon,
 :host .calendar-action-buttons ion-buttons ion-button {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color) .calendar-action-buttons .calendar-month-year-toggle ion-icon,
 :host(.ion-color) .calendar-action-buttons ion-buttons ion-button {
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 :host .calendar-action-buttons ion-buttons {
@@ -240,13 +240,13 @@
 }
 
 .calendar-day.calendar-day-active {
-  background: #{ion-color(primary, base, 0.2)};
+  background: ion-color(primary, base, 0.2);
 
   font-size: dynamic-font-max(22px, 1.6);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-active {
-  background: #{current-color(base, 0.2)};
+  background: current-color(base, 0.2);
 }
 
 /**
@@ -254,11 +254,11 @@
  * should have ion-color for text color.
  */
 :host .calendar-day.calendar-day-today {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-today {
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 /**
@@ -268,14 +268,14 @@
  */
 :host .calendar-day.calendar-day-active,
 :host .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 
   font-weight: 600;
 }
 
 :host(.ion-color) .calendar-day.calendar-day-active,
 :host(.ion-color) .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 /**
@@ -284,13 +284,13 @@
  * with contrast text.
  */
 :host .calendar-day.calendar-day-today.calendar-day-active {
-  background: #{ion-color(primary, base)};
-  color: #{ion-color(primary, contrast)};
+  background: ion-color(primary, base);
+  color: ion-color(primary, contrast);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-today.calendar-day-active {
-  background: #{current-color(base)};
-  color: #{current-color(contrast)};
+  background: current-color(base);
+  color: current-color(contrast);
 }
 
 :host .calendar-day.calendar-day-adjacent-day {

--- a/core/src/components/datetime/datetime.ios.scss
+++ b/core/src/components/datetime/datetime.ios.scss
@@ -53,7 +53,12 @@
 
 :host .calendar-action-buttons .calendar-month-year-toggle ion-icon,
 :host .calendar-action-buttons ion-buttons ion-button {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color) .calendar-action-buttons .calendar-month-year-toggle ion-icon,
+:host(.ion-color) .calendar-action-buttons ion-buttons ion-button {
+  color: #{current-color(base)};
 }
 
 :host .calendar-action-buttons ion-buttons {
@@ -235,9 +240,13 @@
 }
 
 .calendar-day.calendar-day-active {
-  background: current-color(base, 0.2);
+  background: #{ion-color(primary, base, 0.2)};
 
   font-size: dynamic-font-max(22px, 1.6);
+}
+
+:host(.ion-color) .calendar-day.calendar-day-active {
+  background: #{current-color(base, 0.2)};
 }
 
 /**
@@ -245,7 +254,11 @@
  * should have ion-color for text color.
  */
 :host .calendar-day.calendar-day-today {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color) .calendar-day.calendar-day-today {
+  color: #{current-color(base)};
 }
 
 /**
@@ -255,9 +268,14 @@
  */
 :host .calendar-day.calendar-day-active,
 :host .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
 
   font-weight: 600;
+}
+
+:host(.ion-color) .calendar-day.calendar-day-active,
+:host(.ion-color) .calendar-day.calendar-day-adjacent-day.calendar-day-active {
+  color: #{current-color(base)};
 }
 
 /**
@@ -266,8 +284,13 @@
  * with contrast text.
  */
 :host .calendar-day.calendar-day-today.calendar-day-active {
-  background: current-color(base);
-  color: current-color(contrast);
+  background: #{ion-color(primary, base)};
+  color: #{ion-color(primary, contrast)};
+}
+
+:host(.ion-color) .calendar-day.calendar-day-today.calendar-day-active {
+  background: #{current-color(base)};
+  color: #{current-color(contrast)};
 }
 
 :host .calendar-day.calendar-day-adjacent-day {

--- a/core/src/components/datetime/datetime.md.scss
+++ b/core/src/components/datetime/datetime.md.scss
@@ -16,12 +16,12 @@
 :host .datetime-header {
   @include padding($datetime-md-header-padding, $datetime-md-header-padding, $datetime-md-header-padding, $datetime-md-header-padding);
 
-  background: #{ion-color(primary, base)};
+  background: ion-color(primary, base);
   color: var(--title-color);
 }
 
 :host(.ion-color) .datetime-header {
-  background: #{current-color(base)};
+  background: current-color(base);
 }
 
 :host .datetime-header .datetime-title {
@@ -115,15 +115,15 @@
  * should have ion-color for text color.
  */
 :host .calendar-day.calendar-day-today {
-  border: 1px solid #{ion-color(primary, base)};
+  border: 1px solid ion-color(primary, base);
 
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-today {
-  border: 1px solid #{current-color(base)};
+  border: 1px solid current-color(base);
 
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 /**
@@ -133,26 +133,26 @@
  */
 :host .calendar-day.calendar-day-active,
 :host .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: #{ion-color(primary, contrast)};
+  color: ion-color(primary, contrast);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-active,
 :host(.ion-color) .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: #{current-color(contrast)};
+  color: current-color(contrast);
 }
 
 .calendar-day.calendar-day-active,
 .calendar-day.calendar-day-active:focus {
-  border: 1px solid #{ion-color(primary, base)};
+  border: 1px solid ion-color(primary, base);
 
-  background: #{ion-color(primary, base)};
+  background: ion-color(primary, base);
 }
 
 :host(.ion-color) .calendar-day.calendar-day-active,
 :host(.ion-color) .calendar-day.calendar-day-active:focus {
-  border: 1px solid #{current-color(base)};
+  border: 1px solid current-color(base);
 
-  background: #{current-color(base)};
+  background: current-color(base);
 }
 
 :host .calendar-day.calendar-day-adjacent-day {

--- a/core/src/components/datetime/datetime.md.scss
+++ b/core/src/components/datetime/datetime.md.scss
@@ -4,6 +4,10 @@
 
 :host {
   --background: var(--ion-color-step-100, var(--ion-background-color-step-100, #ffffff));
+  --title-color: #{ion-color(primary, contrast)};
+}
+
+:host(.ion-color) {
   --title-color: #{current-color(contrast)};
 }
 
@@ -12,8 +16,12 @@
 :host .datetime-header {
   @include padding($datetime-md-header-padding, $datetime-md-header-padding, $datetime-md-header-padding, $datetime-md-header-padding);
 
-  background: current-color(base);
+  background: #{ion-color(primary, base)};
   color: var(--title-color);
+}
+
+:host(.ion-color) .datetime-header {
+  background: #{current-color(base)};
 }
 
 :host .datetime-header .datetime-title {
@@ -107,9 +115,15 @@
  * should have ion-color for text color.
  */
 :host .calendar-day.calendar-day-today {
-  border: 1px solid current-color(base);
+  border: 1px solid #{ion-color(primary, base)};
 
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color) .calendar-day.calendar-day-today {
+  border: 1px solid #{current-color(base)};
+
+  color: #{current-color(base)};
 }
 
 /**
@@ -119,14 +133,26 @@
  */
 :host .calendar-day.calendar-day-active,
 :host .calendar-day.calendar-day-adjacent-day.calendar-day-active {
-  color: current-color(contrast);
+  color: #{ion-color(primary, contrast)};
+}
+
+:host(.ion-color) .calendar-day.calendar-day-active,
+:host(.ion-color) .calendar-day.calendar-day-adjacent-day.calendar-day-active {
+  color: #{current-color(contrast)};
 }
 
 .calendar-day.calendar-day-active,
 .calendar-day.calendar-day-active:focus {
-  border: 1px solid current-color(base);
+  border: 1px solid #{ion-color(primary, base)};
 
-  background: current-color(base);
+  background: #{ion-color(primary, base)};
+}
+
+:host(.ion-color) .calendar-day.calendar-day-active,
+:host(.ion-color) .calendar-day.calendar-day-active:focus {
+  border: 1px solid #{current-color(base)};
+
+  background: #{current-color(base)};
 }
 
 :host .calendar-day.calendar-day-adjacent-day {

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -379,7 +379,7 @@
 }
 
 :host(.ion-color) .calendar-day:not(.calendar-day-adjacent-day):focus {
-  background: #{current-color(base, 0.2)};
+  background: current-color(base, 0.2);
 
   box-shadow: 0px 0px 0px 4px current-color(base, 0.2);
 }

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -190,6 +190,13 @@
   justify-content: space-between;
 }
 
+
+// Default text color for action buttons (cancel, clear, done).
+// When datetime doesn't receive a color prop.
+:host .datetime-action-buttons ion-button {
+  --color: #{ion-color(primary, base)};
+}
+
 /**
  * The confirm and clear buttons are grouped in a
  * container so that they appear on the end opposite
@@ -366,9 +373,15 @@
 
 
 .calendar-day:not(.calendar-day-adjacent-day):focus {
-  background: current-color(base, 0.2);
+  background: #{ion-color(primary, base, 0.2)};
 
-  box-shadow: 0px 0px 0px 4px current-color(base, 0.2);
+  box-shadow: 0px 0px 0px 4px #{ion-color(primary, base, 0.2)};
+}
+
+:host(.ion-color) .calendar-day:not(.calendar-day-adjacent-day):focus {
+  background: #{current-color(base, 0.2)};
+
+  box-shadow: 0px 0px 0px 4px #{current-color(base, 0.2)};
 }
 
 // Time / Header
@@ -415,7 +428,11 @@
 }
 
 :host .time-body-active {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color) .time-body-active {
+  color: #{current-color(base)};
 }
 
 :host(.in-item) {
@@ -425,6 +442,10 @@
 // Year Picker
 // -----------------------------------
 :host(.show-month-and-year) .calendar-action-buttons .calendar-month-year-toggle {
+  color: #{ion-color(primary, base)};
+}
+
+:host(.show-month-and-year.ion-color) .calendar-action-buttons .calendar-month-year-toggle {
   color: #{current-color(base)};
 }
 

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -381,7 +381,7 @@
 :host(.ion-color) .calendar-day:not(.calendar-day-adjacent-day):focus {
   background: #{current-color(base, 0.2)};
 
-  box-shadow: 0px 0px 0px 4px #{current-color(base, 0.2)};
+  box-shadow: 0px 0px 0px 4px current-color(base, 0.2);
 }
 
 // Time / Header

--- a/core/src/components/datetime/datetime.scss
+++ b/core/src/components/datetime/datetime.scss
@@ -373,9 +373,9 @@
 
 
 .calendar-day:not(.calendar-day-adjacent-day):focus {
-  background: #{ion-color(primary, base, 0.2)};
+  background: ion-color(primary, base, 0.2);
 
-  box-shadow: 0px 0px 0px 4px #{ion-color(primary, base, 0.2)};
+  box-shadow: 0px 0px 0px 4px ion-color(primary, base, 0.2);
 }
 
 :host(.ion-color) .calendar-day:not(.calendar-day-adjacent-day):focus {
@@ -428,11 +428,11 @@
 }
 
 :host .time-body-active {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color) .time-body-active {
-  color: #{current-color(base)};
+  color: current-color(base);
 }
 
 :host(.in-item) {
@@ -442,11 +442,11 @@
 // Year Picker
 // -----------------------------------
 :host(.show-month-and-year) .calendar-action-buttons .calendar-month-year-toggle {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
-:host(.show-month-and-year.ion-color) .calendar-action-buttons .calendar-month-year-toggle {
-  color: #{current-color(base)};
+:host(.ion-color.show-month-and-year) .calendar-action-buttons .calendar-month-year-toggle {
+  color: current-color(base);
 }
 
 .calendar-month-year {

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -181,7 +181,7 @@ export class Datetime implements ComponentInterface {
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
    * For more information on colors, see [theming](/docs/theming/basics).
    */
-  @Prop() color?: Color = 'primary';
+  @Prop() color?: Color;
 
   /**
    * The name of the control, which is submitted with the form data.
@@ -1813,6 +1813,7 @@ export class Datetime implements ComponentInterface {
       >
         {items.map((item) => (
           <ion-picker-column-option
+            color={this.color}
             part={item.value === todayString ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={item.value}
             disabled={item.disabled}
@@ -1931,6 +1932,7 @@ export class Datetime implements ComponentInterface {
       >
         {days.map((day) => (
           <ion-picker-column-option
+            color={this.color}
             part={day.value === pickerColumnValue ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={day.value}
             disabled={day.disabled}
@@ -1979,6 +1981,7 @@ export class Datetime implements ComponentInterface {
       >
         {months.map((month) => (
           <ion-picker-column-option
+            color={this.color}
             part={month.value === workingParts.month ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={month.value}
             disabled={month.disabled}
@@ -2026,6 +2029,7 @@ export class Datetime implements ComponentInterface {
       >
         {years.map((year) => (
           <ion-picker-column-option
+            color={this.color}
             part={year.value === workingParts.year ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={year.value}
             disabled={year.disabled}
@@ -2101,6 +2105,7 @@ export class Datetime implements ComponentInterface {
       >
         {hoursData.map((hour) => (
           <ion-picker-column-option
+            color={this.color}
             part={hour.value === activePart.hour ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={hour.value}
             disabled={hour.disabled}
@@ -2142,6 +2147,7 @@ export class Datetime implements ComponentInterface {
       >
         {minutesData.map((minute) => (
           <ion-picker-column-option
+            color={this.color}
             part={minute.value === activePart.minute ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART}
             key={minute.value}
             disabled={minute.disabled}
@@ -2190,6 +2196,7 @@ export class Datetime implements ComponentInterface {
       >
         {dayPeriodData.map((dayPeriod) => (
           <ion-picker-column-option
+            color={this.color}
             part={
               dayPeriod.value === activePart.ampm ? `${WHEEL_ITEM_PART} ${WHEEL_ITEM_ACTIVE_PART}` : WHEEL_ITEM_PART
             }

--- a/core/src/components/datetime/test/color/datetime.e2e.ts
+++ b/core/src/components/datetime/test/color/datetime.e2e.ts
@@ -29,3 +29,106 @@ configs({ directions: ['ltr'], palettes: ['light', 'dark'] }).forEach(({ title, 
     });
   });
 });
+
+/**
+ * This behavior does not vary across directions
+ */
+configs({ directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('datetime: color'), () => {
+    test('should apply color to the time button when opened', async ({ page }) => {
+      await page.setContent(
+        `
+        <div id="container" style="width: 250px;">
+          <ion-datetime
+            color="danger"
+            value="2022-05-03T14:30:00"
+            presentation="date-time"
+            show-default-title="true"
+            show-default-buttons="true"
+          ></ion-datetime>
+        </div>
+      `,
+        config
+      );
+
+      await page.locator('.datetime-ready').waitFor();
+
+      const timeBody = page.locator('.time-body');
+
+      await timeBody.click();
+
+      const timeBodyActive = page.locator('.time-body-active');
+      const activeTimeBodyStyles = await timeBodyActive.evaluate((el) => {
+        const rgbToHex = (rgb: string): string => {
+          const match = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+          if (!match) return rgb;
+          const r = parseInt(match[1], 10).toString(16).padStart(2, '0');
+          const g = parseInt(match[2], 10).toString(16).padStart(2, '0');
+          const b = parseInt(match[3], 10).toString(16).padStart(2, '0');
+          return `#${r}${g}${b}`;
+        };
+
+        const styles = window.getComputedStyle(el);
+        return {
+          color: rgbToHex(styles.color),
+          colorBase: styles.getPropertyValue('--ion-color-base').trim(),
+        };
+      });
+
+      // Computed color should match the danger color's base value from the CSS custom property
+      expect(activeTimeBodyStyles.color).toEqual(activeTimeBodyStyles.colorBase);
+    });
+  });
+});
+
+/**
+ * This behavior only applies to `md`
+ */
+configs({ modes: ['md'] }).forEach(({ title, config }) => {
+  test.describe(title('datetime: color'), () => {
+    test('should apply color to the selected time option when opened', async ({ page }) => {
+      await page.setContent(
+        `
+        <div id="container" style="width: 250px;">
+          <ion-datetime
+            color="danger"
+            value="2022-05-03T14:30:00"
+            presentation="date-time"
+            show-default-title="true"
+            show-default-buttons="true"
+          ></ion-datetime>
+        </div>
+      `,
+        config
+      );
+
+      await page.locator('.datetime-ready').waitFor();
+
+      const timeBody = page.locator('.time-body');
+
+      await timeBody.click();
+
+      const option = page.locator('ion-picker-column-option[part~="active"]').first();
+
+      const optionStyles = await option.evaluate((el) => {
+        const rgbToHex = (rgb: string): string => {
+          const match = rgb.match(/^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/);
+          if (!match) return rgb;
+          const r = parseInt(match[1], 10).toString(16).padStart(2, '0');
+          const g = parseInt(match[2], 10).toString(16).padStart(2, '0');
+          const b = parseInt(match[3], 10).toString(16).padStart(2, '0');
+          return `#${r}${g}${b}`;
+        };
+
+        const styles = window.getComputedStyle(el);
+        return {
+          color: rgbToHex(styles.color),
+          colorBase: styles.getPropertyValue('--ion-color-base').trim(),
+        };
+      });
+
+      // Selected time option color should match the danger color's base value
+      expect(optionStyles.color).toEqual(optionStyles.colorBase);
+    });
+  });
+});

--- a/core/src/components/datetime/test/color/index.html
+++ b/core/src/components/datetime/test/color/index.html
@@ -64,7 +64,7 @@
             <ion-datetime
               id="color-datetime"
               color="danger"
-              value="2022-05-03"
+              value="2022-05-03T14:30:00"
               show-default-title="true"
               show-default-buttons="true"
             ></ion-datetime>

--- a/core/src/components/picker-column-option/picker-column-option.md.scss
+++ b/core/src/components/picker-column-option/picker-column-option.md.scss
@@ -13,10 +13,10 @@
  */
 :host(.option-active),
 :host([part~="active"]) {
-  color: #{ion-color(primary, base)};
+  color: ion-color(primary, base);
 }
 
 :host(.ion-color.option-active),
 :host(.ion-color[part~="active"]) {
-  color: #{current-color(base)};
+  color: current-color(base);
 }

--- a/core/src/components/picker-column-option/picker-column-option.md.scss
+++ b/core/src/components/picker-column-option/picker-column-option.md.scss
@@ -7,11 +7,16 @@
  * - datetime sets `part="... active"` on the option. This is the reliable
  *   value-based source of truth and keeps the option colored when the column
  *   lives inside datetime's shadow DOM, where the class can be missed
- *   (WebKit's elementsFromPoint is unreliable in a shadow root). 
+ *   (WebKit's elementsFromPoint is unreliable in a shadow root).
  *   TODO(FW-6594): Determine if this workaround can be removed when iOS 16 is
  *   no longer supported.
  */
 :host(.option-active),
 :host([part~="active"]) {
-  color: current-color(base);
+  color: #{ion-color(primary, base)};
+}
+
+:host(.ion-color.option-active),
+:host(.ion-color[part~="active"]) {
+  color: #{current-color(base)};
 }

--- a/core/src/components/picker-column-option/picker-column-option.tsx
+++ b/core/src/components/picker-column-option/picker-column-option.tsx
@@ -49,7 +49,7 @@ export class PickerColumnOption implements ComponentInterface {
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
    * For more information on colors, see [theming](/docs/theming/basics).
    */
-  @Prop({ reflect: true }) color?: Color = 'primary';
+  @Prop({ reflect: true }) color?: Color;
 
   /**
    * The aria-label of the option has changed after the

--- a/core/src/components/picker-column/picker-column.scss
+++ b/core/src/components/picker-column/picker-column.scss
@@ -189,6 +189,6 @@
   }
 
   :host(.ion-color:focus) .picker-opts {
-    background: #{current-color(base, 0.2)};
+    background: current-color(base, 0.2);
   }
 }

--- a/core/src/components/picker-column/picker-column.scss
+++ b/core/src/components/picker-column/picker-column.scss
@@ -185,6 +185,10 @@
   :host(:focus) .picker-opts {
     outline: none;
 
-    background: current-color(base, 0.2);
+    background: rgba(#{ion-color(primary, base, null, true)}, 0.2);
+  }
+
+  :host(.ion-color:focus) .picker-opts {
+    background: #{current-color(base, 0.2)};
   }
 }

--- a/core/src/components/picker-column/picker-column.tsx
+++ b/core/src/components/picker-column/picker-column.tsx
@@ -60,7 +60,7 @@ export class PickerColumn implements ComponentInterface {
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
    * For more information on colors, see [theming](/docs/theming/basics).
    */
-  @Prop({ reflect: true }) color?: Color = 'primary';
+  @Prop({ reflect: true }) color?: Color;
 
   /**
    * If `true`, tapping the picker will


### PR DESCRIPTION
Issue number: resolves internal

---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

`ion-datetime` and related components (`ion-datetime-button`, `ion-picker-column`, `ion-picker-column-option`) have a default `color="primary"` property. This forces users who want to customize datetime styling to override the entire primary color system or set explicit colors on every instance, rather than being able to style the component normally.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- Removed default `color="primary"` property assignments from all four components
- Components now apply primary color styling via SCSS defaults (`ion-color(primary, base)`) instead of relying on a property default
- Added `:host(.ion-color)` overrides in SCSS to apply explicit colors via `current-color()` when a color prop is set
- Action buttons (cancel, done, clear) have explicit primary text color styling to ensure consistent appearance
- Color now cascades from datetime → picker-column → picker-column-option when explicitly set. Previously the selected wheel option (active time picker text) stayed primary regardless of color; it now inherits the value passed to datetime.

| `main` | `FW-6996` |
| --- | --- |
| ![main](https://github.com/user-attachments/assets/3123b70f-1bbc-419b-92cc-f776b293bd61) | ![branch](https://github.com/user-attachments/assets/a7127655-b378-4998-a40e-706a5fccbe10) |

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->

**Backwards compatible:** Visual appearance is unchanged. Components still appear with primary color by default. Existing code that explicitly sets `color` props continues to work identically.

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Dev build: `8.8.14-dev.11783706459.1d5a7aae`

Previews:
- [Datetime: basic](https://ionic-framework-git-fw-6996-ionic1.vercel.app/src/components/datetime/test/basic/)
- [Datetime: color](https://ionic-framework-git-fw-6996-ionic1.vercel.app/src/components/datetime/test/color/)
- [Datetime: display](https://ionic-framework-git-fw-6996-ionic1.vercel.app/src/components/datetime/test/display/)
- [Datetime: presentation](https://ionic-framework-git-fw-6996-ionic1.vercel.app/src/components/datetime/test/presentation/)
- [Picker: basic](https://ionic-framework-git-fw-6996-ionic1.vercel.app/src/components/picker/test/basic/)
