### PR TITLE
feat(nav): remove ion-router integration

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -109,20 +109,62 @@ The following behaviors have been removed:
 - Navigating an `ion-nav` (via `push`, `pop`, `ion-nav-link`, or the swipe-to-go-back gesture) no longer updates the URL, and the router's navigation guards no longer run for `ion-nav` transitions.
 - The internal `setRouteId()` and `getRouteId()` methods and the `updateURL` nav option have been removed.
 
-Apps that relied on `ion-nav` to update the URL (for example, pushing components and expecting the browser URL to change) should use `ion-router-outlet` for URL-based routing:
+Apps that relied on `ion-nav` to update the URL (for example, pushing components and expecting the browser URL to change) should use `ion-router-outlet` for URL-based routing. Keep the `ion-route` definitions and swap the outlet element:
 
 ```diff
-- <ion-router>
--   <ion-nav root="page-one"></ion-nav>
-- </ion-router>
+  <ion-router>
+    <ion-route url="/" component="page-one"></ion-route>
+    <ion-route url="/page-two" component="page-two"></ion-route>
+  </ion-router>
+
+- <ion-nav></ion-nav>
 + <ion-router-outlet></ion-router-outlet>
 ```
 
-An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation:
+An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation. It manages its own stack via `root` and `ion-nav-link`, and the URL never changes as you push and pop:
 
 ```html
 <!-- Inside a routed page, an ion-nav manages a local, URL-less stack -->
 <ion-nav root="page-one"></ion-nav>
+
+<script>
+  // Each view is a standard custom element. Setting `root` renders the first
+  // view, and `ion-nav-link` pushes the next one. The URL never changes.
+  customElements.define(
+    'page-one',
+    class extends HTMLElement {
+      connectedCallback() {
+        this.innerHTML = `
+          <ion-header>
+            <ion-toolbar><ion-title>Page One</ion-title></ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">
+            <ion-nav-link router-direction="forward" component="page-two">
+              <ion-button>Go to Page Two</ion-button>
+            </ion-nav-link>
+          </ion-content>
+        `;
+      }
+    }
+  );
+
+  customElements.define(
+    'page-two',
+    class extends HTMLElement {
+      connectedCallback() {
+        this.innerHTML = `
+          <ion-header>
+            <ion-toolbar>
+              <ion-buttons slot="start"><ion-back-button></ion-back-button></ion-buttons>
+              <ion-title>Page Two</ion-title>
+            </ion-toolbar>
+          </ion-header>
+          <ion-content class="ion-padding">Page Two content</ion-content>
+        `;
+      }
+    }
+  );
+</script>
 ```
 
 <h4 id="version-9x-router-outlet">Router Outlet</h4>

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -109,12 +109,16 @@ The following behaviors have been removed:
 - Navigating an `ion-nav` (via `push`, `pop`, `ion-nav-link`, or the swipe-to-go-back gesture) no longer updates the URL, and the router's navigation guards no longer run for `ion-nav` transitions.
 - The internal `setRouteId()` and `getRouteId()` methods and the `updateURL` nav option have been removed.
 
-Apps that relied on `ion-nav` to update the URL (for example, pushing components and expecting the browser URL to change) should use `ion-router-outlet` for URL-based routing. An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation:
+Apps that relied on `ion-nav` to update the URL (for example, pushing components and expecting the browser URL to change) should use `ion-router-outlet` for URL-based routing:
 
-```html
-<!-- The outlet handles URL-based routing -->
-<ion-router-outlet></ion-router-outlet>
+```diff
+- <ion-router>
+-   <ion-nav root="page-one"></ion-nav>
+- </ion-router>
++ <ion-router-outlet></ion-router-outlet>
 ```
+
+An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation:
 
 ```html
 <!-- Inside a routed page, an ion-nav manages a local, URL-less stack -->

--- a/BREAKING.md
+++ b/BREAKING.md
@@ -20,6 +20,7 @@ This is a comprehensive list of the breaking changes introduced in the major ver
   - [Input](#version-9x-input)
   - [Legacy Picker](#version-9x-legacy-picker)
   - [Modal](#version-9x-modal)
+  - [Nav](#version-9x-nav)
   - [Router Outlet](#version-9x-router-outlet)
   - [Searchbar](#version-9x-searchbar)
   - [Select](#version-9x-select)
@@ -96,6 +97,28 @@ Sheet modals that relied on the handle being inert should set `handleBehavior="n
 
 ```html
 <ion-modal handle-behavior="none"></ion-modal>
+```
+
+<h4 id="version-9x-nav">Nav</h4>
+
+`ion-nav` no longer integrates with `ion-router`. It is now a standalone imperative stack navigation component, driven only through its own API (`root`, `push`, `pop`, `setRoot`, etc.) and `ion-nav-link`.
+
+The following behaviors have been removed:
+
+- The router no longer discovers or drives an `ion-nav`. Placing an `ion-nav` inside an `ion-router` no longer turns it into a routed outlet.
+- Navigating an `ion-nav` (via `push`, `pop`, `ion-nav-link`, or the swipe-to-go-back gesture) no longer updates the URL, and the router's navigation guards no longer run for `ion-nav` transitions.
+- The internal `setRouteId()` and `getRouteId()` methods and the `updateURL` nav option have been removed.
+
+Apps that relied on `ion-nav` to update the URL (for example, pushing components and expecting the browser URL to change) should use `ion-router-outlet` for URL-based routing. An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation:
+
+```html
+<!-- The outlet handles URL-based routing -->
+<ion-router-outlet></ion-router-outlet>
+```
+
+```html
+<!-- Inside a routed page, an ion-nav manages a local, URL-less stack -->
+<ion-nav root="page-one"></ion-nav>
 ```
 
 <h4 id="version-9x-router-outlet">Router Outlet</h4>

--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -2116,10 +2116,6 @@ export namespace Components {
          */
         "getPrevious": (view?: ViewController) => Promise<ViewController | undefined>;
         /**
-          * Called by <ion-router> to retrieve the current component.
-         */
-        "getRouteId": () => Promise<RouteID | undefined>;
-        /**
           * Inserts a component into the navigation stack at the specified index. This is useful to add a component at any point in the navigation stack.
           * @param insertIndex The index to insert the component at in the stack.
           * @param component The component to insert into the navigation stack.
@@ -2194,15 +2190,6 @@ export namespace Components {
           * @param done The transition complete function.
          */
         "setRoot": <T extends NavComponent>(component: T, componentProps?: ComponentProps<T> | null, opts?: NavOptions | null, done?: TransitionDoneFn) => Promise<boolean>;
-        /**
-          * Called by the router to update the view.
-          * @param id The component tag.
-          * @param params The component params.
-          * @param direction A direction hint.
-          * @param animation an AnimationBuilder.
-          * @return the status.
-         */
-        "setRouteId": (id: string, params: ComponentProps | undefined, direction: RouterDirection, animation?: AnimationBuilder) => Promise<RouteWrite>;
         /**
           * If the nav component should allow for swipe-to-go-back.
          */
@@ -2724,7 +2711,7 @@ export namespace Components {
          */
         "beforeLeave"?: NavigationHookCallback;
         /**
-          * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-nav`) when the route matches.  The value of this property is not always the tagname of the component to load, in `ion-tabs` it actually refers to the name of the `ion-tab` to select.
+          * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-router-outlet`) when the route matches.  The value of this property is not always the tagname of the component to load, in `ion-tabs` it actually refers to the name of the `ion-tab` to select.
          */
         "component": string;
         /**
@@ -7897,7 +7884,7 @@ declare namespace LocalJSX {
          */
         "beforeLeave"?: NavigationHookCallback;
         /**
-          * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-nav`) when the route matches.  The value of this property is not always the tagname of the component to load, in `ion-tabs` it actually refers to the name of the `ion-tab` to select.
+          * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-router-outlet`) when the route matches.  The value of this property is not always the tagname of the component to load, in `ion-tabs` it actually refers to the name of the `ion-tab` to select.
          */
         "component": string;
         /**

--- a/core/src/components/nav/nav-interface.ts
+++ b/core/src/components/nav/nav-interface.ts
@@ -42,7 +42,6 @@ export interface RouterOutletOptions {
 
 export interface NavOptions extends RouterOutletOptions {
   progressAnimation?: boolean;
-  updateURL?: boolean;
   delegate?: FrameworkDelegate;
   viewIsReady?: (enteringEl: HTMLElement) => Promise<any>;
 }

--- a/core/src/components/nav/nav.tsx
+++ b/core/src/components/nav/nav.tsx
@@ -1,5 +1,5 @@
-import type { EventEmitter } from '@stencil/core';
-import { Build, Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
+import type { ComponentInterface, EventEmitter } from '@stencil/core';
+import { Component, Element, Event, Method, Prop, Watch, h } from '@stencil/core';
 import { getTimeGivenProgression } from '@utils/animation/cubic-bezier';
 import { assert } from '@utils/helpers';
 import { printIonWarning } from '@utils/logging';
@@ -9,7 +9,6 @@ import { lifecycle, setPageHidden, transition } from '@utils/transition';
 import { config } from '../../global/config';
 import { getIonMode } from '../../global/ionic-global';
 import type { Animation, AnimationBuilder, ComponentProps, FrameworkDelegate, Gesture } from '../../interface';
-import type { NavOutlet, RouteID, RouteWrite, RouterDirection } from '../router/utils/interface';
 
 import { LIFECYCLE_DID_LEAVE, LIFECYCLE_WILL_LEAVE, LIFECYCLE_WILL_UNLOAD } from './constants';
 import type {
@@ -21,18 +20,17 @@ import type {
   TransitionInstruction,
 } from './nav-interface';
 import type { ViewController } from './view-controller';
-import { VIEW_STATE_ATTACHED, VIEW_STATE_DESTROYED, VIEW_STATE_NEW, convertToViews, matches } from './view-controller';
+import { VIEW_STATE_ATTACHED, VIEW_STATE_DESTROYED, VIEW_STATE_NEW, convertToViews } from './view-controller';
 
 @Component({
   tag: 'ion-nav',
   styleUrl: 'nav.scss',
   shadow: true,
 })
-export class Nav implements NavOutlet {
+export class Nav implements ComponentInterface {
   private transInstr: TransitionInstruction[] = [];
   private sbAni?: Animation;
   private gestureOrAnimationInProgress = false;
-  private useRouter = false;
   private isTransitioning = false;
   private destroyed = false;
   private views: ViewController[] = [];
@@ -78,8 +76,6 @@ export class Nav implements NavOutlet {
 
   @Watch('root')
   rootChanged() {
-    const isDev = Build.isDev;
-
     if (this.root === undefined) {
       return;
     }
@@ -92,13 +88,7 @@ export class Nav implements NavOutlet {
       return;
     }
 
-    if (!this.useRouter) {
-      if (this.root !== undefined) {
-        this.setRoot(this.root, this.rootParams);
-      }
-    } else if (isDev) {
-      printIonWarning('[ion-nav] - A root attribute is not supported when using ion-router.', this.el);
-    }
+    this.setRoot(this.root, this.rootParams);
   }
 
   /**
@@ -116,8 +106,6 @@ export class Nav implements NavOutlet {
   @Event({ bubbles: false }) ionNavDidChange!: EventEmitter<void>;
 
   componentWillLoad() {
-    this.useRouter = document.querySelector('ion-router') !== null && this.el.closest('[no-router]') === null;
-
     if (this.swipeGesture === undefined) {
       const mode = getIonMode(this);
       this.swipeGesture = config.getBoolean('swipeBackEnabled', mode === 'ios');
@@ -353,99 +341,6 @@ export class Nav implements NavOutlet {
   }
 
   /**
-   * Called by the router to update the view.
-   *
-   * @param id The component tag.
-   * @param params The component params.
-   * @param direction A direction hint.
-   * @param animation an AnimationBuilder.
-   *
-   * @return the status.
-   * @internal
-   */
-  @Method()
-  setRouteId(
-    id: string,
-    params: ComponentProps | undefined,
-    direction: RouterDirection,
-    animation?: AnimationBuilder
-  ): Promise<RouteWrite> {
-    const active = this.getActiveSync();
-    if (matches(active, id, params)) {
-      return Promise.resolve({
-        changed: false,
-        element: active.element,
-      });
-    }
-
-    let resolve: (result: RouteWrite) => void;
-    const promise = new Promise<RouteWrite>((r) => (resolve = r));
-    let finish: Promise<boolean>;
-    const commonOpts: NavOptions = {
-      updateURL: false,
-      viewIsReady: (enteringEl) => {
-        let mark: () => void;
-        const p = new Promise<void>((r) => (mark = r));
-        resolve({
-          changed: true,
-          element: enteringEl,
-          markVisible: async () => {
-            mark();
-            await finish;
-          },
-        });
-        return p;
-      },
-    };
-
-    if (direction === 'root') {
-      finish = this.setRoot(id, params, commonOpts);
-    } else {
-      // Look for a view matching the target in the view stack.
-      const viewController = this.views.find((v) => matches(v, id, params));
-
-      if (viewController) {
-        finish = this.popTo(viewController, {
-          ...commonOpts,
-          direction: 'back',
-          animationBuilder: animation,
-        });
-      } else if (direction === 'forward') {
-        finish = this.push(id, params, {
-          ...commonOpts,
-          animationBuilder: animation,
-        });
-      } else if (direction === 'back') {
-        finish = this.setRoot(id, params, {
-          ...commonOpts,
-          direction: 'back',
-          animated: true,
-          animationBuilder: animation,
-        });
-      }
-    }
-    return promise;
-  }
-
-  /**
-   * Called by <ion-router> to retrieve the current component.
-   *
-   * @internal
-   */
-  @Method()
-  async getRouteId(): Promise<RouteID | undefined> {
-    const active = this.getActiveSync();
-    if (active) {
-      return {
-        id: active.element!.tagName,
-        params: active.params,
-        element: active.element,
-      };
-    }
-    return undefined;
-  }
-
-  /**
    * Get the active view.
    */
   @Method()
@@ -524,26 +419,6 @@ export class Nav implements NavOutlet {
     });
     ti.done = done;
 
-    /**
-     * If using router, check to see if navigation hooks
-     * will allow us to perform this transition. This
-     * is required in order for hooks to work with
-     * the ion-back-button or swipe to go back.
-     */
-    if (ti.opts && ti.opts.updateURL !== false && this.useRouter) {
-      const router = document.querySelector('ion-router');
-      if (router) {
-        const canTransition = await router.canTransition();
-        if (canTransition === false) {
-          return false;
-        }
-        if (typeof canTransition === 'string') {
-          router.push(canTransition, ti.opts!.direction || 'back');
-          return false;
-        }
-      }
-    }
-
     // Normalize empty
     if (ti.insertViews?.length === 0) {
       ti.insertViews = undefined;
@@ -575,14 +450,6 @@ export class Nav implements NavOutlet {
       );
     }
     ti.resolve!(result.hasCompleted);
-
-    if (ti.opts!.updateURL !== false && this.useRouter) {
-      const router = document.querySelector('ion-router');
-      if (router) {
-        const direction = result.direction === 'back' ? 'back' : 'forward';
-        router.navChanged(direction);
-      }
-    }
   }
 
   private failed(rejectReason: any, ti: TransitionInstruction) {

--- a/core/src/components/nav/test/routing/index.html
+++ b/core/src/components/nav/test/routing/index.html
@@ -15,14 +15,21 @@
   </head>
 
   <body>
+    <!--
+      As of Ionic 9, ion-nav no longer integrates with ion-router. This page
+      reproduces the pattern from https://github.com/ionic-team/ionic-framework/issues/24641,
+      where an ion-router and an ion-nav coexist. The ion-nav must manage its own
+      stack via `root` and ion-nav-link, the URL must never change as the stack
+      changes, and the page must still finish loading even though the router has no
+      outlet to drive.
+    -->
     <ion-app>
-      <ion-router>
+      <ion-router use-hash="true">
         <ion-route url="/" component="page-root"></ion-route>
         <ion-route url="/page-one" component="page-one"></ion-route>
         <ion-route url="/page-two" component="page-two"></ion-route>
-        <ion-route url="/page-three" component="page-three"></ion-route>
       </ion-router>
-      <ion-nav></ion-nav>
+      <ion-nav root="page-root"></ion-nav>
     </ion-app>
 
     <script>
@@ -78,28 +85,6 @@
           </ion-header>
           <ion-content class="ion-padding">
             <h1>Page Two</h1>
-            <div>
-              <ion-nav-link router-direction="forward" component="page-three">
-                <button class="next">Go to Page Three</button>
-              </ion-nav-link>
-            </div>
-          </ion-content>
-        `;
-        }
-      }
-      class PageThree extends HTMLElement {
-        connectedCallback() {
-          this.innerHTML = `
-          <ion-header>
-            <ion-toolbar>
-              <ion-buttons slot="start">
-                <ion-back-button></ion-back-button>
-              </ion-buttons>
-              <ion-title>Page Three</ion-title>
-            </ion-toolbar>
-          </ion-header>
-          <ion-content class="ion-padding">
-            <h1>Page Three</h1>
           </ion-content>
         `;
         }
@@ -107,7 +92,6 @@
       customElements.define('page-root', PageRoot);
       customElements.define('page-one', PageOne);
       customElements.define('page-two', PageTwo);
-      customElements.define('page-three', PageThree);
     </script>
   </body>
 </html>

--- a/core/src/components/nav/test/routing/nav.e2e.ts
+++ b/core/src/components/nav/test/routing/nav.e2e.ts
@@ -1,10 +1,13 @@
 import { expect } from '@playwright/test';
 import { configs, test } from '@utils/test/playwright';
 
-// Tests for ion-nav used in ion-router
-
 /**
- * This behavior does not vary across modes/directions
+ * As of Ionic 9, ion-nav is a standalone stack navigation component and no longer
+ * integrates with ion-router. These tests verify that an ion-nav still manages its
+ * own stack when an ion-router is present on the page, and that navigating the nav
+ * never syncs to the router (the URL does not change).
+ *
+ * This behavior does not vary across modes/directions.
  */
 configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('nav: routing'), () => {
@@ -12,50 +15,28 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await page.goto('/src/components/nav/test/routing', config);
     });
 
-    test('should render the root component', async ({ page }) => {
+    test('should render the root component from the root property', async ({ page }) => {
       const pageRoot = page.locator('page-root');
 
       await expect(pageRoot).toBeVisible();
     });
 
-    test.describe('pushing a new page', () => {
-      test('should render the pushed component', async ({ page }) => {
-        const pageRoot = page.locator('page-root');
-        const pageOne = page.locator('page-one');
-        const pageTwo = page.locator('page-two');
+    test('pushing a page should not update the URL', async ({ page }) => {
+      const urlBefore = page.url();
 
-        const pageOneButton = page.locator('button:has-text("Go to Page One")');
-        const pageTwoButton = page.locator('button:has-text("Go to Page Two")');
+      const pageOne = page.locator('page-one');
+      const pageOneButton = page.locator('button:has-text("Go to Page One")');
 
-        await pageOneButton.click();
-        await page.waitForChanges();
+      await pageOneButton.click();
+      await page.waitForChanges();
 
-        await expect(pageOne).toBeVisible();
-        // Pushing a new page should hide the previous page
-        await expect(pageRoot).not.toBeVisible();
-        await expect(pageRoot).toHaveCount(1);
-
-        await pageTwoButton.click();
-        await page.waitForChanges();
-
-        await expect(pageTwo).toBeVisible();
-        // Pushing a new page should hide the previous page
-        await expect(pageOne).not.toBeVisible();
-        await expect(pageOne).toHaveCount(1);
-      });
-
-      test('should render the back button', async ({ page }) => {
-        const pageOneButton = page.locator('button:has-text("Go to Page One")');
-        const pageOneBackButton = page.locator('page-one ion-back-button');
-
-        await pageOneButton.click();
-        await page.waitForChanges();
-
-        await expect(pageOneBackButton).toBeVisible();
-      });
+      // The nav stack advances...
+      await expect(pageOne).toBeVisible();
+      // ...but the router is not involved, so the URL is unchanged.
+      expect(page.url()).toBe(urlBefore);
     });
 
-    test('back button should pop to the previous page', async ({ page }) => {
+    test('back button should pop the nav stack without touching the URL', async ({ page }) => {
       const pageRoot = page.locator('page-root');
       const pageOne = page.locator('page-one');
 
@@ -65,46 +46,38 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await pageOneButton.click();
       await page.waitForChanges();
 
+      const urlAfterPush = page.url();
+
       await pageOneBackButton.click();
       await page.waitForChanges();
 
       await expect(pageRoot).toBeVisible();
-      // Popping a page should remove it from the DOM
+      // Popping a page removes it from the DOM.
       await expect(pageOne).toHaveCount(0);
+      // The router never observed the pop, so the URL is unchanged.
+      expect(page.url()).toBe(urlAfterPush);
     });
 
-    test.describe('pushing multiple pages', () => {
-      test('should keep previous pages in the DOM', async ({ page }) => {
-        const pageRoot = page.locator('page-root');
-        const pageOne = page.locator('page-one');
-        const pageTwo = page.locator('page-two');
-        const pageThree = page.locator('page-three');
+    test('pushing multiple pages should keep previous pages in the DOM', async ({ page }) => {
+      const pageRoot = page.locator('page-root');
+      const pageOne = page.locator('page-one');
+      const pageTwo = page.locator('page-two');
 
-        const pageOneButton = page.locator('button:has-text("Go to Page One")');
-        const pageTwoButton = page.locator('button:has-text("Go to Page Two")');
-        const pageThreeButton = page.locator('button:has-text("Go to Page Three")');
+      const pageOneButton = page.locator('button:has-text("Go to Page One")');
+      const pageTwoButton = page.locator('button:has-text("Go to Page Two")');
 
-        await pageOneButton.click();
-        await page.waitForChanges();
+      await pageOneButton.click();
+      await page.waitForChanges();
 
-        await expect(pageRoot).toHaveCount(1);
-        await expect(pageOne).toBeVisible();
+      await expect(pageRoot).toHaveCount(1);
+      await expect(pageOne).toBeVisible();
 
-        await pageTwoButton.click();
-        await page.waitForChanges();
+      await pageTwoButton.click();
+      await page.waitForChanges();
 
-        await expect(pageRoot).toHaveCount(1);
-        await expect(pageOne).toHaveCount(1);
-        await expect(pageTwo).toBeVisible();
-
-        await pageThreeButton.click();
-        await page.waitForChanges();
-
-        await expect(pageRoot).toHaveCount(1);
-        await expect(pageOne).toHaveCount(1);
-        await expect(pageTwo).toHaveCount(1);
-        await expect(pageThree).toBeVisible();
-      });
+      await expect(pageRoot).toHaveCount(1);
+      await expect(pageOne).toHaveCount(1);
+      await expect(pageTwo).toBeVisible();
     });
   });
 });

--- a/core/src/components/route/route.tsx
+++ b/core/src/components/route/route.tsx
@@ -18,7 +18,7 @@ export class Route implements ComponentInterface {
   @Prop() url = '';
 
   /**
-   * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-nav`)
+   * Name of the component to load/select in the navigation outlet (`ion-tabs`, `ion-router-outlet`)
    * when the route matches.
    *
    * The value of this property is not always the tagname of the component to load,

--- a/core/src/components/router/test/basic/index.html
+++ b/core/src/components/router/test/basic/index.html
@@ -95,7 +95,7 @@
           </ion-toolbar>
         </ion-header>
         <ion-content>
-          <ion-nav></ion-nav>
+          <ion-router-outlet></ion-router-outlet>
         </ion-content>`;
         }
       }
@@ -222,7 +222,7 @@
         <ion-route-redirect from="/redirect-to-three" to="/three?has_query_string=true"></ion-route-redirect>
       </ion-router>
 
-      <ion-nav></ion-nav>
+      <ion-router-outlet></ion-router-outlet>
     </ion-app>
 
     <style>

--- a/core/src/components/router/test/dom.spec.tsx
+++ b/core/src/components/router/test/dom.spec.tsx
@@ -1,4 +1,4 @@
-import { scrollToFragment } from '../utils/dom';
+import { scrollToFragment, waitUntilNavNode } from '../utils/dom';
 
 describe('scrollToFragment', () => {
   beforeEach(() => {
@@ -95,5 +95,58 @@ describe('scrollToFragment', () => {
     `;
     // Lookup of 'other' must succeed even though a hidden sibling page exists.
     expect(await scrollToFragment('other')).toBe(true);
+  });
+});
+
+describe('waitUntilNavNode', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    jest.useRealTimers();
+  });
+
+  it('should resolve immediately when an outlet is already present', async () => {
+    document.body.innerHTML = '<ion-router-outlet></ion-router-outlet>';
+    await expect(waitUntilNavNode()).resolves.toBeUndefined();
+  });
+
+  it('should resolve when an outlet announces itself via ionNavWillLoad', async () => {
+    document.body.innerHTML = '';
+
+    let resolved = false;
+    const promise = waitUntilNavNode().then(() => {
+      resolved = true;
+    });
+
+    // Nothing to render yet, so the router keeps waiting.
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    // An outlet mounts and fires the load event.
+    document.body.innerHTML = '<ion-router-outlet></ion-router-outlet>';
+    window.dispatchEvent(new Event('ionNavWillLoad'));
+
+    await promise;
+    expect(resolved).toBe(true);
+  });
+
+  it('should resolve after a timeout when no outlet is ever found', async () => {
+    // Regression guard for the router hanging on a page that has no outlet
+    // (e.g. an ion-router with only an ion-nav, which is no longer an outlet as
+    // of Ionic 9). Without the timeout the returned promise would never settle.
+    jest.useFakeTimers();
+    document.body.innerHTML = '';
+
+    let resolved = false;
+    const promise = waitUntilNavNode().then(() => {
+      resolved = true;
+    });
+
+    await Promise.resolve();
+    expect(resolved).toBe(false);
+
+    jest.advanceTimersByTime(500);
+
+    await promise;
+    expect(resolved).toBe(true);
   });
 });

--- a/core/src/components/router/test/guards/index.html
+++ b/core/src/components/router/test/guards/index.html
@@ -56,7 +56,7 @@
         <ion-header>
           <ion-toolbar>
             <ion-buttons>
-              <ion-back-button default-href="/test"></ion-back-button>
+              <ion-back-button default-href="/home"></ion-back-button>
             </ion-buttons>
             <ion-title>Child Page</ion-title>
           </ion-toolbar>
@@ -72,7 +72,7 @@
         <ion-header>
           <ion-toolbar>
             <ion-buttons>
-              <ion-back-button></ion-back-button>
+              <ion-back-button default-href="/home"></ion-back-button>
             </ion-buttons>
             <ion-title>Test Page</ion-title>
           </ion-toolbar>
@@ -155,7 +155,7 @@
         <ion-route url="/guard-initial-page" component="guard-initial-page"></ion-route>
       </ion-router>
 
-      <ion-nav></ion-nav>
+      <ion-router-outlet></ion-router-outlet>
 
       <script>
         const beforeEnterGroup = document.querySelector('ion-radio-group#beforeEnter');

--- a/core/src/components/router/utils/dom.ts
+++ b/core/src/components/router/utils/dom.ts
@@ -1,6 +1,7 @@
+import { Build } from '@stencil/core';
 import { findClosestIonContent, getScrollElement, isIonContent } from '@utils/content';
 import { componentOnReady, raf } from '@utils/helpers';
-import { printIonError } from '@utils/logging';
+import { printIonError, printIonWarning } from '@utils/logging';
 
 import type { AnimationBuilder } from '../../../interface';
 
@@ -202,17 +203,41 @@ export const scrollToFragment = async (
   }
 };
 
+/** How long the router waits for a navigation outlet before giving up and proceeding. */
+const NAV_NODE_TIMEOUT = 500;
+
 export const waitUntilNavNode = (): Promise<void> => {
   if (searchNavNode(document.body)) {
     return Promise.resolve();
   }
   return new Promise((resolve) => {
-    window.addEventListener('ionNavWillLoad', () => resolve(), { once: true });
+    /**
+     * Outlets emit `ionNavWillLoad` as they load, so resolve as soon as one does.
+     * A timeout backstops the case where the page has no outlet at all: without it
+     * the router would wait forever and its `componentWillLoad` would never settle,
+     * which in turn prevents the app from signalling that it has finished loading.
+     */
+    const done = () => {
+      window.removeEventListener('ionNavWillLoad', done);
+      clearTimeout(timeout);
+
+      if (Build.isDev && !searchNavNode(document.body)) {
+        printIonWarning(
+          '[ion-router] - No outlet found. The router requires an ion-router-outlet or ion-tabs to render routed views. ' +
+            'Note that as of Ionic 9 ion-nav is no longer a router outlet.'
+        );
+      }
+
+      resolve();
+    };
+
+    const timeout = setTimeout(done, NAV_NODE_TIMEOUT);
+    window.addEventListener('ionNavWillLoad', done, { once: true });
   });
 };
 
 /** Selector for all the outlets supported by the router. */
-const OUTLET_SELECTOR = ':not([no-router]) ion-nav, :not([no-router]) ion-tabs, :not([no-router]) ion-router-outlet';
+const OUTLET_SELECTOR = ':not([no-router]) ion-tabs, :not([no-router]) ion-router-outlet';
 
 const searchNavNode = (root: HTMLElement | undefined): NavOutletElement | undefined => {
   if (!root) {

--- a/core/src/utils/animation/test/animationbuilder/animation.e2e.ts
+++ b/core/src/utils/animation/test/animationbuilder/animation.e2e.ts
@@ -16,18 +16,21 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
 });
 
 const testNavigation = async (page: E2EPage) => {
-  const ionRouteDidChange = await page.spyOnEvent('ionRouteDidChange');
+  // ionNavDidChange is emitted with bubbles: false, so spy on the ion-nav host
+  // element directly rather than at the window level.
+  const nav = page.locator('ion-nav');
+  const ionNavDidChange = await nav.spyOnEvent('ionNavDidChange');
 
   await page.click('page-root ion-button.next');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
   await page.click('page-one ion-button.next');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
   await page.click('page-two ion-button.next');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
   await page.click('page-three ion-back-button');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
   await page.click('page-two ion-back-button');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
   await page.click('page-one ion-back-button');
-  await ionRouteDidChange.next();
+  await ionNavDidChange.next();
 };

--- a/core/src/utils/animation/test/animationbuilder/index.html
+++ b/core/src/utils/animation/test/animationbuilder/index.html
@@ -116,13 +116,7 @@
 
   <body>
     <ion-app>
-      <ion-router>
-        <ion-route url="/" component="page-root"></ion-route>
-        <ion-route url="/page-one" component="page-one"></ion-route>
-        <ion-route url="/page-two" component="page-two"></ion-route>
-        <ion-route url="/page-three" component="page-three"></ion-route>
-      </ion-router>
-      <ion-nav></ion-nav>
+      <ion-nav root="page-root"></ion-nav>
     </ion-app>
   </body>
 </html>

--- a/core/src/utils/focus-controller/test/generic/index.html
+++ b/core/src/utils/focus-controller/test/generic/index.html
@@ -93,13 +93,7 @@
 
   <body>
     <ion-app>
-      <ion-router>
-        <ion-route url="/" component="page-root"></ion-route>
-        <ion-route url="/page-one" component="page-one"></ion-route>
-        <ion-route url="/page-two" component="page-two"></ion-route>
-        <ion-route url="/page-three" component="page-three"></ion-route>
-      </ion-router>
-      <ion-nav></ion-nav>
+      <ion-nav root="page-root"></ion-nav>
     </ion-app>
   </body>
 </html>

--- a/core/src/utils/focus-controller/test/ionic/index.html
+++ b/core/src/utils/focus-controller/test/ionic/index.html
@@ -92,13 +92,7 @@
 
   <body>
     <ion-app>
-      <ion-router>
-        <ion-route url="/" component="page-root"></ion-route>
-        <ion-route url="/page-one" component="page-one"></ion-route>
-        <ion-route url="/page-two" component="page-two"></ion-route>
-        <ion-route url="/page-three" component="page-three"></ion-route>
-      </ion-router>
-      <ion-nav></ion-nav>
+      <ion-nav root="page-root"></ion-nav>
     </ion-app>
   </body>
 </html>

--- a/packages/react/src/components/components.ts
+++ b/packages/react/src/components/components.ts
@@ -11,1027 +11,1430 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
 import { createComponent } from '@stencil/react-output-target/runtime';
 import React from 'react';
 
-import { type AccordionGroupChangeEventDetail, type BreadcrumbCollapsedClickEventDetail, type CheckboxChangeEventDetail, type DatetimeChangeEventDetail, type InputChangeEventDetail, type InputInputEventDetail, type InputOtpChangeEventDetail, type InputOtpCompleteEventDetail, type InputOtpInputEventDetail, type IonAccordionGroupCustomEvent, type IonBackdropCustomEvent, type IonBreadcrumbsCustomEvent, type IonCheckboxCustomEvent, type IonContentCustomEvent, type IonDatetimeCustomEvent, type IonImgCustomEvent, type IonInfiniteScrollCustomEvent, type IonInputCustomEvent, type IonInputOtpCustomEvent, type IonItemOptionsCustomEvent, type IonItemSlidingCustomEvent, type IonMenuCustomEvent, type IonNavCustomEvent, type IonPickerColumnCustomEvent, type IonRadioCustomEvent, type IonRadioGroupCustomEvent, type IonRangeCustomEvent, type IonRefresherCustomEvent, type IonReorderGroupCustomEvent, type IonSearchbarCustomEvent, type IonSegmentCustomEvent, type IonSegmentViewCustomEvent, type IonSelectCustomEvent, type IonSplitPaneCustomEvent, type IonTextareaCustomEvent, type IonToggleCustomEvent, type ItemReorderEventDetail, type MenuCloseEventDetail, type PickerColumnChangeEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail, type RangeKnobMoveEndEventDetail, type RangeKnobMoveStartEventDetail, type RefresherEventDetail, type RefresherPullEndEventDetail, type ReorderEndEventDetail, type ReorderMoveEventDetail, type ScrollBaseDetail, type ScrollDetail, type SearchbarChangeEventDetail, type SearchbarInputEventDetail, type SegmentChangeEventDetail, type SegmentViewScrollEvent, type SelectChangeEventDetail, type TextareaChangeEventDetail, type TextareaInputEventDetail, type ToggleChangeEventDetail } from "@ionic/core";
-import type { Components } from "@ionic/core/components";
-import { IonAccordionGroup as IonAccordionGroupElement, defineCustomElement as defineIonAccordionGroup } from "@ionic/core/components/ion-accordion-group.js";
-import { IonAccordion as IonAccordionElement, defineCustomElement as defineIonAccordion } from "@ionic/core/components/ion-accordion.js";
-import { IonAvatar as IonAvatarElement, defineCustomElement as defineIonAvatar } from "@ionic/core/components/ion-avatar.js";
-import { IonBackdrop as IonBackdropElement, defineCustomElement as defineIonBackdrop } from "@ionic/core/components/ion-backdrop.js";
-import { IonBadge as IonBadgeElement, defineCustomElement as defineIonBadge } from "@ionic/core/components/ion-badge.js";
-import { IonBreadcrumbs as IonBreadcrumbsElement, defineCustomElement as defineIonBreadcrumbs } from "@ionic/core/components/ion-breadcrumbs.js";
-import { IonButtons as IonButtonsElement, defineCustomElement as defineIonButtons } from "@ionic/core/components/ion-buttons.js";
-import { IonCardContent as IonCardContentElement, defineCustomElement as defineIonCardContent } from "@ionic/core/components/ion-card-content.js";
-import { IonCardHeader as IonCardHeaderElement, defineCustomElement as defineIonCardHeader } from "@ionic/core/components/ion-card-header.js";
-import { IonCardSubtitle as IonCardSubtitleElement, defineCustomElement as defineIonCardSubtitle } from "@ionic/core/components/ion-card-subtitle.js";
-import { IonCardTitle as IonCardTitleElement, defineCustomElement as defineIonCardTitle } from "@ionic/core/components/ion-card-title.js";
-import { IonCheckbox as IonCheckboxElement, defineCustomElement as defineIonCheckbox } from "@ionic/core/components/ion-checkbox.js";
-import { IonChip as IonChipElement, defineCustomElement as defineIonChip } from "@ionic/core/components/ion-chip.js";
-import { IonCol as IonColElement, defineCustomElement as defineIonCol } from "@ionic/core/components/ion-col.js";
-import { IonContent as IonContentElement, defineCustomElement as defineIonContent } from "@ionic/core/components/ion-content.js";
-import { IonDatetimeButton as IonDatetimeButtonElement, defineCustomElement as defineIonDatetimeButton } from "@ionic/core/components/ion-datetime-button.js";
-import { IonDatetime as IonDatetimeElement, defineCustomElement as defineIonDatetime } from "@ionic/core/components/ion-datetime.js";
-import { IonFabList as IonFabListElement, defineCustomElement as defineIonFabList } from "@ionic/core/components/ion-fab-list.js";
-import { IonFab as IonFabElement, defineCustomElement as defineIonFab } from "@ionic/core/components/ion-fab.js";
-import { IonFooter as IonFooterElement, defineCustomElement as defineIonFooter } from "@ionic/core/components/ion-footer.js";
-import { IonGrid as IonGridElement, defineCustomElement as defineIonGrid } from "@ionic/core/components/ion-grid.js";
-import { IonHeader as IonHeaderElement, defineCustomElement as defineIonHeader } from "@ionic/core/components/ion-header.js";
-import { IonImg as IonImgElement, defineCustomElement as defineIonImg } from "@ionic/core/components/ion-img.js";
-import { IonInfiniteScrollContent as IonInfiniteScrollContentElement, defineCustomElement as defineIonInfiniteScrollContent } from "@ionic/core/components/ion-infinite-scroll-content.js";
-import { IonInfiniteScroll as IonInfiniteScrollElement, defineCustomElement as defineIonInfiniteScroll } from "@ionic/core/components/ion-infinite-scroll.js";
-import { IonInputOtp as IonInputOtpElement, defineCustomElement as defineIonInputOtp } from "@ionic/core/components/ion-input-otp.js";
-import { IonInputPasswordToggle as IonInputPasswordToggleElement, defineCustomElement as defineIonInputPasswordToggle } from "@ionic/core/components/ion-input-password-toggle.js";
-import { IonInput as IonInputElement, defineCustomElement as defineIonInput } from "@ionic/core/components/ion-input.js";
-import { IonItemDivider as IonItemDividerElement, defineCustomElement as defineIonItemDivider } from "@ionic/core/components/ion-item-divider.js";
-import { IonItemGroup as IonItemGroupElement, defineCustomElement as defineIonItemGroup } from "@ionic/core/components/ion-item-group.js";
-import { IonItemOptions as IonItemOptionsElement, defineCustomElement as defineIonItemOptions } from "@ionic/core/components/ion-item-options.js";
-import { IonItemSliding as IonItemSlidingElement, defineCustomElement as defineIonItemSliding } from "@ionic/core/components/ion-item-sliding.js";
-import { IonLabel as IonLabelElement, defineCustomElement as defineIonLabel } from "@ionic/core/components/ion-label.js";
-import { IonListHeader as IonListHeaderElement, defineCustomElement as defineIonListHeader } from "@ionic/core/components/ion-list-header.js";
-import { IonList as IonListElement, defineCustomElement as defineIonList } from "@ionic/core/components/ion-list.js";
-import { IonMenuButton as IonMenuButtonElement, defineCustomElement as defineIonMenuButton } from "@ionic/core/components/ion-menu-button.js";
-import { IonMenuToggle as IonMenuToggleElement, defineCustomElement as defineIonMenuToggle } from "@ionic/core/components/ion-menu-toggle.js";
-import { IonMenu as IonMenuElement, defineCustomElement as defineIonMenu } from "@ionic/core/components/ion-menu.js";
-import { IonNavLink as IonNavLinkElement, defineCustomElement as defineIonNavLink } from "@ionic/core/components/ion-nav-link.js";
-import { IonNav as IonNavElement, defineCustomElement as defineIonNav } from "@ionic/core/components/ion-nav.js";
-import { IonNote as IonNoteElement, defineCustomElement as defineIonNote } from "@ionic/core/components/ion-note.js";
-import { IonPickerColumnOption as IonPickerColumnOptionElement, defineCustomElement as defineIonPickerColumnOption } from "@ionic/core/components/ion-picker-column-option.js";
-import { IonPickerColumn as IonPickerColumnElement, defineCustomElement as defineIonPickerColumn } from "@ionic/core/components/ion-picker-column.js";
-import { IonPicker as IonPickerElement, defineCustomElement as defineIonPicker } from "@ionic/core/components/ion-picker.js";
-import { IonProgressBar as IonProgressBarElement, defineCustomElement as defineIonProgressBar } from "@ionic/core/components/ion-progress-bar.js";
-import { IonRadioGroup as IonRadioGroupElement, defineCustomElement as defineIonRadioGroup } from "@ionic/core/components/ion-radio-group.js";
-import { IonRadio as IonRadioElement, defineCustomElement as defineIonRadio } from "@ionic/core/components/ion-radio.js";
-import { IonRange as IonRangeElement, defineCustomElement as defineIonRange } from "@ionic/core/components/ion-range.js";
-import { IonRefresherContent as IonRefresherContentElement, defineCustomElement as defineIonRefresherContent } from "@ionic/core/components/ion-refresher-content.js";
-import { IonRefresher as IonRefresherElement, defineCustomElement as defineIonRefresher } from "@ionic/core/components/ion-refresher.js";
-import { IonReorderGroup as IonReorderGroupElement, defineCustomElement as defineIonReorderGroup } from "@ionic/core/components/ion-reorder-group.js";
-import { IonReorder as IonReorderElement, defineCustomElement as defineIonReorder } from "@ionic/core/components/ion-reorder.js";
-import { IonRippleEffect as IonRippleEffectElement, defineCustomElement as defineIonRippleEffect } from "@ionic/core/components/ion-ripple-effect.js";
-import { IonRow as IonRowElement, defineCustomElement as defineIonRow } from "@ionic/core/components/ion-row.js";
-import { IonSearchbar as IonSearchbarElement, defineCustomElement as defineIonSearchbar } from "@ionic/core/components/ion-searchbar.js";
-import { IonSegmentButton as IonSegmentButtonElement, defineCustomElement as defineIonSegmentButton } from "@ionic/core/components/ion-segment-button.js";
-import { IonSegmentContent as IonSegmentContentElement, defineCustomElement as defineIonSegmentContent } from "@ionic/core/components/ion-segment-content.js";
-import { IonSegmentView as IonSegmentViewElement, defineCustomElement as defineIonSegmentView } from "@ionic/core/components/ion-segment-view.js";
-import { IonSegment as IonSegmentElement, defineCustomElement as defineIonSegment } from "@ionic/core/components/ion-segment.js";
-import { IonSelectModal as IonSelectModalElement, defineCustomElement as defineIonSelectModal } from "@ionic/core/components/ion-select-modal.js";
-import { IonSelectOption as IonSelectOptionElement, defineCustomElement as defineIonSelectOption } from "@ionic/core/components/ion-select-option.js";
-import { IonSelect as IonSelectElement, defineCustomElement as defineIonSelect } from "@ionic/core/components/ion-select.js";
-import { IonSkeletonText as IonSkeletonTextElement, defineCustomElement as defineIonSkeletonText } from "@ionic/core/components/ion-skeleton-text.js";
-import { IonSpinner as IonSpinnerElement, defineCustomElement as defineIonSpinner } from "@ionic/core/components/ion-spinner.js";
-import { IonSplitPane as IonSplitPaneElement, defineCustomElement as defineIonSplitPane } from "@ionic/core/components/ion-split-pane.js";
-import { IonTab as IonTabElement, defineCustomElement as defineIonTab } from "@ionic/core/components/ion-tab.js";
-import { IonText as IonTextElement, defineCustomElement as defineIonText } from "@ionic/core/components/ion-text.js";
-import { IonTextarea as IonTextareaElement, defineCustomElement as defineIonTextarea } from "@ionic/core/components/ion-textarea.js";
-import { IonThumbnail as IonThumbnailElement, defineCustomElement as defineIonThumbnail } from "@ionic/core/components/ion-thumbnail.js";
-import { IonTitle as IonTitleElement, defineCustomElement as defineIonTitle } from "@ionic/core/components/ion-title.js";
-import { IonToggle as IonToggleElement, defineCustomElement as defineIonToggle } from "@ionic/core/components/ion-toggle.js";
-import { IonToolbar as IonToolbarElement, defineCustomElement as defineIonToolbar } from "@ionic/core/components/ion-toolbar.js";
+import {
+  type AccordionGroupChangeEventDetail,
+  type BreadcrumbCollapsedClickEventDetail,
+  type CheckboxChangeEventDetail,
+  type DatetimeChangeEventDetail,
+  type InputChangeEventDetail,
+  type InputInputEventDetail,
+  type InputOtpChangeEventDetail,
+  type InputOtpCompleteEventDetail,
+  type InputOtpInputEventDetail,
+  type IonAccordionGroupCustomEvent,
+  type IonBackdropCustomEvent,
+  type IonBreadcrumbsCustomEvent,
+  type IonCheckboxCustomEvent,
+  type IonContentCustomEvent,
+  type IonDatetimeCustomEvent,
+  type IonImgCustomEvent,
+  type IonInfiniteScrollCustomEvent,
+  type IonInputCustomEvent,
+  type IonInputOtpCustomEvent,
+  type IonItemOptionsCustomEvent,
+  type IonItemSlidingCustomEvent,
+  type IonMenuCustomEvent,
+  type IonNavCustomEvent,
+  type IonPickerColumnCustomEvent,
+  type IonRadioCustomEvent,
+  type IonRadioGroupCustomEvent,
+  type IonRangeCustomEvent,
+  type IonRefresherCustomEvent,
+  type IonReorderGroupCustomEvent,
+  type IonSearchbarCustomEvent,
+  type IonSegmentCustomEvent,
+  type IonSegmentViewCustomEvent,
+  type IonSelectCustomEvent,
+  type IonSplitPaneCustomEvent,
+  type IonTextareaCustomEvent,
+  type IonToggleCustomEvent,
+  type ItemReorderEventDetail,
+  type MenuCloseEventDetail,
+  type PickerColumnChangeEventDetail,
+  type RadioGroupChangeEventDetail,
+  type RangeChangeEventDetail,
+  type RangeKnobMoveEndEventDetail,
+  type RangeKnobMoveStartEventDetail,
+  type RefresherEventDetail,
+  type RefresherPullEndEventDetail,
+  type ReorderEndEventDetail,
+  type ReorderMoveEventDetail,
+  type ScrollBaseDetail,
+  type ScrollDetail,
+  type SearchbarChangeEventDetail,
+  type SearchbarInputEventDetail,
+  type SegmentChangeEventDetail,
+  type SegmentViewScrollEvent,
+  type SelectChangeEventDetail,
+  type TextareaChangeEventDetail,
+  type TextareaInputEventDetail,
+  type ToggleChangeEventDetail,
+} from '@ionic/core';
+import type { Components } from '@ionic/core/components';
+import {
+  IonAccordionGroup as IonAccordionGroupElement,
+  defineCustomElement as defineIonAccordionGroup,
+} from '@ionic/core/components/ion-accordion-group.js';
+import {
+  IonAccordion as IonAccordionElement,
+  defineCustomElement as defineIonAccordion,
+} from '@ionic/core/components/ion-accordion.js';
+import {
+  IonAvatar as IonAvatarElement,
+  defineCustomElement as defineIonAvatar,
+} from '@ionic/core/components/ion-avatar.js';
+import {
+  IonBackdrop as IonBackdropElement,
+  defineCustomElement as defineIonBackdrop,
+} from '@ionic/core/components/ion-backdrop.js';
+import {
+  IonBadge as IonBadgeElement,
+  defineCustomElement as defineIonBadge,
+} from '@ionic/core/components/ion-badge.js';
+import {
+  IonBreadcrumbs as IonBreadcrumbsElement,
+  defineCustomElement as defineIonBreadcrumbs,
+} from '@ionic/core/components/ion-breadcrumbs.js';
+import {
+  IonButtons as IonButtonsElement,
+  defineCustomElement as defineIonButtons,
+} from '@ionic/core/components/ion-buttons.js';
+import {
+  IonCardContent as IonCardContentElement,
+  defineCustomElement as defineIonCardContent,
+} from '@ionic/core/components/ion-card-content.js';
+import {
+  IonCardHeader as IonCardHeaderElement,
+  defineCustomElement as defineIonCardHeader,
+} from '@ionic/core/components/ion-card-header.js';
+import {
+  IonCardSubtitle as IonCardSubtitleElement,
+  defineCustomElement as defineIonCardSubtitle,
+} from '@ionic/core/components/ion-card-subtitle.js';
+import {
+  IonCardTitle as IonCardTitleElement,
+  defineCustomElement as defineIonCardTitle,
+} from '@ionic/core/components/ion-card-title.js';
+import {
+  IonCheckbox as IonCheckboxElement,
+  defineCustomElement as defineIonCheckbox,
+} from '@ionic/core/components/ion-checkbox.js';
+import { IonChip as IonChipElement, defineCustomElement as defineIonChip } from '@ionic/core/components/ion-chip.js';
+import { IonCol as IonColElement, defineCustomElement as defineIonCol } from '@ionic/core/components/ion-col.js';
+import {
+  IonContent as IonContentElement,
+  defineCustomElement as defineIonContent,
+} from '@ionic/core/components/ion-content.js';
+import {
+  IonDatetimeButton as IonDatetimeButtonElement,
+  defineCustomElement as defineIonDatetimeButton,
+} from '@ionic/core/components/ion-datetime-button.js';
+import {
+  IonDatetime as IonDatetimeElement,
+  defineCustomElement as defineIonDatetime,
+} from '@ionic/core/components/ion-datetime.js';
+import {
+  IonFabList as IonFabListElement,
+  defineCustomElement as defineIonFabList,
+} from '@ionic/core/components/ion-fab-list.js';
+import { IonFab as IonFabElement, defineCustomElement as defineIonFab } from '@ionic/core/components/ion-fab.js';
+import {
+  IonFooter as IonFooterElement,
+  defineCustomElement as defineIonFooter,
+} from '@ionic/core/components/ion-footer.js';
+import { IonGrid as IonGridElement, defineCustomElement as defineIonGrid } from '@ionic/core/components/ion-grid.js';
+import {
+  IonHeader as IonHeaderElement,
+  defineCustomElement as defineIonHeader,
+} from '@ionic/core/components/ion-header.js';
+import { IonImg as IonImgElement, defineCustomElement as defineIonImg } from '@ionic/core/components/ion-img.js';
+import {
+  IonInfiniteScrollContent as IonInfiniteScrollContentElement,
+  defineCustomElement as defineIonInfiniteScrollContent,
+} from '@ionic/core/components/ion-infinite-scroll-content.js';
+import {
+  IonInfiniteScroll as IonInfiniteScrollElement,
+  defineCustomElement as defineIonInfiniteScroll,
+} from '@ionic/core/components/ion-infinite-scroll.js';
+import {
+  IonInputOtp as IonInputOtpElement,
+  defineCustomElement as defineIonInputOtp,
+} from '@ionic/core/components/ion-input-otp.js';
+import {
+  IonInputPasswordToggle as IonInputPasswordToggleElement,
+  defineCustomElement as defineIonInputPasswordToggle,
+} from '@ionic/core/components/ion-input-password-toggle.js';
+import {
+  IonInput as IonInputElement,
+  defineCustomElement as defineIonInput,
+} from '@ionic/core/components/ion-input.js';
+import {
+  IonItemDivider as IonItemDividerElement,
+  defineCustomElement as defineIonItemDivider,
+} from '@ionic/core/components/ion-item-divider.js';
+import {
+  IonItemGroup as IonItemGroupElement,
+  defineCustomElement as defineIonItemGroup,
+} from '@ionic/core/components/ion-item-group.js';
+import {
+  IonItemOptions as IonItemOptionsElement,
+  defineCustomElement as defineIonItemOptions,
+} from '@ionic/core/components/ion-item-options.js';
+import {
+  IonItemSliding as IonItemSlidingElement,
+  defineCustomElement as defineIonItemSliding,
+} from '@ionic/core/components/ion-item-sliding.js';
+import {
+  IonLabel as IonLabelElement,
+  defineCustomElement as defineIonLabel,
+} from '@ionic/core/components/ion-label.js';
+import {
+  IonListHeader as IonListHeaderElement,
+  defineCustomElement as defineIonListHeader,
+} from '@ionic/core/components/ion-list-header.js';
+import { IonList as IonListElement, defineCustomElement as defineIonList } from '@ionic/core/components/ion-list.js';
+import {
+  IonMenuButton as IonMenuButtonElement,
+  defineCustomElement as defineIonMenuButton,
+} from '@ionic/core/components/ion-menu-button.js';
+import {
+  IonMenuToggle as IonMenuToggleElement,
+  defineCustomElement as defineIonMenuToggle,
+} from '@ionic/core/components/ion-menu-toggle.js';
+import { IonMenu as IonMenuElement, defineCustomElement as defineIonMenu } from '@ionic/core/components/ion-menu.js';
+import {
+  IonNavLink as IonNavLinkElement,
+  defineCustomElement as defineIonNavLink,
+} from '@ionic/core/components/ion-nav-link.js';
+import { IonNav as IonNavElement, defineCustomElement as defineIonNav } from '@ionic/core/components/ion-nav.js';
+import { IonNote as IonNoteElement, defineCustomElement as defineIonNote } from '@ionic/core/components/ion-note.js';
+import {
+  IonPickerColumnOption as IonPickerColumnOptionElement,
+  defineCustomElement as defineIonPickerColumnOption,
+} from '@ionic/core/components/ion-picker-column-option.js';
+import {
+  IonPickerColumn as IonPickerColumnElement,
+  defineCustomElement as defineIonPickerColumn,
+} from '@ionic/core/components/ion-picker-column.js';
+import {
+  IonPicker as IonPickerElement,
+  defineCustomElement as defineIonPicker,
+} from '@ionic/core/components/ion-picker.js';
+import {
+  IonProgressBar as IonProgressBarElement,
+  defineCustomElement as defineIonProgressBar,
+} from '@ionic/core/components/ion-progress-bar.js';
+import {
+  IonRadioGroup as IonRadioGroupElement,
+  defineCustomElement as defineIonRadioGroup,
+} from '@ionic/core/components/ion-radio-group.js';
+import {
+  IonRadio as IonRadioElement,
+  defineCustomElement as defineIonRadio,
+} from '@ionic/core/components/ion-radio.js';
+import {
+  IonRange as IonRangeElement,
+  defineCustomElement as defineIonRange,
+} from '@ionic/core/components/ion-range.js';
+import {
+  IonRefresherContent as IonRefresherContentElement,
+  defineCustomElement as defineIonRefresherContent,
+} from '@ionic/core/components/ion-refresher-content.js';
+import {
+  IonRefresher as IonRefresherElement,
+  defineCustomElement as defineIonRefresher,
+} from '@ionic/core/components/ion-refresher.js';
+import {
+  IonReorderGroup as IonReorderGroupElement,
+  defineCustomElement as defineIonReorderGroup,
+} from '@ionic/core/components/ion-reorder-group.js';
+import {
+  IonReorder as IonReorderElement,
+  defineCustomElement as defineIonReorder,
+} from '@ionic/core/components/ion-reorder.js';
+import {
+  IonRippleEffect as IonRippleEffectElement,
+  defineCustomElement as defineIonRippleEffect,
+} from '@ionic/core/components/ion-ripple-effect.js';
+import { IonRow as IonRowElement, defineCustomElement as defineIonRow } from '@ionic/core/components/ion-row.js';
+import {
+  IonSearchbar as IonSearchbarElement,
+  defineCustomElement as defineIonSearchbar,
+} from '@ionic/core/components/ion-searchbar.js';
+import {
+  IonSegmentButton as IonSegmentButtonElement,
+  defineCustomElement as defineIonSegmentButton,
+} from '@ionic/core/components/ion-segment-button.js';
+import {
+  IonSegmentContent as IonSegmentContentElement,
+  defineCustomElement as defineIonSegmentContent,
+} from '@ionic/core/components/ion-segment-content.js';
+import {
+  IonSegmentView as IonSegmentViewElement,
+  defineCustomElement as defineIonSegmentView,
+} from '@ionic/core/components/ion-segment-view.js';
+import {
+  IonSegment as IonSegmentElement,
+  defineCustomElement as defineIonSegment,
+} from '@ionic/core/components/ion-segment.js';
+import {
+  IonSelectModal as IonSelectModalElement,
+  defineCustomElement as defineIonSelectModal,
+} from '@ionic/core/components/ion-select-modal.js';
+import {
+  IonSelectOption as IonSelectOptionElement,
+  defineCustomElement as defineIonSelectOption,
+} from '@ionic/core/components/ion-select-option.js';
+import {
+  IonSelect as IonSelectElement,
+  defineCustomElement as defineIonSelect,
+} from '@ionic/core/components/ion-select.js';
+import {
+  IonSkeletonText as IonSkeletonTextElement,
+  defineCustomElement as defineIonSkeletonText,
+} from '@ionic/core/components/ion-skeleton-text.js';
+import {
+  IonSpinner as IonSpinnerElement,
+  defineCustomElement as defineIonSpinner,
+} from '@ionic/core/components/ion-spinner.js';
+import {
+  IonSplitPane as IonSplitPaneElement,
+  defineCustomElement as defineIonSplitPane,
+} from '@ionic/core/components/ion-split-pane.js';
+import { IonTab as IonTabElement, defineCustomElement as defineIonTab } from '@ionic/core/components/ion-tab.js';
+import { IonText as IonTextElement, defineCustomElement as defineIonText } from '@ionic/core/components/ion-text.js';
+import {
+  IonTextarea as IonTextareaElement,
+  defineCustomElement as defineIonTextarea,
+} from '@ionic/core/components/ion-textarea.js';
+import {
+  IonThumbnail as IonThumbnailElement,
+  defineCustomElement as defineIonThumbnail,
+} from '@ionic/core/components/ion-thumbnail.js';
+import {
+  IonTitle as IonTitleElement,
+  defineCustomElement as defineIonTitle,
+} from '@ionic/core/components/ion-title.js';
+import {
+  IonToggle as IonToggleElement,
+  defineCustomElement as defineIonToggle,
+} from '@ionic/core/components/ion-toggle.js';
+import {
+  IonToolbar as IonToolbarElement,
+  defineCustomElement as defineIonToolbar,
+} from '@ionic/core/components/ion-toolbar.js';
 
 export type IonAccordionEvents = NonNullable<unknown>;
 
-export const IonAccordion: StencilReactComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion> = /*@__PURE__*/ createComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion>({
+export const IonAccordion: StencilReactComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion> =
+  /*@__PURE__*/ createComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion>({
     tagName: 'ion-accordion',
     elementClass: IonAccordionElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonAccordionEvents,
-    defineCustomElement: defineIonAccordion
-});
+    defineCustomElement: defineIonAccordion,
+  });
 
-export type IonAccordionGroupEvents = { onIonChange: EventName<IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>> };
+export type IonAccordionGroupEvents = {
+  onIonChange: EventName<IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>>;
+};
 
-export const IonAccordionGroup: StencilReactComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup> = /*@__PURE__*/ createComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup>({
-    tagName: 'ion-accordion-group',
-    elementClass: IonAccordionGroupElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonChange: 'ionChange' } as IonAccordionGroupEvents,
-    defineCustomElement: defineIonAccordionGroup
+export const IonAccordionGroup: StencilReactComponent<
+  IonAccordionGroupElement,
+  IonAccordionGroupEvents,
+  Components.IonAccordionGroup
+> = /*@__PURE__*/ createComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup>({
+  tagName: 'ion-accordion-group',
+  elementClass: IonAccordionGroupElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonChange: 'ionChange' } as IonAccordionGroupEvents,
+  defineCustomElement: defineIonAccordionGroup,
 });
 
 export type IonAvatarEvents = NonNullable<unknown>;
 
-export const IonAvatar: StencilReactComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar> = /*@__PURE__*/ createComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar>({
+export const IonAvatar: StencilReactComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar> =
+  /*@__PURE__*/ createComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar>({
     tagName: 'ion-avatar',
     elementClass: IonAvatarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonAvatarEvents,
-    defineCustomElement: defineIonAvatar
-});
+    defineCustomElement: defineIonAvatar,
+  });
 
 export type IonBackdropEvents = { onIonBackdropTap: EventName<IonBackdropCustomEvent<void>> };
 
-export const IonBackdrop: StencilReactComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop> = /*@__PURE__*/ createComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop>({
+export const IonBackdrop: StencilReactComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop> =
+  /*@__PURE__*/ createComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop>({
     tagName: 'ion-backdrop',
     elementClass: IonBackdropElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonBackdropTap: 'ionBackdropTap' } as IonBackdropEvents,
-    defineCustomElement: defineIonBackdrop
-});
+    defineCustomElement: defineIonBackdrop,
+  });
 
 export type IonBadgeEvents = NonNullable<unknown>;
 
-export const IonBadge: StencilReactComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge> = /*@__PURE__*/ createComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge>({
+export const IonBadge: StencilReactComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge> =
+  /*@__PURE__*/ createComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge>({
     tagName: 'ion-badge',
     elementClass: IonBadgeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonBadgeEvents,
-    defineCustomElement: defineIonBadge
-});
+    defineCustomElement: defineIonBadge,
+  });
 
-export type IonBreadcrumbsEvents = { onIonCollapsedClick: EventName<IonBreadcrumbsCustomEvent<BreadcrumbCollapsedClickEventDetail>> };
+export type IonBreadcrumbsEvents = {
+  onIonCollapsedClick: EventName<IonBreadcrumbsCustomEvent<BreadcrumbCollapsedClickEventDetail>>;
+};
 
-export const IonBreadcrumbs: StencilReactComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs> = /*@__PURE__*/ createComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs>({
-    tagName: 'ion-breadcrumbs',
-    elementClass: IonBreadcrumbsElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonCollapsedClick: 'ionCollapsedClick' } as IonBreadcrumbsEvents,
-    defineCustomElement: defineIonBreadcrumbs
+export const IonBreadcrumbs: StencilReactComponent<
+  IonBreadcrumbsElement,
+  IonBreadcrumbsEvents,
+  Components.IonBreadcrumbs
+> = /*@__PURE__*/ createComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs>({
+  tagName: 'ion-breadcrumbs',
+  elementClass: IonBreadcrumbsElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonCollapsedClick: 'ionCollapsedClick' } as IonBreadcrumbsEvents,
+  defineCustomElement: defineIonBreadcrumbs,
 });
 
 export type IonButtonsEvents = NonNullable<unknown>;
 
-export const IonButtons: StencilReactComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons> = /*@__PURE__*/ createComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons>({
+export const IonButtons: StencilReactComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons> =
+  /*@__PURE__*/ createComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons>({
     tagName: 'ion-buttons',
     elementClass: IonButtonsElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonButtonsEvents,
-    defineCustomElement: defineIonButtons
-});
+    defineCustomElement: defineIonButtons,
+  });
 
 export type IonCardContentEvents = NonNullable<unknown>;
 
-export const IonCardContent: StencilReactComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent> = /*@__PURE__*/ createComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent>({
-    tagName: 'ion-card-content',
-    elementClass: IonCardContentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonCardContentEvents,
-    defineCustomElement: defineIonCardContent
+export const IonCardContent: StencilReactComponent<
+  IonCardContentElement,
+  IonCardContentEvents,
+  Components.IonCardContent
+> = /*@__PURE__*/ createComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent>({
+  tagName: 'ion-card-content',
+  elementClass: IonCardContentElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonCardContentEvents,
+  defineCustomElement: defineIonCardContent,
 });
 
 export type IonCardHeaderEvents = NonNullable<unknown>;
 
-export const IonCardHeader: StencilReactComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader> = /*@__PURE__*/ createComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader>({
+export const IonCardHeader: StencilReactComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader> =
+  /*@__PURE__*/ createComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader>({
     tagName: 'ion-card-header',
     elementClass: IonCardHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonCardHeaderEvents,
-    defineCustomElement: defineIonCardHeader
-});
+    defineCustomElement: defineIonCardHeader,
+  });
 
 export type IonCardSubtitleEvents = NonNullable<unknown>;
 
-export const IonCardSubtitle: StencilReactComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle> = /*@__PURE__*/ createComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle>({
-    tagName: 'ion-card-subtitle',
-    elementClass: IonCardSubtitleElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonCardSubtitleEvents,
-    defineCustomElement: defineIonCardSubtitle
+export const IonCardSubtitle: StencilReactComponent<
+  IonCardSubtitleElement,
+  IonCardSubtitleEvents,
+  Components.IonCardSubtitle
+> = /*@__PURE__*/ createComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle>({
+  tagName: 'ion-card-subtitle',
+  elementClass: IonCardSubtitleElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonCardSubtitleEvents,
+  defineCustomElement: defineIonCardSubtitle,
 });
 
 export type IonCardTitleEvents = NonNullable<unknown>;
 
-export const IonCardTitle: StencilReactComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle> = /*@__PURE__*/ createComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle>({
+export const IonCardTitle: StencilReactComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle> =
+  /*@__PURE__*/ createComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle>({
     tagName: 'ion-card-title',
     elementClass: IonCardTitleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonCardTitleEvents,
-    defineCustomElement: defineIonCardTitle
-});
+    defineCustomElement: defineIonCardTitle,
+  });
 
 export type IonCheckboxEvents = {
-    onIonChange: EventName<IonCheckboxCustomEvent<CheckboxChangeEventDetail>>,
-    onIonFocus: EventName<IonCheckboxCustomEvent<void>>,
-    onIonBlur: EventName<IonCheckboxCustomEvent<void>>
+  onIonChange: EventName<IonCheckboxCustomEvent<CheckboxChangeEventDetail>>;
+  onIonFocus: EventName<IonCheckboxCustomEvent<void>>;
+  onIonBlur: EventName<IonCheckboxCustomEvent<void>>;
 };
 
-export const IonCheckbox: StencilReactComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox> = /*@__PURE__*/ createComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox>({
+export const IonCheckbox: StencilReactComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox> =
+  /*@__PURE__*/ createComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox>({
     tagName: 'ion-checkbox',
     elementClass: IonCheckboxElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonChange: 'ionChange',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
+      onIonChange: 'ionChange',
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
     } as IonCheckboxEvents,
-    defineCustomElement: defineIonCheckbox
-});
+    defineCustomElement: defineIonCheckbox,
+  });
 
 export type IonChipEvents = NonNullable<unknown>;
 
-export const IonChip: StencilReactComponent<IonChipElement, IonChipEvents, Components.IonChip> = /*@__PURE__*/ createComponent<IonChipElement, IonChipEvents, Components.IonChip>({
+export const IonChip: StencilReactComponent<IonChipElement, IonChipEvents, Components.IonChip> =
+  /*@__PURE__*/ createComponent<IonChipElement, IonChipEvents, Components.IonChip>({
     tagName: 'ion-chip',
     elementClass: IonChipElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonChipEvents,
-    defineCustomElement: defineIonChip
-});
+    defineCustomElement: defineIonChip,
+  });
 
 export type IonColEvents = NonNullable<unknown>;
 
-export const IonCol: StencilReactComponent<IonColElement, IonColEvents, Components.IonCol> = /*@__PURE__*/ createComponent<IonColElement, IonColEvents, Components.IonCol>({
+export const IonCol: StencilReactComponent<IonColElement, IonColEvents, Components.IonCol> =
+  /*@__PURE__*/ createComponent<IonColElement, IonColEvents, Components.IonCol>({
     tagName: 'ion-col',
     elementClass: IonColElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonColEvents,
-    defineCustomElement: defineIonCol
-});
+    defineCustomElement: defineIonCol,
+  });
 
 export type IonContentEvents = {
-    onIonScrollStart: EventName<IonContentCustomEvent<ScrollBaseDetail>>,
-    onIonScroll: EventName<IonContentCustomEvent<ScrollDetail>>,
-    onIonScrollEnd: EventName<IonContentCustomEvent<ScrollBaseDetail>>
+  onIonScrollStart: EventName<IonContentCustomEvent<ScrollBaseDetail>>;
+  onIonScroll: EventName<IonContentCustomEvent<ScrollDetail>>;
+  onIonScrollEnd: EventName<IonContentCustomEvent<ScrollBaseDetail>>;
 };
 
-export const IonContent: StencilReactComponent<IonContentElement, IonContentEvents, Components.IonContent> = /*@__PURE__*/ createComponent<IonContentElement, IonContentEvents, Components.IonContent>({
+export const IonContent: StencilReactComponent<IonContentElement, IonContentEvents, Components.IonContent> =
+  /*@__PURE__*/ createComponent<IonContentElement, IonContentEvents, Components.IonContent>({
     tagName: 'ion-content',
     elementClass: IonContentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonScrollStart: 'ionScrollStart',
-        onIonScroll: 'ionScroll',
-        onIonScrollEnd: 'ionScrollEnd'
+      onIonScrollStart: 'ionScrollStart',
+      onIonScroll: 'ionScroll',
+      onIonScrollEnd: 'ionScrollEnd',
     } as IonContentEvents,
-    defineCustomElement: defineIonContent
-});
+    defineCustomElement: defineIonContent,
+  });
 
 export type IonDatetimeEvents = {
-    onIonCancel: EventName<IonDatetimeCustomEvent<void>>,
-    onIonChange: EventName<IonDatetimeCustomEvent<DatetimeChangeEventDetail>>,
-    onIonFocus: EventName<IonDatetimeCustomEvent<void>>,
-    onIonBlur: EventName<IonDatetimeCustomEvent<void>>
+  onIonCancel: EventName<IonDatetimeCustomEvent<void>>;
+  onIonChange: EventName<IonDatetimeCustomEvent<DatetimeChangeEventDetail>>;
+  onIonFocus: EventName<IonDatetimeCustomEvent<void>>;
+  onIonBlur: EventName<IonDatetimeCustomEvent<void>>;
 };
 
-export const IonDatetime: StencilReactComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime> = /*@__PURE__*/ createComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime>({
+export const IonDatetime: StencilReactComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime> =
+  /*@__PURE__*/ createComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime>({
     tagName: 'ion-datetime',
     elementClass: IonDatetimeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonCancel: 'ionCancel',
-        onIonChange: 'ionChange',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
+      onIonCancel: 'ionCancel',
+      onIonChange: 'ionChange',
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
     } as IonDatetimeEvents,
-    defineCustomElement: defineIonDatetime
-});
+    defineCustomElement: defineIonDatetime,
+  });
 
 export type IonDatetimeButtonEvents = NonNullable<unknown>;
 
-export const IonDatetimeButton: StencilReactComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton> = /*@__PURE__*/ createComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton>({
-    tagName: 'ion-datetime-button',
-    elementClass: IonDatetimeButtonElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonDatetimeButtonEvents,
-    defineCustomElement: defineIonDatetimeButton
+export const IonDatetimeButton: StencilReactComponent<
+  IonDatetimeButtonElement,
+  IonDatetimeButtonEvents,
+  Components.IonDatetimeButton
+> = /*@__PURE__*/ createComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton>({
+  tagName: 'ion-datetime-button',
+  elementClass: IonDatetimeButtonElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonDatetimeButtonEvents,
+  defineCustomElement: defineIonDatetimeButton,
 });
 
 export type IonFabEvents = NonNullable<unknown>;
 
-export const IonFab: StencilReactComponent<IonFabElement, IonFabEvents, Components.IonFab> = /*@__PURE__*/ createComponent<IonFabElement, IonFabEvents, Components.IonFab>({
+export const IonFab: StencilReactComponent<IonFabElement, IonFabEvents, Components.IonFab> =
+  /*@__PURE__*/ createComponent<IonFabElement, IonFabEvents, Components.IonFab>({
     tagName: 'ion-fab',
     elementClass: IonFabElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFabEvents,
-    defineCustomElement: defineIonFab
-});
+    defineCustomElement: defineIonFab,
+  });
 
 export type IonFabListEvents = NonNullable<unknown>;
 
-export const IonFabList: StencilReactComponent<IonFabListElement, IonFabListEvents, Components.IonFabList> = /*@__PURE__*/ createComponent<IonFabListElement, IonFabListEvents, Components.IonFabList>({
+export const IonFabList: StencilReactComponent<IonFabListElement, IonFabListEvents, Components.IonFabList> =
+  /*@__PURE__*/ createComponent<IonFabListElement, IonFabListEvents, Components.IonFabList>({
     tagName: 'ion-fab-list',
     elementClass: IonFabListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFabListEvents,
-    defineCustomElement: defineIonFabList
-});
+    defineCustomElement: defineIonFabList,
+  });
 
 export type IonFooterEvents = NonNullable<unknown>;
 
-export const IonFooter: StencilReactComponent<IonFooterElement, IonFooterEvents, Components.IonFooter> = /*@__PURE__*/ createComponent<IonFooterElement, IonFooterEvents, Components.IonFooter>({
+export const IonFooter: StencilReactComponent<IonFooterElement, IonFooterEvents, Components.IonFooter> =
+  /*@__PURE__*/ createComponent<IonFooterElement, IonFooterEvents, Components.IonFooter>({
     tagName: 'ion-footer',
     elementClass: IonFooterElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFooterEvents,
-    defineCustomElement: defineIonFooter
-});
+    defineCustomElement: defineIonFooter,
+  });
 
 export type IonGridEvents = NonNullable<unknown>;
 
-export const IonGrid: StencilReactComponent<IonGridElement, IonGridEvents, Components.IonGrid> = /*@__PURE__*/ createComponent<IonGridElement, IonGridEvents, Components.IonGrid>({
+export const IonGrid: StencilReactComponent<IonGridElement, IonGridEvents, Components.IonGrid> =
+  /*@__PURE__*/ createComponent<IonGridElement, IonGridEvents, Components.IonGrid>({
     tagName: 'ion-grid',
     elementClass: IonGridElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonGridEvents,
-    defineCustomElement: defineIonGrid
-});
+    defineCustomElement: defineIonGrid,
+  });
 
 export type IonHeaderEvents = NonNullable<unknown>;
 
-export const IonHeader: StencilReactComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader> = /*@__PURE__*/ createComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader>({
+export const IonHeader: StencilReactComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader> =
+  /*@__PURE__*/ createComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader>({
     tagName: 'ion-header',
     elementClass: IonHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonHeaderEvents,
-    defineCustomElement: defineIonHeader
-});
+    defineCustomElement: defineIonHeader,
+  });
 
 export type IonImgEvents = {
-    onIonImgWillLoad: EventName<IonImgCustomEvent<void>>,
-    onIonImgDidLoad: EventName<IonImgCustomEvent<void>>,
-    onIonError: EventName<IonImgCustomEvent<void>>
+  onIonImgWillLoad: EventName<IonImgCustomEvent<void>>;
+  onIonImgDidLoad: EventName<IonImgCustomEvent<void>>;
+  onIonError: EventName<IonImgCustomEvent<void>>;
 };
 
-export const IonImg: StencilReactComponent<IonImgElement, IonImgEvents, Components.IonImg> = /*@__PURE__*/ createComponent<IonImgElement, IonImgEvents, Components.IonImg>({
+export const IonImg: StencilReactComponent<IonImgElement, IonImgEvents, Components.IonImg> =
+  /*@__PURE__*/ createComponent<IonImgElement, IonImgEvents, Components.IonImg>({
     tagName: 'ion-img',
     elementClass: IonImgElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonImgWillLoad: 'ionImgWillLoad',
-        onIonImgDidLoad: 'ionImgDidLoad',
-        onIonError: 'ionError'
+      onIonImgWillLoad: 'ionImgWillLoad',
+      onIonImgDidLoad: 'ionImgDidLoad',
+      onIonError: 'ionError',
     } as IonImgEvents,
-    defineCustomElement: defineIonImg
-});
+    defineCustomElement: defineIonImg,
+  });
 
 export type IonInfiniteScrollEvents = { onIonInfinite: EventName<IonInfiniteScrollCustomEvent<void>> };
 
-export const IonInfiniteScroll: StencilReactComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll> = /*@__PURE__*/ createComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll>({
-    tagName: 'ion-infinite-scroll',
-    elementClass: IonInfiniteScrollElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonInfinite: 'ionInfinite' } as IonInfiniteScrollEvents,
-    defineCustomElement: defineIonInfiniteScroll
+export const IonInfiniteScroll: StencilReactComponent<
+  IonInfiniteScrollElement,
+  IonInfiniteScrollEvents,
+  Components.IonInfiniteScroll
+> = /*@__PURE__*/ createComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll>({
+  tagName: 'ion-infinite-scroll',
+  elementClass: IonInfiniteScrollElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonInfinite: 'ionInfinite' } as IonInfiniteScrollEvents,
+  defineCustomElement: defineIonInfiniteScroll,
 });
 
 export type IonInfiniteScrollContentEvents = NonNullable<unknown>;
 
-export const IonInfiniteScrollContent: StencilReactComponent<IonInfiniteScrollContentElement, IonInfiniteScrollContentEvents, Components.IonInfiniteScrollContent> = /*@__PURE__*/ createComponent<IonInfiniteScrollContentElement, IonInfiniteScrollContentEvents, Components.IonInfiniteScrollContent>({
-    tagName: 'ion-infinite-scroll-content',
-    elementClass: IonInfiniteScrollContentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonInfiniteScrollContentEvents,
-    defineCustomElement: defineIonInfiniteScrollContent
+export const IonInfiniteScrollContent: StencilReactComponent<
+  IonInfiniteScrollContentElement,
+  IonInfiniteScrollContentEvents,
+  Components.IonInfiniteScrollContent
+> = /*@__PURE__*/ createComponent<
+  IonInfiniteScrollContentElement,
+  IonInfiniteScrollContentEvents,
+  Components.IonInfiniteScrollContent
+>({
+  tagName: 'ion-infinite-scroll-content',
+  elementClass: IonInfiniteScrollContentElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonInfiniteScrollContentEvents,
+  defineCustomElement: defineIonInfiniteScrollContent,
 });
 
 export type IonInputEvents = {
-    onIonInput: EventName<IonInputCustomEvent<InputInputEventDetail>>,
-    onIonChange: EventName<IonInputCustomEvent<InputChangeEventDetail>>,
-    onIonBlur: EventName<IonInputCustomEvent<FocusEvent>>,
-    onIonFocus: EventName<IonInputCustomEvent<FocusEvent>>
+  onIonInput: EventName<IonInputCustomEvent<InputInputEventDetail>>;
+  onIonChange: EventName<IonInputCustomEvent<InputChangeEventDetail>>;
+  onIonBlur: EventName<IonInputCustomEvent<FocusEvent>>;
+  onIonFocus: EventName<IonInputCustomEvent<FocusEvent>>;
 };
 
-export const IonInput: StencilReactComponent<IonInputElement, IonInputEvents, Components.IonInput> = /*@__PURE__*/ createComponent<IonInputElement, IonInputEvents, Components.IonInput>({
+export const IonInput: StencilReactComponent<IonInputElement, IonInputEvents, Components.IonInput> =
+  /*@__PURE__*/ createComponent<IonInputElement, IonInputEvents, Components.IonInput>({
     tagName: 'ion-input',
     elementClass: IonInputElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonInput: 'ionInput',
-        onIonChange: 'ionChange',
-        onIonBlur: 'ionBlur',
-        onIonFocus: 'ionFocus'
+      onIonInput: 'ionInput',
+      onIonChange: 'ionChange',
+      onIonBlur: 'ionBlur',
+      onIonFocus: 'ionFocus',
     } as IonInputEvents,
-    defineCustomElement: defineIonInput
-});
+    defineCustomElement: defineIonInput,
+  });
 
 export type IonInputOtpEvents = {
-    onIonInput: EventName<IonInputOtpCustomEvent<InputOtpInputEventDetail>>,
-    onIonChange: EventName<IonInputOtpCustomEvent<InputOtpChangeEventDetail>>,
-    onIonComplete: EventName<IonInputOtpCustomEvent<InputOtpCompleteEventDetail>>,
-    onIonBlur: EventName<IonInputOtpCustomEvent<FocusEvent>>,
-    onIonFocus: EventName<IonInputOtpCustomEvent<FocusEvent>>
+  onIonInput: EventName<IonInputOtpCustomEvent<InputOtpInputEventDetail>>;
+  onIonChange: EventName<IonInputOtpCustomEvent<InputOtpChangeEventDetail>>;
+  onIonComplete: EventName<IonInputOtpCustomEvent<InputOtpCompleteEventDetail>>;
+  onIonBlur: EventName<IonInputOtpCustomEvent<FocusEvent>>;
+  onIonFocus: EventName<IonInputOtpCustomEvent<FocusEvent>>;
 };
 
-export const IonInputOtp: StencilReactComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp> = /*@__PURE__*/ createComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp>({
+export const IonInputOtp: StencilReactComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp> =
+  /*@__PURE__*/ createComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp>({
     tagName: 'ion-input-otp',
     elementClass: IonInputOtpElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonInput: 'ionInput',
-        onIonChange: 'ionChange',
-        onIonComplete: 'ionComplete',
-        onIonBlur: 'ionBlur',
-        onIonFocus: 'ionFocus'
+      onIonInput: 'ionInput',
+      onIonChange: 'ionChange',
+      onIonComplete: 'ionComplete',
+      onIonBlur: 'ionBlur',
+      onIonFocus: 'ionFocus',
     } as IonInputOtpEvents,
-    defineCustomElement: defineIonInputOtp
-});
+    defineCustomElement: defineIonInputOtp,
+  });
 
 export type IonInputPasswordToggleEvents = NonNullable<unknown>;
 
-export const IonInputPasswordToggle: StencilReactComponent<IonInputPasswordToggleElement, IonInputPasswordToggleEvents, Components.IonInputPasswordToggle> = /*@__PURE__*/ createComponent<IonInputPasswordToggleElement, IonInputPasswordToggleEvents, Components.IonInputPasswordToggle>({
-    tagName: 'ion-input-password-toggle',
-    elementClass: IonInputPasswordToggleElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonInputPasswordToggleEvents,
-    defineCustomElement: defineIonInputPasswordToggle
+export const IonInputPasswordToggle: StencilReactComponent<
+  IonInputPasswordToggleElement,
+  IonInputPasswordToggleEvents,
+  Components.IonInputPasswordToggle
+> = /*@__PURE__*/ createComponent<
+  IonInputPasswordToggleElement,
+  IonInputPasswordToggleEvents,
+  Components.IonInputPasswordToggle
+>({
+  tagName: 'ion-input-password-toggle',
+  elementClass: IonInputPasswordToggleElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonInputPasswordToggleEvents,
+  defineCustomElement: defineIonInputPasswordToggle,
 });
 
 export type IonItemDividerEvents = NonNullable<unknown>;
 
-export const IonItemDivider: StencilReactComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider> = /*@__PURE__*/ createComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider>({
-    tagName: 'ion-item-divider',
-    elementClass: IonItemDividerElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonItemDividerEvents,
-    defineCustomElement: defineIonItemDivider
+export const IonItemDivider: StencilReactComponent<
+  IonItemDividerElement,
+  IonItemDividerEvents,
+  Components.IonItemDivider
+> = /*@__PURE__*/ createComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider>({
+  tagName: 'ion-item-divider',
+  elementClass: IonItemDividerElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonItemDividerEvents,
+  defineCustomElement: defineIonItemDivider,
 });
 
 export type IonItemGroupEvents = NonNullable<unknown>;
 
-export const IonItemGroup: StencilReactComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup> = /*@__PURE__*/ createComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup>({
+export const IonItemGroup: StencilReactComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup> =
+  /*@__PURE__*/ createComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup>({
     tagName: 'ion-item-group',
     elementClass: IonItemGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonItemGroupEvents,
-    defineCustomElement: defineIonItemGroup
-});
+    defineCustomElement: defineIonItemGroup,
+  });
 
 export type IonItemOptionsEvents = { onIonSwipe: EventName<IonItemOptionsCustomEvent<any>> };
 
-export const IonItemOptions: StencilReactComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions> = /*@__PURE__*/ createComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions>({
-    tagName: 'ion-item-options',
-    elementClass: IonItemOptionsElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonSwipe: 'ionSwipe' } as IonItemOptionsEvents,
-    defineCustomElement: defineIonItemOptions
+export const IonItemOptions: StencilReactComponent<
+  IonItemOptionsElement,
+  IonItemOptionsEvents,
+  Components.IonItemOptions
+> = /*@__PURE__*/ createComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions>({
+  tagName: 'ion-item-options',
+  elementClass: IonItemOptionsElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonSwipe: 'ionSwipe' } as IonItemOptionsEvents,
+  defineCustomElement: defineIonItemOptions,
 });
 
 export type IonItemSlidingEvents = { onIonDrag: EventName<IonItemSlidingCustomEvent<any>> };
 
-export const IonItemSliding: StencilReactComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding> = /*@__PURE__*/ createComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding>({
-    tagName: 'ion-item-sliding',
-    elementClass: IonItemSlidingElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonDrag: 'ionDrag' } as IonItemSlidingEvents,
-    defineCustomElement: defineIonItemSliding
+export const IonItemSliding: StencilReactComponent<
+  IonItemSlidingElement,
+  IonItemSlidingEvents,
+  Components.IonItemSliding
+> = /*@__PURE__*/ createComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding>({
+  tagName: 'ion-item-sliding',
+  elementClass: IonItemSlidingElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonDrag: 'ionDrag' } as IonItemSlidingEvents,
+  defineCustomElement: defineIonItemSliding,
 });
 
 export type IonLabelEvents = NonNullable<unknown>;
 
-export const IonLabel: StencilReactComponent<IonLabelElement, IonLabelEvents, Components.IonLabel> = /*@__PURE__*/ createComponent<IonLabelElement, IonLabelEvents, Components.IonLabel>({
+export const IonLabel: StencilReactComponent<IonLabelElement, IonLabelEvents, Components.IonLabel> =
+  /*@__PURE__*/ createComponent<IonLabelElement, IonLabelEvents, Components.IonLabel>({
     tagName: 'ion-label',
     elementClass: IonLabelElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonLabelEvents,
-    defineCustomElement: defineIonLabel
-});
+    defineCustomElement: defineIonLabel,
+  });
 
 export type IonListEvents = NonNullable<unknown>;
 
-export const IonList: StencilReactComponent<IonListElement, IonListEvents, Components.IonList> = /*@__PURE__*/ createComponent<IonListElement, IonListEvents, Components.IonList>({
+export const IonList: StencilReactComponent<IonListElement, IonListEvents, Components.IonList> =
+  /*@__PURE__*/ createComponent<IonListElement, IonListEvents, Components.IonList>({
     tagName: 'ion-list',
     elementClass: IonListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonListEvents,
-    defineCustomElement: defineIonList
-});
+    defineCustomElement: defineIonList,
+  });
 
 export type IonListHeaderEvents = NonNullable<unknown>;
 
-export const IonListHeader: StencilReactComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader> = /*@__PURE__*/ createComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader>({
+export const IonListHeader: StencilReactComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader> =
+  /*@__PURE__*/ createComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader>({
     tagName: 'ion-list-header',
     elementClass: IonListHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonListHeaderEvents,
-    defineCustomElement: defineIonListHeader
-});
+    defineCustomElement: defineIonListHeader,
+  });
 
 export type IonMenuEvents = {
-    onIonWillOpen: EventName<IonMenuCustomEvent<void>>,
-    onIonWillClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>,
-    onIonDidOpen: EventName<IonMenuCustomEvent<void>>,
-    onIonDidClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>
+  onIonWillOpen: EventName<IonMenuCustomEvent<void>>;
+  onIonWillClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>;
+  onIonDidOpen: EventName<IonMenuCustomEvent<void>>;
+  onIonDidClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>;
 };
 
-export const IonMenu: StencilReactComponent<IonMenuElement, IonMenuEvents, Components.IonMenu> = /*@__PURE__*/ createComponent<IonMenuElement, IonMenuEvents, Components.IonMenu>({
+export const IonMenu: StencilReactComponent<IonMenuElement, IonMenuEvents, Components.IonMenu> =
+  /*@__PURE__*/ createComponent<IonMenuElement, IonMenuEvents, Components.IonMenu>({
     tagName: 'ion-menu',
     elementClass: IonMenuElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonWillOpen: 'ionWillOpen',
-        onIonWillClose: 'ionWillClose',
-        onIonDidOpen: 'ionDidOpen',
-        onIonDidClose: 'ionDidClose'
+      onIonWillOpen: 'ionWillOpen',
+      onIonWillClose: 'ionWillClose',
+      onIonDidOpen: 'ionDidOpen',
+      onIonDidClose: 'ionDidClose',
     } as IonMenuEvents,
-    defineCustomElement: defineIonMenu
-});
+    defineCustomElement: defineIonMenu,
+  });
 
 export type IonMenuButtonEvents = NonNullable<unknown>;
 
-export const IonMenuButton: StencilReactComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton> = /*@__PURE__*/ createComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton>({
+export const IonMenuButton: StencilReactComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton> =
+  /*@__PURE__*/ createComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton>({
     tagName: 'ion-menu-button',
     elementClass: IonMenuButtonElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonMenuButtonEvents,
-    defineCustomElement: defineIonMenuButton
-});
+    defineCustomElement: defineIonMenuButton,
+  });
 
 export type IonMenuToggleEvents = NonNullable<unknown>;
 
-export const IonMenuToggle: StencilReactComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle> = /*@__PURE__*/ createComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle>({
+export const IonMenuToggle: StencilReactComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle> =
+  /*@__PURE__*/ createComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle>({
     tagName: 'ion-menu-toggle',
     elementClass: IonMenuToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonMenuToggleEvents,
-    defineCustomElement: defineIonMenuToggle
-});
+    defineCustomElement: defineIonMenuToggle,
+  });
 
 export type IonNavEvents = {
-    onIonNavWillChange: EventName<IonNavCustomEvent<void>>,
-    onIonNavDidChange: EventName<IonNavCustomEvent<void>>
+  onIonNavWillChange: EventName<IonNavCustomEvent<void>>;
+  onIonNavDidChange: EventName<IonNavCustomEvent<void>>;
 };
 
-export const IonNav: StencilReactComponent<IonNavElement, IonNavEvents, Components.IonNav> = /*@__PURE__*/ createComponent<IonNavElement, IonNavEvents, Components.IonNav>({
+export const IonNav: StencilReactComponent<IonNavElement, IonNavEvents, Components.IonNav> =
+  /*@__PURE__*/ createComponent<IonNavElement, IonNavEvents, Components.IonNav>({
     tagName: 'ion-nav',
     elementClass: IonNavElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonNavWillChange: 'ionNavWillChange',
-        onIonNavDidChange: 'ionNavDidChange'
+      onIonNavWillChange: 'ionNavWillChange',
+      onIonNavDidChange: 'ionNavDidChange',
     } as IonNavEvents,
-    defineCustomElement: defineIonNav
-});
+    defineCustomElement: defineIonNav,
+  });
 
 export type IonNavLinkEvents = NonNullable<unknown>;
 
-export const IonNavLink: StencilReactComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink> = /*@__PURE__*/ createComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink>({
+export const IonNavLink: StencilReactComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink> =
+  /*@__PURE__*/ createComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink>({
     tagName: 'ion-nav-link',
     elementClass: IonNavLinkElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonNavLinkEvents,
-    defineCustomElement: defineIonNavLink
-});
+    defineCustomElement: defineIonNavLink,
+  });
 
 export type IonNoteEvents = NonNullable<unknown>;
 
-export const IonNote: StencilReactComponent<IonNoteElement, IonNoteEvents, Components.IonNote> = /*@__PURE__*/ createComponent<IonNoteElement, IonNoteEvents, Components.IonNote>({
+export const IonNote: StencilReactComponent<IonNoteElement, IonNoteEvents, Components.IonNote> =
+  /*@__PURE__*/ createComponent<IonNoteElement, IonNoteEvents, Components.IonNote>({
     tagName: 'ion-note',
     elementClass: IonNoteElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonNoteEvents,
-    defineCustomElement: defineIonNote
-});
+    defineCustomElement: defineIonNote,
+  });
 
 export type IonPickerEvents = NonNullable<unknown>;
 
-export const IonPicker: StencilReactComponent<IonPickerElement, IonPickerEvents, Components.IonPicker> = /*@__PURE__*/ createComponent<IonPickerElement, IonPickerEvents, Components.IonPicker>({
+export const IonPicker: StencilReactComponent<IonPickerElement, IonPickerEvents, Components.IonPicker> =
+  /*@__PURE__*/ createComponent<IonPickerElement, IonPickerEvents, Components.IonPicker>({
     tagName: 'ion-picker',
     elementClass: IonPickerElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonPickerEvents,
-    defineCustomElement: defineIonPicker
-});
+    defineCustomElement: defineIonPicker,
+  });
 
-export type IonPickerColumnEvents = { onIonChange: EventName<IonPickerColumnCustomEvent<PickerColumnChangeEventDetail>> };
+export type IonPickerColumnEvents = {
+  onIonChange: EventName<IonPickerColumnCustomEvent<PickerColumnChangeEventDetail>>;
+};
 
-export const IonPickerColumn: StencilReactComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn> = /*@__PURE__*/ createComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn>({
-    tagName: 'ion-picker-column',
-    elementClass: IonPickerColumnElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonChange: 'ionChange' } as IonPickerColumnEvents,
-    defineCustomElement: defineIonPickerColumn
+export const IonPickerColumn: StencilReactComponent<
+  IonPickerColumnElement,
+  IonPickerColumnEvents,
+  Components.IonPickerColumn
+> = /*@__PURE__*/ createComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn>({
+  tagName: 'ion-picker-column',
+  elementClass: IonPickerColumnElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonChange: 'ionChange' } as IonPickerColumnEvents,
+  defineCustomElement: defineIonPickerColumn,
 });
 
 export type IonPickerColumnOptionEvents = NonNullable<unknown>;
 
-export const IonPickerColumnOption: StencilReactComponent<IonPickerColumnOptionElement, IonPickerColumnOptionEvents, Components.IonPickerColumnOption> = /*@__PURE__*/ createComponent<IonPickerColumnOptionElement, IonPickerColumnOptionEvents, Components.IonPickerColumnOption>({
-    tagName: 'ion-picker-column-option',
-    elementClass: IonPickerColumnOptionElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonPickerColumnOptionEvents,
-    defineCustomElement: defineIonPickerColumnOption
+export const IonPickerColumnOption: StencilReactComponent<
+  IonPickerColumnOptionElement,
+  IonPickerColumnOptionEvents,
+  Components.IonPickerColumnOption
+> = /*@__PURE__*/ createComponent<
+  IonPickerColumnOptionElement,
+  IonPickerColumnOptionEvents,
+  Components.IonPickerColumnOption
+>({
+  tagName: 'ion-picker-column-option',
+  elementClass: IonPickerColumnOptionElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonPickerColumnOptionEvents,
+  defineCustomElement: defineIonPickerColumnOption,
 });
 
 export type IonProgressBarEvents = NonNullable<unknown>;
 
-export const IonProgressBar: StencilReactComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar> = /*@__PURE__*/ createComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar>({
-    tagName: 'ion-progress-bar',
-    elementClass: IonProgressBarElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonProgressBarEvents,
-    defineCustomElement: defineIonProgressBar
+export const IonProgressBar: StencilReactComponent<
+  IonProgressBarElement,
+  IonProgressBarEvents,
+  Components.IonProgressBar
+> = /*@__PURE__*/ createComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar>({
+  tagName: 'ion-progress-bar',
+  elementClass: IonProgressBarElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonProgressBarEvents,
+  defineCustomElement: defineIonProgressBar,
 });
 
 export type IonRadioEvents = {
-    onIonFocus: EventName<IonRadioCustomEvent<void>>,
-    onIonBlur: EventName<IonRadioCustomEvent<void>>
+  onIonFocus: EventName<IonRadioCustomEvent<void>>;
+  onIonBlur: EventName<IonRadioCustomEvent<void>>;
 };
 
-export const IonRadio: StencilReactComponent<IonRadioElement, IonRadioEvents, Components.IonRadio> = /*@__PURE__*/ createComponent<IonRadioElement, IonRadioEvents, Components.IonRadio>({
+export const IonRadio: StencilReactComponent<IonRadioElement, IonRadioEvents, Components.IonRadio> =
+  /*@__PURE__*/ createComponent<IonRadioElement, IonRadioEvents, Components.IonRadio>({
     tagName: 'ion-radio',
     elementClass: IonRadioElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
     } as IonRadioEvents,
-    defineCustomElement: defineIonRadio
-});
+    defineCustomElement: defineIonRadio,
+  });
 
 export type IonRadioGroupEvents = { onIonChange: EventName<IonRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
 
-export const IonRadioGroup: StencilReactComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup> = /*@__PURE__*/ createComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup>({
+export const IonRadioGroup: StencilReactComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup> =
+  /*@__PURE__*/ createComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup>({
     tagName: 'ion-radio-group',
     elementClass: IonRadioGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonChange: 'ionChange' } as IonRadioGroupEvents,
-    defineCustomElement: defineIonRadioGroup
-});
+    defineCustomElement: defineIonRadioGroup,
+  });
 
 export type IonRangeEvents = {
-    onIonChange: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>,
-    onIonInput: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>,
-    onIonFocus: EventName<IonRangeCustomEvent<void>>,
-    onIonBlur: EventName<IonRangeCustomEvent<void>>,
-    onIonKnobMoveStart: EventName<IonRangeCustomEvent<RangeKnobMoveStartEventDetail>>,
-    onIonKnobMoveEnd: EventName<IonRangeCustomEvent<RangeKnobMoveEndEventDetail>>
+  onIonChange: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>;
+  onIonInput: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>;
+  onIonFocus: EventName<IonRangeCustomEvent<void>>;
+  onIonBlur: EventName<IonRangeCustomEvent<void>>;
+  onIonKnobMoveStart: EventName<IonRangeCustomEvent<RangeKnobMoveStartEventDetail>>;
+  onIonKnobMoveEnd: EventName<IonRangeCustomEvent<RangeKnobMoveEndEventDetail>>;
 };
 
-export const IonRange: StencilReactComponent<IonRangeElement, IonRangeEvents, Components.IonRange> = /*@__PURE__*/ createComponent<IonRangeElement, IonRangeEvents, Components.IonRange>({
+export const IonRange: StencilReactComponent<IonRangeElement, IonRangeEvents, Components.IonRange> =
+  /*@__PURE__*/ createComponent<IonRangeElement, IonRangeEvents, Components.IonRange>({
     tagName: 'ion-range',
     elementClass: IonRangeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonChange: 'ionChange',
-        onIonInput: 'ionInput',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur',
-        onIonKnobMoveStart: 'ionKnobMoveStart',
-        onIonKnobMoveEnd: 'ionKnobMoveEnd'
+      onIonChange: 'ionChange',
+      onIonInput: 'ionInput',
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
+      onIonKnobMoveStart: 'ionKnobMoveStart',
+      onIonKnobMoveEnd: 'ionKnobMoveEnd',
     } as IonRangeEvents,
-    defineCustomElement: defineIonRange
-});
+    defineCustomElement: defineIonRange,
+  });
 
 export type IonRefresherEvents = {
-    onIonRefresh: EventName<IonRefresherCustomEvent<RefresherEventDetail>>,
-    onIonPull: EventName<IonRefresherCustomEvent<void>>,
-    onIonStart: EventName<IonRefresherCustomEvent<void>>,
-    onIonPullStart: EventName<IonRefresherCustomEvent<void>>,
-    onIonPullEnd: EventName<IonRefresherCustomEvent<RefresherPullEndEventDetail>>
+  onIonRefresh: EventName<IonRefresherCustomEvent<RefresherEventDetail>>;
+  onIonPull: EventName<IonRefresherCustomEvent<void>>;
+  onIonStart: EventName<IonRefresherCustomEvent<void>>;
+  onIonPullStart: EventName<IonRefresherCustomEvent<void>>;
+  onIonPullEnd: EventName<IonRefresherCustomEvent<RefresherPullEndEventDetail>>;
 };
 
-export const IonRefresher: StencilReactComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher> = /*@__PURE__*/ createComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher>({
+export const IonRefresher: StencilReactComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher> =
+  /*@__PURE__*/ createComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher>({
     tagName: 'ion-refresher',
     elementClass: IonRefresherElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonRefresh: 'ionRefresh',
-        onIonPull: 'ionPull',
-        onIonStart: 'ionStart',
-        onIonPullStart: 'ionPullStart',
-        onIonPullEnd: 'ionPullEnd'
+      onIonRefresh: 'ionRefresh',
+      onIonPull: 'ionPull',
+      onIonStart: 'ionStart',
+      onIonPullStart: 'ionPullStart',
+      onIonPullEnd: 'ionPullEnd',
     } as IonRefresherEvents,
-    defineCustomElement: defineIonRefresher
-});
+    defineCustomElement: defineIonRefresher,
+  });
 
 export type IonRefresherContentEvents = NonNullable<unknown>;
 
-export const IonRefresherContent: StencilReactComponent<IonRefresherContentElement, IonRefresherContentEvents, Components.IonRefresherContent> = /*@__PURE__*/ createComponent<IonRefresherContentElement, IonRefresherContentEvents, Components.IonRefresherContent>({
-    tagName: 'ion-refresher-content',
-    elementClass: IonRefresherContentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonRefresherContentEvents,
-    defineCustomElement: defineIonRefresherContent
+export const IonRefresherContent: StencilReactComponent<
+  IonRefresherContentElement,
+  IonRefresherContentEvents,
+  Components.IonRefresherContent
+> = /*@__PURE__*/ createComponent<
+  IonRefresherContentElement,
+  IonRefresherContentEvents,
+  Components.IonRefresherContent
+>({
+  tagName: 'ion-refresher-content',
+  elementClass: IonRefresherContentElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonRefresherContentEvents,
+  defineCustomElement: defineIonRefresherContent,
 });
 
 export type IonReorderEvents = NonNullable<unknown>;
 
-export const IonReorder: StencilReactComponent<IonReorderElement, IonReorderEvents, Components.IonReorder> = /*@__PURE__*/ createComponent<IonReorderElement, IonReorderEvents, Components.IonReorder>({
+export const IonReorder: StencilReactComponent<IonReorderElement, IonReorderEvents, Components.IonReorder> =
+  /*@__PURE__*/ createComponent<IonReorderElement, IonReorderEvents, Components.IonReorder>({
     tagName: 'ion-reorder',
     elementClass: IonReorderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonReorderEvents,
-    defineCustomElement: defineIonReorder
-});
+    defineCustomElement: defineIonReorder,
+  });
 
 export type IonReorderGroupEvents = {
-    onIonItemReorder: EventName<IonReorderGroupCustomEvent<ItemReorderEventDetail>>,
-    onIonReorderStart: EventName<IonReorderGroupCustomEvent<void>>,
-    onIonReorderMove: EventName<IonReorderGroupCustomEvent<ReorderMoveEventDetail>>,
-    onIonReorderEnd: EventName<IonReorderGroupCustomEvent<ReorderEndEventDetail>>
+  onIonItemReorder: EventName<IonReorderGroupCustomEvent<ItemReorderEventDetail>>;
+  onIonReorderStart: EventName<IonReorderGroupCustomEvent<void>>;
+  onIonReorderMove: EventName<IonReorderGroupCustomEvent<ReorderMoveEventDetail>>;
+  onIonReorderEnd: EventName<IonReorderGroupCustomEvent<ReorderEndEventDetail>>;
 };
 
-export const IonReorderGroup: StencilReactComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup> = /*@__PURE__*/ createComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup>({
-    tagName: 'ion-reorder-group',
-    elementClass: IonReorderGroupElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {
-        onIonItemReorder: 'ionItemReorder',
-        onIonReorderStart: 'ionReorderStart',
-        onIonReorderMove: 'ionReorderMove',
-        onIonReorderEnd: 'ionReorderEnd'
-    } as IonReorderGroupEvents,
-    defineCustomElement: defineIonReorderGroup
+export const IonReorderGroup: StencilReactComponent<
+  IonReorderGroupElement,
+  IonReorderGroupEvents,
+  Components.IonReorderGroup
+> = /*@__PURE__*/ createComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup>({
+  tagName: 'ion-reorder-group',
+  elementClass: IonReorderGroupElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {
+    onIonItemReorder: 'ionItemReorder',
+    onIonReorderStart: 'ionReorderStart',
+    onIonReorderMove: 'ionReorderMove',
+    onIonReorderEnd: 'ionReorderEnd',
+  } as IonReorderGroupEvents,
+  defineCustomElement: defineIonReorderGroup,
 });
 
 export type IonRippleEffectEvents = NonNullable<unknown>;
 
-export const IonRippleEffect: StencilReactComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect> = /*@__PURE__*/ createComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect>({
-    tagName: 'ion-ripple-effect',
-    elementClass: IonRippleEffectElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonRippleEffectEvents,
-    defineCustomElement: defineIonRippleEffect
+export const IonRippleEffect: StencilReactComponent<
+  IonRippleEffectElement,
+  IonRippleEffectEvents,
+  Components.IonRippleEffect
+> = /*@__PURE__*/ createComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect>({
+  tagName: 'ion-ripple-effect',
+  elementClass: IonRippleEffectElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonRippleEffectEvents,
+  defineCustomElement: defineIonRippleEffect,
 });
 
 export type IonRowEvents = NonNullable<unknown>;
 
-export const IonRow: StencilReactComponent<IonRowElement, IonRowEvents, Components.IonRow> = /*@__PURE__*/ createComponent<IonRowElement, IonRowEvents, Components.IonRow>({
+export const IonRow: StencilReactComponent<IonRowElement, IonRowEvents, Components.IonRow> =
+  /*@__PURE__*/ createComponent<IonRowElement, IonRowEvents, Components.IonRow>({
     tagName: 'ion-row',
     elementClass: IonRowElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonRowEvents,
-    defineCustomElement: defineIonRow
-});
+    defineCustomElement: defineIonRow,
+  });
 
 export type IonSearchbarEvents = {
-    onIonInput: EventName<IonSearchbarCustomEvent<SearchbarInputEventDetail>>,
-    onIonChange: EventName<IonSearchbarCustomEvent<SearchbarChangeEventDetail>>,
-    onIonCancel: EventName<IonSearchbarCustomEvent<void>>,
-    onIonClear: EventName<IonSearchbarCustomEvent<void>>,
-    onIonBlur: EventName<IonSearchbarCustomEvent<void>>,
-    onIonFocus: EventName<IonSearchbarCustomEvent<void>>
+  onIonInput: EventName<IonSearchbarCustomEvent<SearchbarInputEventDetail>>;
+  onIonChange: EventName<IonSearchbarCustomEvent<SearchbarChangeEventDetail>>;
+  onIonCancel: EventName<IonSearchbarCustomEvent<void>>;
+  onIonClear: EventName<IonSearchbarCustomEvent<void>>;
+  onIonBlur: EventName<IonSearchbarCustomEvent<void>>;
+  onIonFocus: EventName<IonSearchbarCustomEvent<void>>;
 };
 
-export const IonSearchbar: StencilReactComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar> = /*@__PURE__*/ createComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar>({
+export const IonSearchbar: StencilReactComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar> =
+  /*@__PURE__*/ createComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar>({
     tagName: 'ion-searchbar',
     elementClass: IonSearchbarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonInput: 'ionInput',
-        onIonChange: 'ionChange',
-        onIonCancel: 'ionCancel',
-        onIonClear: 'ionClear',
-        onIonBlur: 'ionBlur',
-        onIonFocus: 'ionFocus'
+      onIonInput: 'ionInput',
+      onIonChange: 'ionChange',
+      onIonCancel: 'ionCancel',
+      onIonClear: 'ionClear',
+      onIonBlur: 'ionBlur',
+      onIonFocus: 'ionFocus',
     } as IonSearchbarEvents,
-    defineCustomElement: defineIonSearchbar
-});
+    defineCustomElement: defineIonSearchbar,
+  });
 
 export type IonSegmentEvents = { onIonChange: EventName<IonSegmentCustomEvent<SegmentChangeEventDetail>> };
 
-export const IonSegment: StencilReactComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment> = /*@__PURE__*/ createComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment>({
+export const IonSegment: StencilReactComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment> =
+  /*@__PURE__*/ createComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment>({
     tagName: 'ion-segment',
     elementClass: IonSegmentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonChange: 'ionChange' } as IonSegmentEvents,
-    defineCustomElement: defineIonSegment
-});
+    defineCustomElement: defineIonSegment,
+  });
 
 export type IonSegmentButtonEvents = NonNullable<unknown>;
 
-export const IonSegmentButton: StencilReactComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton> = /*@__PURE__*/ createComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton>({
-    tagName: 'ion-segment-button',
-    elementClass: IonSegmentButtonElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonSegmentButtonEvents,
-    defineCustomElement: defineIonSegmentButton
+export const IonSegmentButton: StencilReactComponent<
+  IonSegmentButtonElement,
+  IonSegmentButtonEvents,
+  Components.IonSegmentButton
+> = /*@__PURE__*/ createComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton>({
+  tagName: 'ion-segment-button',
+  elementClass: IonSegmentButtonElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonSegmentButtonEvents,
+  defineCustomElement: defineIonSegmentButton,
 });
 
 export type IonSegmentContentEvents = NonNullable<unknown>;
 
-export const IonSegmentContent: StencilReactComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent> = /*@__PURE__*/ createComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent>({
-    tagName: 'ion-segment-content',
-    elementClass: IonSegmentContentElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonSegmentContentEvents,
-    defineCustomElement: defineIonSegmentContent
+export const IonSegmentContent: StencilReactComponent<
+  IonSegmentContentElement,
+  IonSegmentContentEvents,
+  Components.IonSegmentContent
+> = /*@__PURE__*/ createComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent>({
+  tagName: 'ion-segment-content',
+  elementClass: IonSegmentContentElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonSegmentContentEvents,
+  defineCustomElement: defineIonSegmentContent,
 });
 
-export type IonSegmentViewEvents = { onIonSegmentViewScroll: EventName<IonSegmentViewCustomEvent<SegmentViewScrollEvent>> };
+export type IonSegmentViewEvents = {
+  onIonSegmentViewScroll: EventName<IonSegmentViewCustomEvent<SegmentViewScrollEvent>>;
+};
 
-export const IonSegmentView: StencilReactComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView> = /*@__PURE__*/ createComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView>({
-    tagName: 'ion-segment-view',
-    elementClass: IonSegmentViewElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: { onIonSegmentViewScroll: 'ionSegmentViewScroll' } as IonSegmentViewEvents,
-    defineCustomElement: defineIonSegmentView
+export const IonSegmentView: StencilReactComponent<
+  IonSegmentViewElement,
+  IonSegmentViewEvents,
+  Components.IonSegmentView
+> = /*@__PURE__*/ createComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView>({
+  tagName: 'ion-segment-view',
+  elementClass: IonSegmentViewElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: { onIonSegmentViewScroll: 'ionSegmentViewScroll' } as IonSegmentViewEvents,
+  defineCustomElement: defineIonSegmentView,
 });
 
 export type IonSelectEvents = {
-    onIonChange: EventName<IonSelectCustomEvent<SelectChangeEventDetail>>,
-    onIonCancel: EventName<IonSelectCustomEvent<void>>,
-    onIonDismiss: EventName<IonSelectCustomEvent<void>>,
-    onIonFocus: EventName<IonSelectCustomEvent<void>>,
-    onIonBlur: EventName<IonSelectCustomEvent<void>>
+  onIonChange: EventName<IonSelectCustomEvent<SelectChangeEventDetail>>;
+  onIonCancel: EventName<IonSelectCustomEvent<void>>;
+  onIonDismiss: EventName<IonSelectCustomEvent<void>>;
+  onIonFocus: EventName<IonSelectCustomEvent<void>>;
+  onIonBlur: EventName<IonSelectCustomEvent<void>>;
 };
 
-export const IonSelect: StencilReactComponent<IonSelectElement, IonSelectEvents, Components.IonSelect> = /*@__PURE__*/ createComponent<IonSelectElement, IonSelectEvents, Components.IonSelect>({
+export const IonSelect: StencilReactComponent<IonSelectElement, IonSelectEvents, Components.IonSelect> =
+  /*@__PURE__*/ createComponent<IonSelectElement, IonSelectEvents, Components.IonSelect>({
     tagName: 'ion-select',
     elementClass: IonSelectElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonChange: 'ionChange',
-        onIonCancel: 'ionCancel',
-        onIonDismiss: 'ionDismiss',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
+      onIonChange: 'ionChange',
+      onIonCancel: 'ionCancel',
+      onIonDismiss: 'ionDismiss',
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
     } as IonSelectEvents,
-    defineCustomElement: defineIonSelect
-});
+    defineCustomElement: defineIonSelect,
+  });
 
 export type IonSelectModalEvents = NonNullable<unknown>;
 
-export const IonSelectModal: StencilReactComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal> = /*@__PURE__*/ createComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal>({
-    tagName: 'ion-select-modal',
-    elementClass: IonSelectModalElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonSelectModalEvents,
-    defineCustomElement: defineIonSelectModal
+export const IonSelectModal: StencilReactComponent<
+  IonSelectModalElement,
+  IonSelectModalEvents,
+  Components.IonSelectModal
+> = /*@__PURE__*/ createComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal>({
+  tagName: 'ion-select-modal',
+  elementClass: IonSelectModalElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonSelectModalEvents,
+  defineCustomElement: defineIonSelectModal,
 });
 
 export type IonSelectOptionEvents = NonNullable<unknown>;
 
-export const IonSelectOption: StencilReactComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption> = /*@__PURE__*/ createComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption>({
-    tagName: 'ion-select-option',
-    elementClass: IonSelectOptionElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonSelectOptionEvents,
-    defineCustomElement: defineIonSelectOption
+export const IonSelectOption: StencilReactComponent<
+  IonSelectOptionElement,
+  IonSelectOptionEvents,
+  Components.IonSelectOption
+> = /*@__PURE__*/ createComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption>({
+  tagName: 'ion-select-option',
+  elementClass: IonSelectOptionElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonSelectOptionEvents,
+  defineCustomElement: defineIonSelectOption,
 });
 
 export type IonSkeletonTextEvents = NonNullable<unknown>;
 
-export const IonSkeletonText: StencilReactComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText> = /*@__PURE__*/ createComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText>({
-    tagName: 'ion-skeleton-text',
-    elementClass: IonSkeletonTextElement,
-    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-    react: React,
-    events: {} as IonSkeletonTextEvents,
-    defineCustomElement: defineIonSkeletonText
+export const IonSkeletonText: StencilReactComponent<
+  IonSkeletonTextElement,
+  IonSkeletonTextEvents,
+  Components.IonSkeletonText
+> = /*@__PURE__*/ createComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText>({
+  tagName: 'ion-skeleton-text',
+  elementClass: IonSkeletonTextElement,
+  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+  react: React,
+  events: {} as IonSkeletonTextEvents,
+  defineCustomElement: defineIonSkeletonText,
 });
 
 export type IonSpinnerEvents = NonNullable<unknown>;
 
-export const IonSpinner: StencilReactComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner> = /*@__PURE__*/ createComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner>({
+export const IonSpinner: StencilReactComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner> =
+  /*@__PURE__*/ createComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner>({
     tagName: 'ion-spinner',
     elementClass: IonSpinnerElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonSpinnerEvents,
-    defineCustomElement: defineIonSpinner
-});
+    defineCustomElement: defineIonSpinner,
+  });
 
 export type IonSplitPaneEvents = { onIonSplitPaneVisible: EventName<IonSplitPaneCustomEvent<{ visible: boolean }>> };
 
-export const IonSplitPane: StencilReactComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane> = /*@__PURE__*/ createComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane>({
+export const IonSplitPane: StencilReactComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane> =
+  /*@__PURE__*/ createComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane>({
     tagName: 'ion-split-pane',
     elementClass: IonSplitPaneElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonSplitPaneVisible: 'ionSplitPaneVisible' } as IonSplitPaneEvents,
-    defineCustomElement: defineIonSplitPane
-});
+    defineCustomElement: defineIonSplitPane,
+  });
 
 export type IonTabEvents = NonNullable<unknown>;
 
-export const IonTab: StencilReactComponent<IonTabElement, IonTabEvents, Components.IonTab> = /*@__PURE__*/ createComponent<IonTabElement, IonTabEvents, Components.IonTab>({
+export const IonTab: StencilReactComponent<IonTabElement, IonTabEvents, Components.IonTab> =
+  /*@__PURE__*/ createComponent<IonTabElement, IonTabEvents, Components.IonTab>({
     tagName: 'ion-tab',
     elementClass: IonTabElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTabEvents,
-    defineCustomElement: defineIonTab
-});
+    defineCustomElement: defineIonTab,
+  });
 
 export type IonTextEvents = NonNullable<unknown>;
 
-export const IonText: StencilReactComponent<IonTextElement, IonTextEvents, Components.IonText> = /*@__PURE__*/ createComponent<IonTextElement, IonTextEvents, Components.IonText>({
+export const IonText: StencilReactComponent<IonTextElement, IonTextEvents, Components.IonText> =
+  /*@__PURE__*/ createComponent<IonTextElement, IonTextEvents, Components.IonText>({
     tagName: 'ion-text',
     elementClass: IonTextElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTextEvents,
-    defineCustomElement: defineIonText
-});
+    defineCustomElement: defineIonText,
+  });
 
 export type IonTextareaEvents = {
-    onIonChange: EventName<IonTextareaCustomEvent<TextareaChangeEventDetail>>,
-    onIonInput: EventName<IonTextareaCustomEvent<TextareaInputEventDetail>>,
-    onIonBlur: EventName<IonTextareaCustomEvent<FocusEvent>>,
-    onIonFocus: EventName<IonTextareaCustomEvent<FocusEvent>>
+  onIonChange: EventName<IonTextareaCustomEvent<TextareaChangeEventDetail>>;
+  onIonInput: EventName<IonTextareaCustomEvent<TextareaInputEventDetail>>;
+  onIonBlur: EventName<IonTextareaCustomEvent<FocusEvent>>;
+  onIonFocus: EventName<IonTextareaCustomEvent<FocusEvent>>;
 };
 
-export const IonTextarea: StencilReactComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea> = /*@__PURE__*/ createComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea>({
+export const IonTextarea: StencilReactComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea> =
+  /*@__PURE__*/ createComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea>({
     tagName: 'ion-textarea',
     elementClass: IonTextareaElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonChange: 'ionChange',
-        onIonInput: 'ionInput',
-        onIonBlur: 'ionBlur',
-        onIonFocus: 'ionFocus'
+      onIonChange: 'ionChange',
+      onIonInput: 'ionInput',
+      onIonBlur: 'ionBlur',
+      onIonFocus: 'ionFocus',
     } as IonTextareaEvents,
-    defineCustomElement: defineIonTextarea
-});
+    defineCustomElement: defineIonTextarea,
+  });
 
 export type IonThumbnailEvents = NonNullable<unknown>;
 
-export const IonThumbnail: StencilReactComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail> = /*@__PURE__*/ createComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail>({
+export const IonThumbnail: StencilReactComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail> =
+  /*@__PURE__*/ createComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail>({
     tagName: 'ion-thumbnail',
     elementClass: IonThumbnailElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonThumbnailEvents,
-    defineCustomElement: defineIonThumbnail
-});
+    defineCustomElement: defineIonThumbnail,
+  });
 
 export type IonTitleEvents = NonNullable<unknown>;
 
-export const IonTitle: StencilReactComponent<IonTitleElement, IonTitleEvents, Components.IonTitle> = /*@__PURE__*/ createComponent<IonTitleElement, IonTitleEvents, Components.IonTitle>({
+export const IonTitle: StencilReactComponent<IonTitleElement, IonTitleEvents, Components.IonTitle> =
+  /*@__PURE__*/ createComponent<IonTitleElement, IonTitleEvents, Components.IonTitle>({
     tagName: 'ion-title',
     elementClass: IonTitleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTitleEvents,
-    defineCustomElement: defineIonTitle
-});
+    defineCustomElement: defineIonTitle,
+  });
 
 export type IonToggleEvents = {
-    onIonChange: EventName<IonToggleCustomEvent<ToggleChangeEventDetail>>,
-    onIonFocus: EventName<IonToggleCustomEvent<void>>,
-    onIonBlur: EventName<IonToggleCustomEvent<void>>
+  onIonChange: EventName<IonToggleCustomEvent<ToggleChangeEventDetail>>;
+  onIonFocus: EventName<IonToggleCustomEvent<void>>;
+  onIonBlur: EventName<IonToggleCustomEvent<void>>;
 };
 
-export const IonToggle: StencilReactComponent<IonToggleElement, IonToggleEvents, Components.IonToggle> = /*@__PURE__*/ createComponent<IonToggleElement, IonToggleEvents, Components.IonToggle>({
+export const IonToggle: StencilReactComponent<IonToggleElement, IonToggleEvents, Components.IonToggle> =
+  /*@__PURE__*/ createComponent<IonToggleElement, IonToggleEvents, Components.IonToggle>({
     tagName: 'ion-toggle',
     elementClass: IonToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-        onIonChange: 'ionChange',
-        onIonFocus: 'ionFocus',
-        onIonBlur: 'ionBlur'
+      onIonChange: 'ionChange',
+      onIonFocus: 'ionFocus',
+      onIonBlur: 'ionBlur',
     } as IonToggleEvents,
-    defineCustomElement: defineIonToggle
-});
+    defineCustomElement: defineIonToggle,
+  });
 
 export type IonToolbarEvents = NonNullable<unknown>;
 
-export const IonToolbar: StencilReactComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar> = /*@__PURE__*/ createComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar>({
+export const IonToolbar: StencilReactComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar> =
+  /*@__PURE__*/ createComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar>({
     tagName: 'ion-toolbar',
     elementClass: IonToolbarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonToolbarEvents,
-    defineCustomElement: defineIonToolbar
-});
+    defineCustomElement: defineIonToolbar,
+  });

--- a/packages/react/src/components/components.ts
+++ b/packages/react/src/components/components.ts
@@ -11,1430 +11,1027 @@ import type { EventName, StencilReactComponent } from '@stencil/react-output-tar
 import { createComponent } from '@stencil/react-output-target/runtime';
 import React from 'react';
 
-import {
-  type AccordionGroupChangeEventDetail,
-  type BreadcrumbCollapsedClickEventDetail,
-  type CheckboxChangeEventDetail,
-  type DatetimeChangeEventDetail,
-  type InputChangeEventDetail,
-  type InputInputEventDetail,
-  type InputOtpChangeEventDetail,
-  type InputOtpCompleteEventDetail,
-  type InputOtpInputEventDetail,
-  type IonAccordionGroupCustomEvent,
-  type IonBackdropCustomEvent,
-  type IonBreadcrumbsCustomEvent,
-  type IonCheckboxCustomEvent,
-  type IonContentCustomEvent,
-  type IonDatetimeCustomEvent,
-  type IonImgCustomEvent,
-  type IonInfiniteScrollCustomEvent,
-  type IonInputCustomEvent,
-  type IonInputOtpCustomEvent,
-  type IonItemOptionsCustomEvent,
-  type IonItemSlidingCustomEvent,
-  type IonMenuCustomEvent,
-  type IonNavCustomEvent,
-  type IonPickerColumnCustomEvent,
-  type IonRadioCustomEvent,
-  type IonRadioGroupCustomEvent,
-  type IonRangeCustomEvent,
-  type IonRefresherCustomEvent,
-  type IonReorderGroupCustomEvent,
-  type IonSearchbarCustomEvent,
-  type IonSegmentCustomEvent,
-  type IonSegmentViewCustomEvent,
-  type IonSelectCustomEvent,
-  type IonSplitPaneCustomEvent,
-  type IonTextareaCustomEvent,
-  type IonToggleCustomEvent,
-  type ItemReorderEventDetail,
-  type MenuCloseEventDetail,
-  type PickerColumnChangeEventDetail,
-  type RadioGroupChangeEventDetail,
-  type RangeChangeEventDetail,
-  type RangeKnobMoveEndEventDetail,
-  type RangeKnobMoveStartEventDetail,
-  type RefresherEventDetail,
-  type RefresherPullEndEventDetail,
-  type ReorderEndEventDetail,
-  type ReorderMoveEventDetail,
-  type ScrollBaseDetail,
-  type ScrollDetail,
-  type SearchbarChangeEventDetail,
-  type SearchbarInputEventDetail,
-  type SegmentChangeEventDetail,
-  type SegmentViewScrollEvent,
-  type SelectChangeEventDetail,
-  type TextareaChangeEventDetail,
-  type TextareaInputEventDetail,
-  type ToggleChangeEventDetail,
-} from '@ionic/core';
-import type { Components } from '@ionic/core/components';
-import {
-  IonAccordionGroup as IonAccordionGroupElement,
-  defineCustomElement as defineIonAccordionGroup,
-} from '@ionic/core/components/ion-accordion-group.js';
-import {
-  IonAccordion as IonAccordionElement,
-  defineCustomElement as defineIonAccordion,
-} from '@ionic/core/components/ion-accordion.js';
-import {
-  IonAvatar as IonAvatarElement,
-  defineCustomElement as defineIonAvatar,
-} from '@ionic/core/components/ion-avatar.js';
-import {
-  IonBackdrop as IonBackdropElement,
-  defineCustomElement as defineIonBackdrop,
-} from '@ionic/core/components/ion-backdrop.js';
-import {
-  IonBadge as IonBadgeElement,
-  defineCustomElement as defineIonBadge,
-} from '@ionic/core/components/ion-badge.js';
-import {
-  IonBreadcrumbs as IonBreadcrumbsElement,
-  defineCustomElement as defineIonBreadcrumbs,
-} from '@ionic/core/components/ion-breadcrumbs.js';
-import {
-  IonButtons as IonButtonsElement,
-  defineCustomElement as defineIonButtons,
-} from '@ionic/core/components/ion-buttons.js';
-import {
-  IonCardContent as IonCardContentElement,
-  defineCustomElement as defineIonCardContent,
-} from '@ionic/core/components/ion-card-content.js';
-import {
-  IonCardHeader as IonCardHeaderElement,
-  defineCustomElement as defineIonCardHeader,
-} from '@ionic/core/components/ion-card-header.js';
-import {
-  IonCardSubtitle as IonCardSubtitleElement,
-  defineCustomElement as defineIonCardSubtitle,
-} from '@ionic/core/components/ion-card-subtitle.js';
-import {
-  IonCardTitle as IonCardTitleElement,
-  defineCustomElement as defineIonCardTitle,
-} from '@ionic/core/components/ion-card-title.js';
-import {
-  IonCheckbox as IonCheckboxElement,
-  defineCustomElement as defineIonCheckbox,
-} from '@ionic/core/components/ion-checkbox.js';
-import { IonChip as IonChipElement, defineCustomElement as defineIonChip } from '@ionic/core/components/ion-chip.js';
-import { IonCol as IonColElement, defineCustomElement as defineIonCol } from '@ionic/core/components/ion-col.js';
-import {
-  IonContent as IonContentElement,
-  defineCustomElement as defineIonContent,
-} from '@ionic/core/components/ion-content.js';
-import {
-  IonDatetimeButton as IonDatetimeButtonElement,
-  defineCustomElement as defineIonDatetimeButton,
-} from '@ionic/core/components/ion-datetime-button.js';
-import {
-  IonDatetime as IonDatetimeElement,
-  defineCustomElement as defineIonDatetime,
-} from '@ionic/core/components/ion-datetime.js';
-import {
-  IonFabList as IonFabListElement,
-  defineCustomElement as defineIonFabList,
-} from '@ionic/core/components/ion-fab-list.js';
-import { IonFab as IonFabElement, defineCustomElement as defineIonFab } from '@ionic/core/components/ion-fab.js';
-import {
-  IonFooter as IonFooterElement,
-  defineCustomElement as defineIonFooter,
-} from '@ionic/core/components/ion-footer.js';
-import { IonGrid as IonGridElement, defineCustomElement as defineIonGrid } from '@ionic/core/components/ion-grid.js';
-import {
-  IonHeader as IonHeaderElement,
-  defineCustomElement as defineIonHeader,
-} from '@ionic/core/components/ion-header.js';
-import { IonImg as IonImgElement, defineCustomElement as defineIonImg } from '@ionic/core/components/ion-img.js';
-import {
-  IonInfiniteScrollContent as IonInfiniteScrollContentElement,
-  defineCustomElement as defineIonInfiniteScrollContent,
-} from '@ionic/core/components/ion-infinite-scroll-content.js';
-import {
-  IonInfiniteScroll as IonInfiniteScrollElement,
-  defineCustomElement as defineIonInfiniteScroll,
-} from '@ionic/core/components/ion-infinite-scroll.js';
-import {
-  IonInputOtp as IonInputOtpElement,
-  defineCustomElement as defineIonInputOtp,
-} from '@ionic/core/components/ion-input-otp.js';
-import {
-  IonInputPasswordToggle as IonInputPasswordToggleElement,
-  defineCustomElement as defineIonInputPasswordToggle,
-} from '@ionic/core/components/ion-input-password-toggle.js';
-import {
-  IonInput as IonInputElement,
-  defineCustomElement as defineIonInput,
-} from '@ionic/core/components/ion-input.js';
-import {
-  IonItemDivider as IonItemDividerElement,
-  defineCustomElement as defineIonItemDivider,
-} from '@ionic/core/components/ion-item-divider.js';
-import {
-  IonItemGroup as IonItemGroupElement,
-  defineCustomElement as defineIonItemGroup,
-} from '@ionic/core/components/ion-item-group.js';
-import {
-  IonItemOptions as IonItemOptionsElement,
-  defineCustomElement as defineIonItemOptions,
-} from '@ionic/core/components/ion-item-options.js';
-import {
-  IonItemSliding as IonItemSlidingElement,
-  defineCustomElement as defineIonItemSliding,
-} from '@ionic/core/components/ion-item-sliding.js';
-import {
-  IonLabel as IonLabelElement,
-  defineCustomElement as defineIonLabel,
-} from '@ionic/core/components/ion-label.js';
-import {
-  IonListHeader as IonListHeaderElement,
-  defineCustomElement as defineIonListHeader,
-} from '@ionic/core/components/ion-list-header.js';
-import { IonList as IonListElement, defineCustomElement as defineIonList } from '@ionic/core/components/ion-list.js';
-import {
-  IonMenuButton as IonMenuButtonElement,
-  defineCustomElement as defineIonMenuButton,
-} from '@ionic/core/components/ion-menu-button.js';
-import {
-  IonMenuToggle as IonMenuToggleElement,
-  defineCustomElement as defineIonMenuToggle,
-} from '@ionic/core/components/ion-menu-toggle.js';
-import { IonMenu as IonMenuElement, defineCustomElement as defineIonMenu } from '@ionic/core/components/ion-menu.js';
-import {
-  IonNavLink as IonNavLinkElement,
-  defineCustomElement as defineIonNavLink,
-} from '@ionic/core/components/ion-nav-link.js';
-import { IonNav as IonNavElement, defineCustomElement as defineIonNav } from '@ionic/core/components/ion-nav.js';
-import { IonNote as IonNoteElement, defineCustomElement as defineIonNote } from '@ionic/core/components/ion-note.js';
-import {
-  IonPickerColumnOption as IonPickerColumnOptionElement,
-  defineCustomElement as defineIonPickerColumnOption,
-} from '@ionic/core/components/ion-picker-column-option.js';
-import {
-  IonPickerColumn as IonPickerColumnElement,
-  defineCustomElement as defineIonPickerColumn,
-} from '@ionic/core/components/ion-picker-column.js';
-import {
-  IonPicker as IonPickerElement,
-  defineCustomElement as defineIonPicker,
-} from '@ionic/core/components/ion-picker.js';
-import {
-  IonProgressBar as IonProgressBarElement,
-  defineCustomElement as defineIonProgressBar,
-} from '@ionic/core/components/ion-progress-bar.js';
-import {
-  IonRadioGroup as IonRadioGroupElement,
-  defineCustomElement as defineIonRadioGroup,
-} from '@ionic/core/components/ion-radio-group.js';
-import {
-  IonRadio as IonRadioElement,
-  defineCustomElement as defineIonRadio,
-} from '@ionic/core/components/ion-radio.js';
-import {
-  IonRange as IonRangeElement,
-  defineCustomElement as defineIonRange,
-} from '@ionic/core/components/ion-range.js';
-import {
-  IonRefresherContent as IonRefresherContentElement,
-  defineCustomElement as defineIonRefresherContent,
-} from '@ionic/core/components/ion-refresher-content.js';
-import {
-  IonRefresher as IonRefresherElement,
-  defineCustomElement as defineIonRefresher,
-} from '@ionic/core/components/ion-refresher.js';
-import {
-  IonReorderGroup as IonReorderGroupElement,
-  defineCustomElement as defineIonReorderGroup,
-} from '@ionic/core/components/ion-reorder-group.js';
-import {
-  IonReorder as IonReorderElement,
-  defineCustomElement as defineIonReorder,
-} from '@ionic/core/components/ion-reorder.js';
-import {
-  IonRippleEffect as IonRippleEffectElement,
-  defineCustomElement as defineIonRippleEffect,
-} from '@ionic/core/components/ion-ripple-effect.js';
-import { IonRow as IonRowElement, defineCustomElement as defineIonRow } from '@ionic/core/components/ion-row.js';
-import {
-  IonSearchbar as IonSearchbarElement,
-  defineCustomElement as defineIonSearchbar,
-} from '@ionic/core/components/ion-searchbar.js';
-import {
-  IonSegmentButton as IonSegmentButtonElement,
-  defineCustomElement as defineIonSegmentButton,
-} from '@ionic/core/components/ion-segment-button.js';
-import {
-  IonSegmentContent as IonSegmentContentElement,
-  defineCustomElement as defineIonSegmentContent,
-} from '@ionic/core/components/ion-segment-content.js';
-import {
-  IonSegmentView as IonSegmentViewElement,
-  defineCustomElement as defineIonSegmentView,
-} from '@ionic/core/components/ion-segment-view.js';
-import {
-  IonSegment as IonSegmentElement,
-  defineCustomElement as defineIonSegment,
-} from '@ionic/core/components/ion-segment.js';
-import {
-  IonSelectModal as IonSelectModalElement,
-  defineCustomElement as defineIonSelectModal,
-} from '@ionic/core/components/ion-select-modal.js';
-import {
-  IonSelectOption as IonSelectOptionElement,
-  defineCustomElement as defineIonSelectOption,
-} from '@ionic/core/components/ion-select-option.js';
-import {
-  IonSelect as IonSelectElement,
-  defineCustomElement as defineIonSelect,
-} from '@ionic/core/components/ion-select.js';
-import {
-  IonSkeletonText as IonSkeletonTextElement,
-  defineCustomElement as defineIonSkeletonText,
-} from '@ionic/core/components/ion-skeleton-text.js';
-import {
-  IonSpinner as IonSpinnerElement,
-  defineCustomElement as defineIonSpinner,
-} from '@ionic/core/components/ion-spinner.js';
-import {
-  IonSplitPane as IonSplitPaneElement,
-  defineCustomElement as defineIonSplitPane,
-} from '@ionic/core/components/ion-split-pane.js';
-import { IonTab as IonTabElement, defineCustomElement as defineIonTab } from '@ionic/core/components/ion-tab.js';
-import { IonText as IonTextElement, defineCustomElement as defineIonText } from '@ionic/core/components/ion-text.js';
-import {
-  IonTextarea as IonTextareaElement,
-  defineCustomElement as defineIonTextarea,
-} from '@ionic/core/components/ion-textarea.js';
-import {
-  IonThumbnail as IonThumbnailElement,
-  defineCustomElement as defineIonThumbnail,
-} from '@ionic/core/components/ion-thumbnail.js';
-import {
-  IonTitle as IonTitleElement,
-  defineCustomElement as defineIonTitle,
-} from '@ionic/core/components/ion-title.js';
-import {
-  IonToggle as IonToggleElement,
-  defineCustomElement as defineIonToggle,
-} from '@ionic/core/components/ion-toggle.js';
-import {
-  IonToolbar as IonToolbarElement,
-  defineCustomElement as defineIonToolbar,
-} from '@ionic/core/components/ion-toolbar.js';
+import { type AccordionGroupChangeEventDetail, type BreadcrumbCollapsedClickEventDetail, type CheckboxChangeEventDetail, type DatetimeChangeEventDetail, type InputChangeEventDetail, type InputInputEventDetail, type InputOtpChangeEventDetail, type InputOtpCompleteEventDetail, type InputOtpInputEventDetail, type IonAccordionGroupCustomEvent, type IonBackdropCustomEvent, type IonBreadcrumbsCustomEvent, type IonCheckboxCustomEvent, type IonContentCustomEvent, type IonDatetimeCustomEvent, type IonImgCustomEvent, type IonInfiniteScrollCustomEvent, type IonInputCustomEvent, type IonInputOtpCustomEvent, type IonItemOptionsCustomEvent, type IonItemSlidingCustomEvent, type IonMenuCustomEvent, type IonNavCustomEvent, type IonPickerColumnCustomEvent, type IonRadioCustomEvent, type IonRadioGroupCustomEvent, type IonRangeCustomEvent, type IonRefresherCustomEvent, type IonReorderGroupCustomEvent, type IonSearchbarCustomEvent, type IonSegmentCustomEvent, type IonSegmentViewCustomEvent, type IonSelectCustomEvent, type IonSplitPaneCustomEvent, type IonTextareaCustomEvent, type IonToggleCustomEvent, type ItemReorderEventDetail, type MenuCloseEventDetail, type PickerColumnChangeEventDetail, type RadioGroupChangeEventDetail, type RangeChangeEventDetail, type RangeKnobMoveEndEventDetail, type RangeKnobMoveStartEventDetail, type RefresherEventDetail, type RefresherPullEndEventDetail, type ReorderEndEventDetail, type ReorderMoveEventDetail, type ScrollBaseDetail, type ScrollDetail, type SearchbarChangeEventDetail, type SearchbarInputEventDetail, type SegmentChangeEventDetail, type SegmentViewScrollEvent, type SelectChangeEventDetail, type TextareaChangeEventDetail, type TextareaInputEventDetail, type ToggleChangeEventDetail } from "@ionic/core";
+import type { Components } from "@ionic/core/components";
+import { IonAccordionGroup as IonAccordionGroupElement, defineCustomElement as defineIonAccordionGroup } from "@ionic/core/components/ion-accordion-group.js";
+import { IonAccordion as IonAccordionElement, defineCustomElement as defineIonAccordion } from "@ionic/core/components/ion-accordion.js";
+import { IonAvatar as IonAvatarElement, defineCustomElement as defineIonAvatar } from "@ionic/core/components/ion-avatar.js";
+import { IonBackdrop as IonBackdropElement, defineCustomElement as defineIonBackdrop } from "@ionic/core/components/ion-backdrop.js";
+import { IonBadge as IonBadgeElement, defineCustomElement as defineIonBadge } from "@ionic/core/components/ion-badge.js";
+import { IonBreadcrumbs as IonBreadcrumbsElement, defineCustomElement as defineIonBreadcrumbs } from "@ionic/core/components/ion-breadcrumbs.js";
+import { IonButtons as IonButtonsElement, defineCustomElement as defineIonButtons } from "@ionic/core/components/ion-buttons.js";
+import { IonCardContent as IonCardContentElement, defineCustomElement as defineIonCardContent } from "@ionic/core/components/ion-card-content.js";
+import { IonCardHeader as IonCardHeaderElement, defineCustomElement as defineIonCardHeader } from "@ionic/core/components/ion-card-header.js";
+import { IonCardSubtitle as IonCardSubtitleElement, defineCustomElement as defineIonCardSubtitle } from "@ionic/core/components/ion-card-subtitle.js";
+import { IonCardTitle as IonCardTitleElement, defineCustomElement as defineIonCardTitle } from "@ionic/core/components/ion-card-title.js";
+import { IonCheckbox as IonCheckboxElement, defineCustomElement as defineIonCheckbox } from "@ionic/core/components/ion-checkbox.js";
+import { IonChip as IonChipElement, defineCustomElement as defineIonChip } from "@ionic/core/components/ion-chip.js";
+import { IonCol as IonColElement, defineCustomElement as defineIonCol } from "@ionic/core/components/ion-col.js";
+import { IonContent as IonContentElement, defineCustomElement as defineIonContent } from "@ionic/core/components/ion-content.js";
+import { IonDatetimeButton as IonDatetimeButtonElement, defineCustomElement as defineIonDatetimeButton } from "@ionic/core/components/ion-datetime-button.js";
+import { IonDatetime as IonDatetimeElement, defineCustomElement as defineIonDatetime } from "@ionic/core/components/ion-datetime.js";
+import { IonFabList as IonFabListElement, defineCustomElement as defineIonFabList } from "@ionic/core/components/ion-fab-list.js";
+import { IonFab as IonFabElement, defineCustomElement as defineIonFab } from "@ionic/core/components/ion-fab.js";
+import { IonFooter as IonFooterElement, defineCustomElement as defineIonFooter } from "@ionic/core/components/ion-footer.js";
+import { IonGrid as IonGridElement, defineCustomElement as defineIonGrid } from "@ionic/core/components/ion-grid.js";
+import { IonHeader as IonHeaderElement, defineCustomElement as defineIonHeader } from "@ionic/core/components/ion-header.js";
+import { IonImg as IonImgElement, defineCustomElement as defineIonImg } from "@ionic/core/components/ion-img.js";
+import { IonInfiniteScrollContent as IonInfiniteScrollContentElement, defineCustomElement as defineIonInfiniteScrollContent } from "@ionic/core/components/ion-infinite-scroll-content.js";
+import { IonInfiniteScroll as IonInfiniteScrollElement, defineCustomElement as defineIonInfiniteScroll } from "@ionic/core/components/ion-infinite-scroll.js";
+import { IonInputOtp as IonInputOtpElement, defineCustomElement as defineIonInputOtp } from "@ionic/core/components/ion-input-otp.js";
+import { IonInputPasswordToggle as IonInputPasswordToggleElement, defineCustomElement as defineIonInputPasswordToggle } from "@ionic/core/components/ion-input-password-toggle.js";
+import { IonInput as IonInputElement, defineCustomElement as defineIonInput } from "@ionic/core/components/ion-input.js";
+import { IonItemDivider as IonItemDividerElement, defineCustomElement as defineIonItemDivider } from "@ionic/core/components/ion-item-divider.js";
+import { IonItemGroup as IonItemGroupElement, defineCustomElement as defineIonItemGroup } from "@ionic/core/components/ion-item-group.js";
+import { IonItemOptions as IonItemOptionsElement, defineCustomElement as defineIonItemOptions } from "@ionic/core/components/ion-item-options.js";
+import { IonItemSliding as IonItemSlidingElement, defineCustomElement as defineIonItemSliding } from "@ionic/core/components/ion-item-sliding.js";
+import { IonLabel as IonLabelElement, defineCustomElement as defineIonLabel } from "@ionic/core/components/ion-label.js";
+import { IonListHeader as IonListHeaderElement, defineCustomElement as defineIonListHeader } from "@ionic/core/components/ion-list-header.js";
+import { IonList as IonListElement, defineCustomElement as defineIonList } from "@ionic/core/components/ion-list.js";
+import { IonMenuButton as IonMenuButtonElement, defineCustomElement as defineIonMenuButton } from "@ionic/core/components/ion-menu-button.js";
+import { IonMenuToggle as IonMenuToggleElement, defineCustomElement as defineIonMenuToggle } from "@ionic/core/components/ion-menu-toggle.js";
+import { IonMenu as IonMenuElement, defineCustomElement as defineIonMenu } from "@ionic/core/components/ion-menu.js";
+import { IonNavLink as IonNavLinkElement, defineCustomElement as defineIonNavLink } from "@ionic/core/components/ion-nav-link.js";
+import { IonNav as IonNavElement, defineCustomElement as defineIonNav } from "@ionic/core/components/ion-nav.js";
+import { IonNote as IonNoteElement, defineCustomElement as defineIonNote } from "@ionic/core/components/ion-note.js";
+import { IonPickerColumnOption as IonPickerColumnOptionElement, defineCustomElement as defineIonPickerColumnOption } from "@ionic/core/components/ion-picker-column-option.js";
+import { IonPickerColumn as IonPickerColumnElement, defineCustomElement as defineIonPickerColumn } from "@ionic/core/components/ion-picker-column.js";
+import { IonPicker as IonPickerElement, defineCustomElement as defineIonPicker } from "@ionic/core/components/ion-picker.js";
+import { IonProgressBar as IonProgressBarElement, defineCustomElement as defineIonProgressBar } from "@ionic/core/components/ion-progress-bar.js";
+import { IonRadioGroup as IonRadioGroupElement, defineCustomElement as defineIonRadioGroup } from "@ionic/core/components/ion-radio-group.js";
+import { IonRadio as IonRadioElement, defineCustomElement as defineIonRadio } from "@ionic/core/components/ion-radio.js";
+import { IonRange as IonRangeElement, defineCustomElement as defineIonRange } from "@ionic/core/components/ion-range.js";
+import { IonRefresherContent as IonRefresherContentElement, defineCustomElement as defineIonRefresherContent } from "@ionic/core/components/ion-refresher-content.js";
+import { IonRefresher as IonRefresherElement, defineCustomElement as defineIonRefresher } from "@ionic/core/components/ion-refresher.js";
+import { IonReorderGroup as IonReorderGroupElement, defineCustomElement as defineIonReorderGroup } from "@ionic/core/components/ion-reorder-group.js";
+import { IonReorder as IonReorderElement, defineCustomElement as defineIonReorder } from "@ionic/core/components/ion-reorder.js";
+import { IonRippleEffect as IonRippleEffectElement, defineCustomElement as defineIonRippleEffect } from "@ionic/core/components/ion-ripple-effect.js";
+import { IonRow as IonRowElement, defineCustomElement as defineIonRow } from "@ionic/core/components/ion-row.js";
+import { IonSearchbar as IonSearchbarElement, defineCustomElement as defineIonSearchbar } from "@ionic/core/components/ion-searchbar.js";
+import { IonSegmentButton as IonSegmentButtonElement, defineCustomElement as defineIonSegmentButton } from "@ionic/core/components/ion-segment-button.js";
+import { IonSegmentContent as IonSegmentContentElement, defineCustomElement as defineIonSegmentContent } from "@ionic/core/components/ion-segment-content.js";
+import { IonSegmentView as IonSegmentViewElement, defineCustomElement as defineIonSegmentView } from "@ionic/core/components/ion-segment-view.js";
+import { IonSegment as IonSegmentElement, defineCustomElement as defineIonSegment } from "@ionic/core/components/ion-segment.js";
+import { IonSelectModal as IonSelectModalElement, defineCustomElement as defineIonSelectModal } from "@ionic/core/components/ion-select-modal.js";
+import { IonSelectOption as IonSelectOptionElement, defineCustomElement as defineIonSelectOption } from "@ionic/core/components/ion-select-option.js";
+import { IonSelect as IonSelectElement, defineCustomElement as defineIonSelect } from "@ionic/core/components/ion-select.js";
+import { IonSkeletonText as IonSkeletonTextElement, defineCustomElement as defineIonSkeletonText } from "@ionic/core/components/ion-skeleton-text.js";
+import { IonSpinner as IonSpinnerElement, defineCustomElement as defineIonSpinner } from "@ionic/core/components/ion-spinner.js";
+import { IonSplitPane as IonSplitPaneElement, defineCustomElement as defineIonSplitPane } from "@ionic/core/components/ion-split-pane.js";
+import { IonTab as IonTabElement, defineCustomElement as defineIonTab } from "@ionic/core/components/ion-tab.js";
+import { IonText as IonTextElement, defineCustomElement as defineIonText } from "@ionic/core/components/ion-text.js";
+import { IonTextarea as IonTextareaElement, defineCustomElement as defineIonTextarea } from "@ionic/core/components/ion-textarea.js";
+import { IonThumbnail as IonThumbnailElement, defineCustomElement as defineIonThumbnail } from "@ionic/core/components/ion-thumbnail.js";
+import { IonTitle as IonTitleElement, defineCustomElement as defineIonTitle } from "@ionic/core/components/ion-title.js";
+import { IonToggle as IonToggleElement, defineCustomElement as defineIonToggle } from "@ionic/core/components/ion-toggle.js";
+import { IonToolbar as IonToolbarElement, defineCustomElement as defineIonToolbar } from "@ionic/core/components/ion-toolbar.js";
 
 export type IonAccordionEvents = NonNullable<unknown>;
 
-export const IonAccordion: StencilReactComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion> =
-  /*@__PURE__*/ createComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion>({
+export const IonAccordion: StencilReactComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion> = /*@__PURE__*/ createComponent<IonAccordionElement, IonAccordionEvents, Components.IonAccordion>({
     tagName: 'ion-accordion',
     elementClass: IonAccordionElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonAccordionEvents,
-    defineCustomElement: defineIonAccordion,
-  });
+    defineCustomElement: defineIonAccordion
+});
 
-export type IonAccordionGroupEvents = {
-  onIonChange: EventName<IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>>;
-};
+export type IonAccordionGroupEvents = { onIonChange: EventName<IonAccordionGroupCustomEvent<AccordionGroupChangeEventDetail>> };
 
-export const IonAccordionGroup: StencilReactComponent<
-  IonAccordionGroupElement,
-  IonAccordionGroupEvents,
-  Components.IonAccordionGroup
-> = /*@__PURE__*/ createComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup>({
-  tagName: 'ion-accordion-group',
-  elementClass: IonAccordionGroupElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonChange: 'ionChange' } as IonAccordionGroupEvents,
-  defineCustomElement: defineIonAccordionGroup,
+export const IonAccordionGroup: StencilReactComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup> = /*@__PURE__*/ createComponent<IonAccordionGroupElement, IonAccordionGroupEvents, Components.IonAccordionGroup>({
+    tagName: 'ion-accordion-group',
+    elementClass: IonAccordionGroupElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonChange: 'ionChange' } as IonAccordionGroupEvents,
+    defineCustomElement: defineIonAccordionGroup
 });
 
 export type IonAvatarEvents = NonNullable<unknown>;
 
-export const IonAvatar: StencilReactComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar> =
-  /*@__PURE__*/ createComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar>({
+export const IonAvatar: StencilReactComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar> = /*@__PURE__*/ createComponent<IonAvatarElement, IonAvatarEvents, Components.IonAvatar>({
     tagName: 'ion-avatar',
     elementClass: IonAvatarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonAvatarEvents,
-    defineCustomElement: defineIonAvatar,
-  });
+    defineCustomElement: defineIonAvatar
+});
 
 export type IonBackdropEvents = { onIonBackdropTap: EventName<IonBackdropCustomEvent<void>> };
 
-export const IonBackdrop: StencilReactComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop> =
-  /*@__PURE__*/ createComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop>({
+export const IonBackdrop: StencilReactComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop> = /*@__PURE__*/ createComponent<IonBackdropElement, IonBackdropEvents, Components.IonBackdrop>({
     tagName: 'ion-backdrop',
     elementClass: IonBackdropElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonBackdropTap: 'ionBackdropTap' } as IonBackdropEvents,
-    defineCustomElement: defineIonBackdrop,
-  });
+    defineCustomElement: defineIonBackdrop
+});
 
 export type IonBadgeEvents = NonNullable<unknown>;
 
-export const IonBadge: StencilReactComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge> =
-  /*@__PURE__*/ createComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge>({
+export const IonBadge: StencilReactComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge> = /*@__PURE__*/ createComponent<IonBadgeElement, IonBadgeEvents, Components.IonBadge>({
     tagName: 'ion-badge',
     elementClass: IonBadgeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonBadgeEvents,
-    defineCustomElement: defineIonBadge,
-  });
+    defineCustomElement: defineIonBadge
+});
 
-export type IonBreadcrumbsEvents = {
-  onIonCollapsedClick: EventName<IonBreadcrumbsCustomEvent<BreadcrumbCollapsedClickEventDetail>>;
-};
+export type IonBreadcrumbsEvents = { onIonCollapsedClick: EventName<IonBreadcrumbsCustomEvent<BreadcrumbCollapsedClickEventDetail>> };
 
-export const IonBreadcrumbs: StencilReactComponent<
-  IonBreadcrumbsElement,
-  IonBreadcrumbsEvents,
-  Components.IonBreadcrumbs
-> = /*@__PURE__*/ createComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs>({
-  tagName: 'ion-breadcrumbs',
-  elementClass: IonBreadcrumbsElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonCollapsedClick: 'ionCollapsedClick' } as IonBreadcrumbsEvents,
-  defineCustomElement: defineIonBreadcrumbs,
+export const IonBreadcrumbs: StencilReactComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs> = /*@__PURE__*/ createComponent<IonBreadcrumbsElement, IonBreadcrumbsEvents, Components.IonBreadcrumbs>({
+    tagName: 'ion-breadcrumbs',
+    elementClass: IonBreadcrumbsElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonCollapsedClick: 'ionCollapsedClick' } as IonBreadcrumbsEvents,
+    defineCustomElement: defineIonBreadcrumbs
 });
 
 export type IonButtonsEvents = NonNullable<unknown>;
 
-export const IonButtons: StencilReactComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons> =
-  /*@__PURE__*/ createComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons>({
+export const IonButtons: StencilReactComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons> = /*@__PURE__*/ createComponent<IonButtonsElement, IonButtonsEvents, Components.IonButtons>({
     tagName: 'ion-buttons',
     elementClass: IonButtonsElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonButtonsEvents,
-    defineCustomElement: defineIonButtons,
-  });
+    defineCustomElement: defineIonButtons
+});
 
 export type IonCardContentEvents = NonNullable<unknown>;
 
-export const IonCardContent: StencilReactComponent<
-  IonCardContentElement,
-  IonCardContentEvents,
-  Components.IonCardContent
-> = /*@__PURE__*/ createComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent>({
-  tagName: 'ion-card-content',
-  elementClass: IonCardContentElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonCardContentEvents,
-  defineCustomElement: defineIonCardContent,
+export const IonCardContent: StencilReactComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent> = /*@__PURE__*/ createComponent<IonCardContentElement, IonCardContentEvents, Components.IonCardContent>({
+    tagName: 'ion-card-content',
+    elementClass: IonCardContentElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonCardContentEvents,
+    defineCustomElement: defineIonCardContent
 });
 
 export type IonCardHeaderEvents = NonNullable<unknown>;
 
-export const IonCardHeader: StencilReactComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader> =
-  /*@__PURE__*/ createComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader>({
+export const IonCardHeader: StencilReactComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader> = /*@__PURE__*/ createComponent<IonCardHeaderElement, IonCardHeaderEvents, Components.IonCardHeader>({
     tagName: 'ion-card-header',
     elementClass: IonCardHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonCardHeaderEvents,
-    defineCustomElement: defineIonCardHeader,
-  });
+    defineCustomElement: defineIonCardHeader
+});
 
 export type IonCardSubtitleEvents = NonNullable<unknown>;
 
-export const IonCardSubtitle: StencilReactComponent<
-  IonCardSubtitleElement,
-  IonCardSubtitleEvents,
-  Components.IonCardSubtitle
-> = /*@__PURE__*/ createComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle>({
-  tagName: 'ion-card-subtitle',
-  elementClass: IonCardSubtitleElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonCardSubtitleEvents,
-  defineCustomElement: defineIonCardSubtitle,
+export const IonCardSubtitle: StencilReactComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle> = /*@__PURE__*/ createComponent<IonCardSubtitleElement, IonCardSubtitleEvents, Components.IonCardSubtitle>({
+    tagName: 'ion-card-subtitle',
+    elementClass: IonCardSubtitleElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonCardSubtitleEvents,
+    defineCustomElement: defineIonCardSubtitle
 });
 
 export type IonCardTitleEvents = NonNullable<unknown>;
 
-export const IonCardTitle: StencilReactComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle> =
-  /*@__PURE__*/ createComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle>({
+export const IonCardTitle: StencilReactComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle> = /*@__PURE__*/ createComponent<IonCardTitleElement, IonCardTitleEvents, Components.IonCardTitle>({
     tagName: 'ion-card-title',
     elementClass: IonCardTitleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonCardTitleEvents,
-    defineCustomElement: defineIonCardTitle,
-  });
+    defineCustomElement: defineIonCardTitle
+});
 
 export type IonCheckboxEvents = {
-  onIonChange: EventName<IonCheckboxCustomEvent<CheckboxChangeEventDetail>>;
-  onIonFocus: EventName<IonCheckboxCustomEvent<void>>;
-  onIonBlur: EventName<IonCheckboxCustomEvent<void>>;
+    onIonChange: EventName<IonCheckboxCustomEvent<CheckboxChangeEventDetail>>,
+    onIonFocus: EventName<IonCheckboxCustomEvent<void>>,
+    onIonBlur: EventName<IonCheckboxCustomEvent<void>>
 };
 
-export const IonCheckbox: StencilReactComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox> =
-  /*@__PURE__*/ createComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox>({
+export const IonCheckbox: StencilReactComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox> = /*@__PURE__*/ createComponent<IonCheckboxElement, IonCheckboxEvents, Components.IonCheckbox>({
     tagName: 'ion-checkbox',
     elementClass: IonCheckboxElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonChange: 'ionChange',
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
+        onIonChange: 'ionChange',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur'
     } as IonCheckboxEvents,
-    defineCustomElement: defineIonCheckbox,
-  });
+    defineCustomElement: defineIonCheckbox
+});
 
 export type IonChipEvents = NonNullable<unknown>;
 
-export const IonChip: StencilReactComponent<IonChipElement, IonChipEvents, Components.IonChip> =
-  /*@__PURE__*/ createComponent<IonChipElement, IonChipEvents, Components.IonChip>({
+export const IonChip: StencilReactComponent<IonChipElement, IonChipEvents, Components.IonChip> = /*@__PURE__*/ createComponent<IonChipElement, IonChipEvents, Components.IonChip>({
     tagName: 'ion-chip',
     elementClass: IonChipElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonChipEvents,
-    defineCustomElement: defineIonChip,
-  });
+    defineCustomElement: defineIonChip
+});
 
 export type IonColEvents = NonNullable<unknown>;
 
-export const IonCol: StencilReactComponent<IonColElement, IonColEvents, Components.IonCol> =
-  /*@__PURE__*/ createComponent<IonColElement, IonColEvents, Components.IonCol>({
+export const IonCol: StencilReactComponent<IonColElement, IonColEvents, Components.IonCol> = /*@__PURE__*/ createComponent<IonColElement, IonColEvents, Components.IonCol>({
     tagName: 'ion-col',
     elementClass: IonColElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonColEvents,
-    defineCustomElement: defineIonCol,
-  });
+    defineCustomElement: defineIonCol
+});
 
 export type IonContentEvents = {
-  onIonScrollStart: EventName<IonContentCustomEvent<ScrollBaseDetail>>;
-  onIonScroll: EventName<IonContentCustomEvent<ScrollDetail>>;
-  onIonScrollEnd: EventName<IonContentCustomEvent<ScrollBaseDetail>>;
+    onIonScrollStart: EventName<IonContentCustomEvent<ScrollBaseDetail>>,
+    onIonScroll: EventName<IonContentCustomEvent<ScrollDetail>>,
+    onIonScrollEnd: EventName<IonContentCustomEvent<ScrollBaseDetail>>
 };
 
-export const IonContent: StencilReactComponent<IonContentElement, IonContentEvents, Components.IonContent> =
-  /*@__PURE__*/ createComponent<IonContentElement, IonContentEvents, Components.IonContent>({
+export const IonContent: StencilReactComponent<IonContentElement, IonContentEvents, Components.IonContent> = /*@__PURE__*/ createComponent<IonContentElement, IonContentEvents, Components.IonContent>({
     tagName: 'ion-content',
     elementClass: IonContentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonScrollStart: 'ionScrollStart',
-      onIonScroll: 'ionScroll',
-      onIonScrollEnd: 'ionScrollEnd',
+        onIonScrollStart: 'ionScrollStart',
+        onIonScroll: 'ionScroll',
+        onIonScrollEnd: 'ionScrollEnd'
     } as IonContentEvents,
-    defineCustomElement: defineIonContent,
-  });
+    defineCustomElement: defineIonContent
+});
 
 export type IonDatetimeEvents = {
-  onIonCancel: EventName<IonDatetimeCustomEvent<void>>;
-  onIonChange: EventName<IonDatetimeCustomEvent<DatetimeChangeEventDetail>>;
-  onIonFocus: EventName<IonDatetimeCustomEvent<void>>;
-  onIonBlur: EventName<IonDatetimeCustomEvent<void>>;
+    onIonCancel: EventName<IonDatetimeCustomEvent<void>>,
+    onIonChange: EventName<IonDatetimeCustomEvent<DatetimeChangeEventDetail>>,
+    onIonFocus: EventName<IonDatetimeCustomEvent<void>>,
+    onIonBlur: EventName<IonDatetimeCustomEvent<void>>
 };
 
-export const IonDatetime: StencilReactComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime> =
-  /*@__PURE__*/ createComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime>({
+export const IonDatetime: StencilReactComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime> = /*@__PURE__*/ createComponent<IonDatetimeElement, IonDatetimeEvents, Components.IonDatetime>({
     tagName: 'ion-datetime',
     elementClass: IonDatetimeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonCancel: 'ionCancel',
-      onIonChange: 'ionChange',
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
+        onIonCancel: 'ionCancel',
+        onIonChange: 'ionChange',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur'
     } as IonDatetimeEvents,
-    defineCustomElement: defineIonDatetime,
-  });
+    defineCustomElement: defineIonDatetime
+});
 
 export type IonDatetimeButtonEvents = NonNullable<unknown>;
 
-export const IonDatetimeButton: StencilReactComponent<
-  IonDatetimeButtonElement,
-  IonDatetimeButtonEvents,
-  Components.IonDatetimeButton
-> = /*@__PURE__*/ createComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton>({
-  tagName: 'ion-datetime-button',
-  elementClass: IonDatetimeButtonElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonDatetimeButtonEvents,
-  defineCustomElement: defineIonDatetimeButton,
+export const IonDatetimeButton: StencilReactComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton> = /*@__PURE__*/ createComponent<IonDatetimeButtonElement, IonDatetimeButtonEvents, Components.IonDatetimeButton>({
+    tagName: 'ion-datetime-button',
+    elementClass: IonDatetimeButtonElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonDatetimeButtonEvents,
+    defineCustomElement: defineIonDatetimeButton
 });
 
 export type IonFabEvents = NonNullable<unknown>;
 
-export const IonFab: StencilReactComponent<IonFabElement, IonFabEvents, Components.IonFab> =
-  /*@__PURE__*/ createComponent<IonFabElement, IonFabEvents, Components.IonFab>({
+export const IonFab: StencilReactComponent<IonFabElement, IonFabEvents, Components.IonFab> = /*@__PURE__*/ createComponent<IonFabElement, IonFabEvents, Components.IonFab>({
     tagName: 'ion-fab',
     elementClass: IonFabElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFabEvents,
-    defineCustomElement: defineIonFab,
-  });
+    defineCustomElement: defineIonFab
+});
 
 export type IonFabListEvents = NonNullable<unknown>;
 
-export const IonFabList: StencilReactComponent<IonFabListElement, IonFabListEvents, Components.IonFabList> =
-  /*@__PURE__*/ createComponent<IonFabListElement, IonFabListEvents, Components.IonFabList>({
+export const IonFabList: StencilReactComponent<IonFabListElement, IonFabListEvents, Components.IonFabList> = /*@__PURE__*/ createComponent<IonFabListElement, IonFabListEvents, Components.IonFabList>({
     tagName: 'ion-fab-list',
     elementClass: IonFabListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFabListEvents,
-    defineCustomElement: defineIonFabList,
-  });
+    defineCustomElement: defineIonFabList
+});
 
 export type IonFooterEvents = NonNullable<unknown>;
 
-export const IonFooter: StencilReactComponent<IonFooterElement, IonFooterEvents, Components.IonFooter> =
-  /*@__PURE__*/ createComponent<IonFooterElement, IonFooterEvents, Components.IonFooter>({
+export const IonFooter: StencilReactComponent<IonFooterElement, IonFooterEvents, Components.IonFooter> = /*@__PURE__*/ createComponent<IonFooterElement, IonFooterEvents, Components.IonFooter>({
     tagName: 'ion-footer',
     elementClass: IonFooterElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonFooterEvents,
-    defineCustomElement: defineIonFooter,
-  });
+    defineCustomElement: defineIonFooter
+});
 
 export type IonGridEvents = NonNullable<unknown>;
 
-export const IonGrid: StencilReactComponent<IonGridElement, IonGridEvents, Components.IonGrid> =
-  /*@__PURE__*/ createComponent<IonGridElement, IonGridEvents, Components.IonGrid>({
+export const IonGrid: StencilReactComponent<IonGridElement, IonGridEvents, Components.IonGrid> = /*@__PURE__*/ createComponent<IonGridElement, IonGridEvents, Components.IonGrid>({
     tagName: 'ion-grid',
     elementClass: IonGridElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonGridEvents,
-    defineCustomElement: defineIonGrid,
-  });
+    defineCustomElement: defineIonGrid
+});
 
 export type IonHeaderEvents = NonNullable<unknown>;
 
-export const IonHeader: StencilReactComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader> =
-  /*@__PURE__*/ createComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader>({
+export const IonHeader: StencilReactComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader> = /*@__PURE__*/ createComponent<IonHeaderElement, IonHeaderEvents, Components.IonHeader>({
     tagName: 'ion-header',
     elementClass: IonHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonHeaderEvents,
-    defineCustomElement: defineIonHeader,
-  });
+    defineCustomElement: defineIonHeader
+});
 
 export type IonImgEvents = {
-  onIonImgWillLoad: EventName<IonImgCustomEvent<void>>;
-  onIonImgDidLoad: EventName<IonImgCustomEvent<void>>;
-  onIonError: EventName<IonImgCustomEvent<void>>;
+    onIonImgWillLoad: EventName<IonImgCustomEvent<void>>,
+    onIonImgDidLoad: EventName<IonImgCustomEvent<void>>,
+    onIonError: EventName<IonImgCustomEvent<void>>
 };
 
-export const IonImg: StencilReactComponent<IonImgElement, IonImgEvents, Components.IonImg> =
-  /*@__PURE__*/ createComponent<IonImgElement, IonImgEvents, Components.IonImg>({
+export const IonImg: StencilReactComponent<IonImgElement, IonImgEvents, Components.IonImg> = /*@__PURE__*/ createComponent<IonImgElement, IonImgEvents, Components.IonImg>({
     tagName: 'ion-img',
     elementClass: IonImgElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonImgWillLoad: 'ionImgWillLoad',
-      onIonImgDidLoad: 'ionImgDidLoad',
-      onIonError: 'ionError',
+        onIonImgWillLoad: 'ionImgWillLoad',
+        onIonImgDidLoad: 'ionImgDidLoad',
+        onIonError: 'ionError'
     } as IonImgEvents,
-    defineCustomElement: defineIonImg,
-  });
+    defineCustomElement: defineIonImg
+});
 
 export type IonInfiniteScrollEvents = { onIonInfinite: EventName<IonInfiniteScrollCustomEvent<void>> };
 
-export const IonInfiniteScroll: StencilReactComponent<
-  IonInfiniteScrollElement,
-  IonInfiniteScrollEvents,
-  Components.IonInfiniteScroll
-> = /*@__PURE__*/ createComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll>({
-  tagName: 'ion-infinite-scroll',
-  elementClass: IonInfiniteScrollElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonInfinite: 'ionInfinite' } as IonInfiniteScrollEvents,
-  defineCustomElement: defineIonInfiniteScroll,
+export const IonInfiniteScroll: StencilReactComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll> = /*@__PURE__*/ createComponent<IonInfiniteScrollElement, IonInfiniteScrollEvents, Components.IonInfiniteScroll>({
+    tagName: 'ion-infinite-scroll',
+    elementClass: IonInfiniteScrollElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonInfinite: 'ionInfinite' } as IonInfiniteScrollEvents,
+    defineCustomElement: defineIonInfiniteScroll
 });
 
 export type IonInfiniteScrollContentEvents = NonNullable<unknown>;
 
-export const IonInfiniteScrollContent: StencilReactComponent<
-  IonInfiniteScrollContentElement,
-  IonInfiniteScrollContentEvents,
-  Components.IonInfiniteScrollContent
-> = /*@__PURE__*/ createComponent<
-  IonInfiniteScrollContentElement,
-  IonInfiniteScrollContentEvents,
-  Components.IonInfiniteScrollContent
->({
-  tagName: 'ion-infinite-scroll-content',
-  elementClass: IonInfiniteScrollContentElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonInfiniteScrollContentEvents,
-  defineCustomElement: defineIonInfiniteScrollContent,
+export const IonInfiniteScrollContent: StencilReactComponent<IonInfiniteScrollContentElement, IonInfiniteScrollContentEvents, Components.IonInfiniteScrollContent> = /*@__PURE__*/ createComponent<IonInfiniteScrollContentElement, IonInfiniteScrollContentEvents, Components.IonInfiniteScrollContent>({
+    tagName: 'ion-infinite-scroll-content',
+    elementClass: IonInfiniteScrollContentElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonInfiniteScrollContentEvents,
+    defineCustomElement: defineIonInfiniteScrollContent
 });
 
 export type IonInputEvents = {
-  onIonInput: EventName<IonInputCustomEvent<InputInputEventDetail>>;
-  onIonChange: EventName<IonInputCustomEvent<InputChangeEventDetail>>;
-  onIonBlur: EventName<IonInputCustomEvent<FocusEvent>>;
-  onIonFocus: EventName<IonInputCustomEvent<FocusEvent>>;
+    onIonInput: EventName<IonInputCustomEvent<InputInputEventDetail>>,
+    onIonChange: EventName<IonInputCustomEvent<InputChangeEventDetail>>,
+    onIonBlur: EventName<IonInputCustomEvent<FocusEvent>>,
+    onIonFocus: EventName<IonInputCustomEvent<FocusEvent>>
 };
 
-export const IonInput: StencilReactComponent<IonInputElement, IonInputEvents, Components.IonInput> =
-  /*@__PURE__*/ createComponent<IonInputElement, IonInputEvents, Components.IonInput>({
+export const IonInput: StencilReactComponent<IonInputElement, IonInputEvents, Components.IonInput> = /*@__PURE__*/ createComponent<IonInputElement, IonInputEvents, Components.IonInput>({
     tagName: 'ion-input',
     elementClass: IonInputElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonInput: 'ionInput',
-      onIonChange: 'ionChange',
-      onIonBlur: 'ionBlur',
-      onIonFocus: 'ionFocus',
+        onIonInput: 'ionInput',
+        onIonChange: 'ionChange',
+        onIonBlur: 'ionBlur',
+        onIonFocus: 'ionFocus'
     } as IonInputEvents,
-    defineCustomElement: defineIonInput,
-  });
+    defineCustomElement: defineIonInput
+});
 
 export type IonInputOtpEvents = {
-  onIonInput: EventName<IonInputOtpCustomEvent<InputOtpInputEventDetail>>;
-  onIonChange: EventName<IonInputOtpCustomEvent<InputOtpChangeEventDetail>>;
-  onIonComplete: EventName<IonInputOtpCustomEvent<InputOtpCompleteEventDetail>>;
-  onIonBlur: EventName<IonInputOtpCustomEvent<FocusEvent>>;
-  onIonFocus: EventName<IonInputOtpCustomEvent<FocusEvent>>;
+    onIonInput: EventName<IonInputOtpCustomEvent<InputOtpInputEventDetail>>,
+    onIonChange: EventName<IonInputOtpCustomEvent<InputOtpChangeEventDetail>>,
+    onIonComplete: EventName<IonInputOtpCustomEvent<InputOtpCompleteEventDetail>>,
+    onIonBlur: EventName<IonInputOtpCustomEvent<FocusEvent>>,
+    onIonFocus: EventName<IonInputOtpCustomEvent<FocusEvent>>
 };
 
-export const IonInputOtp: StencilReactComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp> =
-  /*@__PURE__*/ createComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp>({
+export const IonInputOtp: StencilReactComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp> = /*@__PURE__*/ createComponent<IonInputOtpElement, IonInputOtpEvents, Components.IonInputOtp>({
     tagName: 'ion-input-otp',
     elementClass: IonInputOtpElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonInput: 'ionInput',
-      onIonChange: 'ionChange',
-      onIonComplete: 'ionComplete',
-      onIonBlur: 'ionBlur',
-      onIonFocus: 'ionFocus',
+        onIonInput: 'ionInput',
+        onIonChange: 'ionChange',
+        onIonComplete: 'ionComplete',
+        onIonBlur: 'ionBlur',
+        onIonFocus: 'ionFocus'
     } as IonInputOtpEvents,
-    defineCustomElement: defineIonInputOtp,
-  });
+    defineCustomElement: defineIonInputOtp
+});
 
 export type IonInputPasswordToggleEvents = NonNullable<unknown>;
 
-export const IonInputPasswordToggle: StencilReactComponent<
-  IonInputPasswordToggleElement,
-  IonInputPasswordToggleEvents,
-  Components.IonInputPasswordToggle
-> = /*@__PURE__*/ createComponent<
-  IonInputPasswordToggleElement,
-  IonInputPasswordToggleEvents,
-  Components.IonInputPasswordToggle
->({
-  tagName: 'ion-input-password-toggle',
-  elementClass: IonInputPasswordToggleElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonInputPasswordToggleEvents,
-  defineCustomElement: defineIonInputPasswordToggle,
+export const IonInputPasswordToggle: StencilReactComponent<IonInputPasswordToggleElement, IonInputPasswordToggleEvents, Components.IonInputPasswordToggle> = /*@__PURE__*/ createComponent<IonInputPasswordToggleElement, IonInputPasswordToggleEvents, Components.IonInputPasswordToggle>({
+    tagName: 'ion-input-password-toggle',
+    elementClass: IonInputPasswordToggleElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonInputPasswordToggleEvents,
+    defineCustomElement: defineIonInputPasswordToggle
 });
 
 export type IonItemDividerEvents = NonNullable<unknown>;
 
-export const IonItemDivider: StencilReactComponent<
-  IonItemDividerElement,
-  IonItemDividerEvents,
-  Components.IonItemDivider
-> = /*@__PURE__*/ createComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider>({
-  tagName: 'ion-item-divider',
-  elementClass: IonItemDividerElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonItemDividerEvents,
-  defineCustomElement: defineIonItemDivider,
+export const IonItemDivider: StencilReactComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider> = /*@__PURE__*/ createComponent<IonItemDividerElement, IonItemDividerEvents, Components.IonItemDivider>({
+    tagName: 'ion-item-divider',
+    elementClass: IonItemDividerElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonItemDividerEvents,
+    defineCustomElement: defineIonItemDivider
 });
 
 export type IonItemGroupEvents = NonNullable<unknown>;
 
-export const IonItemGroup: StencilReactComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup> =
-  /*@__PURE__*/ createComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup>({
+export const IonItemGroup: StencilReactComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup> = /*@__PURE__*/ createComponent<IonItemGroupElement, IonItemGroupEvents, Components.IonItemGroup>({
     tagName: 'ion-item-group',
     elementClass: IonItemGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonItemGroupEvents,
-    defineCustomElement: defineIonItemGroup,
-  });
+    defineCustomElement: defineIonItemGroup
+});
 
 export type IonItemOptionsEvents = { onIonSwipe: EventName<IonItemOptionsCustomEvent<any>> };
 
-export const IonItemOptions: StencilReactComponent<
-  IonItemOptionsElement,
-  IonItemOptionsEvents,
-  Components.IonItemOptions
-> = /*@__PURE__*/ createComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions>({
-  tagName: 'ion-item-options',
-  elementClass: IonItemOptionsElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonSwipe: 'ionSwipe' } as IonItemOptionsEvents,
-  defineCustomElement: defineIonItemOptions,
+export const IonItemOptions: StencilReactComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions> = /*@__PURE__*/ createComponent<IonItemOptionsElement, IonItemOptionsEvents, Components.IonItemOptions>({
+    tagName: 'ion-item-options',
+    elementClass: IonItemOptionsElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonSwipe: 'ionSwipe' } as IonItemOptionsEvents,
+    defineCustomElement: defineIonItemOptions
 });
 
 export type IonItemSlidingEvents = { onIonDrag: EventName<IonItemSlidingCustomEvent<any>> };
 
-export const IonItemSliding: StencilReactComponent<
-  IonItemSlidingElement,
-  IonItemSlidingEvents,
-  Components.IonItemSliding
-> = /*@__PURE__*/ createComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding>({
-  tagName: 'ion-item-sliding',
-  elementClass: IonItemSlidingElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonDrag: 'ionDrag' } as IonItemSlidingEvents,
-  defineCustomElement: defineIonItemSliding,
+export const IonItemSliding: StencilReactComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding> = /*@__PURE__*/ createComponent<IonItemSlidingElement, IonItemSlidingEvents, Components.IonItemSliding>({
+    tagName: 'ion-item-sliding',
+    elementClass: IonItemSlidingElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonDrag: 'ionDrag' } as IonItemSlidingEvents,
+    defineCustomElement: defineIonItemSliding
 });
 
 export type IonLabelEvents = NonNullable<unknown>;
 
-export const IonLabel: StencilReactComponent<IonLabelElement, IonLabelEvents, Components.IonLabel> =
-  /*@__PURE__*/ createComponent<IonLabelElement, IonLabelEvents, Components.IonLabel>({
+export const IonLabel: StencilReactComponent<IonLabelElement, IonLabelEvents, Components.IonLabel> = /*@__PURE__*/ createComponent<IonLabelElement, IonLabelEvents, Components.IonLabel>({
     tagName: 'ion-label',
     elementClass: IonLabelElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonLabelEvents,
-    defineCustomElement: defineIonLabel,
-  });
+    defineCustomElement: defineIonLabel
+});
 
 export type IonListEvents = NonNullable<unknown>;
 
-export const IonList: StencilReactComponent<IonListElement, IonListEvents, Components.IonList> =
-  /*@__PURE__*/ createComponent<IonListElement, IonListEvents, Components.IonList>({
+export const IonList: StencilReactComponent<IonListElement, IonListEvents, Components.IonList> = /*@__PURE__*/ createComponent<IonListElement, IonListEvents, Components.IonList>({
     tagName: 'ion-list',
     elementClass: IonListElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonListEvents,
-    defineCustomElement: defineIonList,
-  });
+    defineCustomElement: defineIonList
+});
 
 export type IonListHeaderEvents = NonNullable<unknown>;
 
-export const IonListHeader: StencilReactComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader> =
-  /*@__PURE__*/ createComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader>({
+export const IonListHeader: StencilReactComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader> = /*@__PURE__*/ createComponent<IonListHeaderElement, IonListHeaderEvents, Components.IonListHeader>({
     tagName: 'ion-list-header',
     elementClass: IonListHeaderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonListHeaderEvents,
-    defineCustomElement: defineIonListHeader,
-  });
+    defineCustomElement: defineIonListHeader
+});
 
 export type IonMenuEvents = {
-  onIonWillOpen: EventName<IonMenuCustomEvent<void>>;
-  onIonWillClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>;
-  onIonDidOpen: EventName<IonMenuCustomEvent<void>>;
-  onIonDidClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>;
+    onIonWillOpen: EventName<IonMenuCustomEvent<void>>,
+    onIonWillClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>,
+    onIonDidOpen: EventName<IonMenuCustomEvent<void>>,
+    onIonDidClose: EventName<IonMenuCustomEvent<MenuCloseEventDetail>>
 };
 
-export const IonMenu: StencilReactComponent<IonMenuElement, IonMenuEvents, Components.IonMenu> =
-  /*@__PURE__*/ createComponent<IonMenuElement, IonMenuEvents, Components.IonMenu>({
+export const IonMenu: StencilReactComponent<IonMenuElement, IonMenuEvents, Components.IonMenu> = /*@__PURE__*/ createComponent<IonMenuElement, IonMenuEvents, Components.IonMenu>({
     tagName: 'ion-menu',
     elementClass: IonMenuElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonWillOpen: 'ionWillOpen',
-      onIonWillClose: 'ionWillClose',
-      onIonDidOpen: 'ionDidOpen',
-      onIonDidClose: 'ionDidClose',
+        onIonWillOpen: 'ionWillOpen',
+        onIonWillClose: 'ionWillClose',
+        onIonDidOpen: 'ionDidOpen',
+        onIonDidClose: 'ionDidClose'
     } as IonMenuEvents,
-    defineCustomElement: defineIonMenu,
-  });
+    defineCustomElement: defineIonMenu
+});
 
 export type IonMenuButtonEvents = NonNullable<unknown>;
 
-export const IonMenuButton: StencilReactComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton> =
-  /*@__PURE__*/ createComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton>({
+export const IonMenuButton: StencilReactComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton> = /*@__PURE__*/ createComponent<IonMenuButtonElement, IonMenuButtonEvents, Components.IonMenuButton>({
     tagName: 'ion-menu-button',
     elementClass: IonMenuButtonElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonMenuButtonEvents,
-    defineCustomElement: defineIonMenuButton,
-  });
+    defineCustomElement: defineIonMenuButton
+});
 
 export type IonMenuToggleEvents = NonNullable<unknown>;
 
-export const IonMenuToggle: StencilReactComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle> =
-  /*@__PURE__*/ createComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle>({
+export const IonMenuToggle: StencilReactComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle> = /*@__PURE__*/ createComponent<IonMenuToggleElement, IonMenuToggleEvents, Components.IonMenuToggle>({
     tagName: 'ion-menu-toggle',
     elementClass: IonMenuToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonMenuToggleEvents,
-    defineCustomElement: defineIonMenuToggle,
-  });
+    defineCustomElement: defineIonMenuToggle
+});
 
 export type IonNavEvents = {
-  onIonNavWillChange: EventName<IonNavCustomEvent<void>>;
-  onIonNavDidChange: EventName<IonNavCustomEvent<void>>;
+    onIonNavWillChange: EventName<IonNavCustomEvent<void>>,
+    onIonNavDidChange: EventName<IonNavCustomEvent<void>>
 };
 
-export const IonNav: StencilReactComponent<IonNavElement, IonNavEvents, Components.IonNav> =
-  /*@__PURE__*/ createComponent<IonNavElement, IonNavEvents, Components.IonNav>({
+export const IonNav: StencilReactComponent<IonNavElement, IonNavEvents, Components.IonNav> = /*@__PURE__*/ createComponent<IonNavElement, IonNavEvents, Components.IonNav>({
     tagName: 'ion-nav',
     elementClass: IonNavElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonNavWillChange: 'ionNavWillChange',
-      onIonNavDidChange: 'ionNavDidChange',
+        onIonNavWillChange: 'ionNavWillChange',
+        onIonNavDidChange: 'ionNavDidChange'
     } as IonNavEvents,
-    defineCustomElement: defineIonNav,
-  });
+    defineCustomElement: defineIonNav
+});
 
 export type IonNavLinkEvents = NonNullable<unknown>;
 
-export const IonNavLink: StencilReactComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink> =
-  /*@__PURE__*/ createComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink>({
+export const IonNavLink: StencilReactComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink> = /*@__PURE__*/ createComponent<IonNavLinkElement, IonNavLinkEvents, Components.IonNavLink>({
     tagName: 'ion-nav-link',
     elementClass: IonNavLinkElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonNavLinkEvents,
-    defineCustomElement: defineIonNavLink,
-  });
+    defineCustomElement: defineIonNavLink
+});
 
 export type IonNoteEvents = NonNullable<unknown>;
 
-export const IonNote: StencilReactComponent<IonNoteElement, IonNoteEvents, Components.IonNote> =
-  /*@__PURE__*/ createComponent<IonNoteElement, IonNoteEvents, Components.IonNote>({
+export const IonNote: StencilReactComponent<IonNoteElement, IonNoteEvents, Components.IonNote> = /*@__PURE__*/ createComponent<IonNoteElement, IonNoteEvents, Components.IonNote>({
     tagName: 'ion-note',
     elementClass: IonNoteElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonNoteEvents,
-    defineCustomElement: defineIonNote,
-  });
+    defineCustomElement: defineIonNote
+});
 
 export type IonPickerEvents = NonNullable<unknown>;
 
-export const IonPicker: StencilReactComponent<IonPickerElement, IonPickerEvents, Components.IonPicker> =
-  /*@__PURE__*/ createComponent<IonPickerElement, IonPickerEvents, Components.IonPicker>({
+export const IonPicker: StencilReactComponent<IonPickerElement, IonPickerEvents, Components.IonPicker> = /*@__PURE__*/ createComponent<IonPickerElement, IonPickerEvents, Components.IonPicker>({
     tagName: 'ion-picker',
     elementClass: IonPickerElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonPickerEvents,
-    defineCustomElement: defineIonPicker,
-  });
+    defineCustomElement: defineIonPicker
+});
 
-export type IonPickerColumnEvents = {
-  onIonChange: EventName<IonPickerColumnCustomEvent<PickerColumnChangeEventDetail>>;
-};
+export type IonPickerColumnEvents = { onIonChange: EventName<IonPickerColumnCustomEvent<PickerColumnChangeEventDetail>> };
 
-export const IonPickerColumn: StencilReactComponent<
-  IonPickerColumnElement,
-  IonPickerColumnEvents,
-  Components.IonPickerColumn
-> = /*@__PURE__*/ createComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn>({
-  tagName: 'ion-picker-column',
-  elementClass: IonPickerColumnElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonChange: 'ionChange' } as IonPickerColumnEvents,
-  defineCustomElement: defineIonPickerColumn,
+export const IonPickerColumn: StencilReactComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn> = /*@__PURE__*/ createComponent<IonPickerColumnElement, IonPickerColumnEvents, Components.IonPickerColumn>({
+    tagName: 'ion-picker-column',
+    elementClass: IonPickerColumnElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonChange: 'ionChange' } as IonPickerColumnEvents,
+    defineCustomElement: defineIonPickerColumn
 });
 
 export type IonPickerColumnOptionEvents = NonNullable<unknown>;
 
-export const IonPickerColumnOption: StencilReactComponent<
-  IonPickerColumnOptionElement,
-  IonPickerColumnOptionEvents,
-  Components.IonPickerColumnOption
-> = /*@__PURE__*/ createComponent<
-  IonPickerColumnOptionElement,
-  IonPickerColumnOptionEvents,
-  Components.IonPickerColumnOption
->({
-  tagName: 'ion-picker-column-option',
-  elementClass: IonPickerColumnOptionElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonPickerColumnOptionEvents,
-  defineCustomElement: defineIonPickerColumnOption,
+export const IonPickerColumnOption: StencilReactComponent<IonPickerColumnOptionElement, IonPickerColumnOptionEvents, Components.IonPickerColumnOption> = /*@__PURE__*/ createComponent<IonPickerColumnOptionElement, IonPickerColumnOptionEvents, Components.IonPickerColumnOption>({
+    tagName: 'ion-picker-column-option',
+    elementClass: IonPickerColumnOptionElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonPickerColumnOptionEvents,
+    defineCustomElement: defineIonPickerColumnOption
 });
 
 export type IonProgressBarEvents = NonNullable<unknown>;
 
-export const IonProgressBar: StencilReactComponent<
-  IonProgressBarElement,
-  IonProgressBarEvents,
-  Components.IonProgressBar
-> = /*@__PURE__*/ createComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar>({
-  tagName: 'ion-progress-bar',
-  elementClass: IonProgressBarElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonProgressBarEvents,
-  defineCustomElement: defineIonProgressBar,
+export const IonProgressBar: StencilReactComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar> = /*@__PURE__*/ createComponent<IonProgressBarElement, IonProgressBarEvents, Components.IonProgressBar>({
+    tagName: 'ion-progress-bar',
+    elementClass: IonProgressBarElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonProgressBarEvents,
+    defineCustomElement: defineIonProgressBar
 });
 
 export type IonRadioEvents = {
-  onIonFocus: EventName<IonRadioCustomEvent<void>>;
-  onIonBlur: EventName<IonRadioCustomEvent<void>>;
+    onIonFocus: EventName<IonRadioCustomEvent<void>>,
+    onIonBlur: EventName<IonRadioCustomEvent<void>>
 };
 
-export const IonRadio: StencilReactComponent<IonRadioElement, IonRadioEvents, Components.IonRadio> =
-  /*@__PURE__*/ createComponent<IonRadioElement, IonRadioEvents, Components.IonRadio>({
+export const IonRadio: StencilReactComponent<IonRadioElement, IonRadioEvents, Components.IonRadio> = /*@__PURE__*/ createComponent<IonRadioElement, IonRadioEvents, Components.IonRadio>({
     tagName: 'ion-radio',
     elementClass: IonRadioElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur'
     } as IonRadioEvents,
-    defineCustomElement: defineIonRadio,
-  });
+    defineCustomElement: defineIonRadio
+});
 
 export type IonRadioGroupEvents = { onIonChange: EventName<IonRadioGroupCustomEvent<RadioGroupChangeEventDetail>> };
 
-export const IonRadioGroup: StencilReactComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup> =
-  /*@__PURE__*/ createComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup>({
+export const IonRadioGroup: StencilReactComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup> = /*@__PURE__*/ createComponent<IonRadioGroupElement, IonRadioGroupEvents, Components.IonRadioGroup>({
     tagName: 'ion-radio-group',
     elementClass: IonRadioGroupElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonChange: 'ionChange' } as IonRadioGroupEvents,
-    defineCustomElement: defineIonRadioGroup,
-  });
+    defineCustomElement: defineIonRadioGroup
+});
 
 export type IonRangeEvents = {
-  onIonChange: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>;
-  onIonInput: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>;
-  onIonFocus: EventName<IonRangeCustomEvent<void>>;
-  onIonBlur: EventName<IonRangeCustomEvent<void>>;
-  onIonKnobMoveStart: EventName<IonRangeCustomEvent<RangeKnobMoveStartEventDetail>>;
-  onIonKnobMoveEnd: EventName<IonRangeCustomEvent<RangeKnobMoveEndEventDetail>>;
+    onIonChange: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>,
+    onIonInput: EventName<IonRangeCustomEvent<RangeChangeEventDetail>>,
+    onIonFocus: EventName<IonRangeCustomEvent<void>>,
+    onIonBlur: EventName<IonRangeCustomEvent<void>>,
+    onIonKnobMoveStart: EventName<IonRangeCustomEvent<RangeKnobMoveStartEventDetail>>,
+    onIonKnobMoveEnd: EventName<IonRangeCustomEvent<RangeKnobMoveEndEventDetail>>
 };
 
-export const IonRange: StencilReactComponent<IonRangeElement, IonRangeEvents, Components.IonRange> =
-  /*@__PURE__*/ createComponent<IonRangeElement, IonRangeEvents, Components.IonRange>({
+export const IonRange: StencilReactComponent<IonRangeElement, IonRangeEvents, Components.IonRange> = /*@__PURE__*/ createComponent<IonRangeElement, IonRangeEvents, Components.IonRange>({
     tagName: 'ion-range',
     elementClass: IonRangeElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonChange: 'ionChange',
-      onIonInput: 'ionInput',
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
-      onIonKnobMoveStart: 'ionKnobMoveStart',
-      onIonKnobMoveEnd: 'ionKnobMoveEnd',
+        onIonChange: 'ionChange',
+        onIonInput: 'ionInput',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur',
+        onIonKnobMoveStart: 'ionKnobMoveStart',
+        onIonKnobMoveEnd: 'ionKnobMoveEnd'
     } as IonRangeEvents,
-    defineCustomElement: defineIonRange,
-  });
+    defineCustomElement: defineIonRange
+});
 
 export type IonRefresherEvents = {
-  onIonRefresh: EventName<IonRefresherCustomEvent<RefresherEventDetail>>;
-  onIonPull: EventName<IonRefresherCustomEvent<void>>;
-  onIonStart: EventName<IonRefresherCustomEvent<void>>;
-  onIonPullStart: EventName<IonRefresherCustomEvent<void>>;
-  onIonPullEnd: EventName<IonRefresherCustomEvent<RefresherPullEndEventDetail>>;
+    onIonRefresh: EventName<IonRefresherCustomEvent<RefresherEventDetail>>,
+    onIonPull: EventName<IonRefresherCustomEvent<void>>,
+    onIonStart: EventName<IonRefresherCustomEvent<void>>,
+    onIonPullStart: EventName<IonRefresherCustomEvent<void>>,
+    onIonPullEnd: EventName<IonRefresherCustomEvent<RefresherPullEndEventDetail>>
 };
 
-export const IonRefresher: StencilReactComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher> =
-  /*@__PURE__*/ createComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher>({
+export const IonRefresher: StencilReactComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher> = /*@__PURE__*/ createComponent<IonRefresherElement, IonRefresherEvents, Components.IonRefresher>({
     tagName: 'ion-refresher',
     elementClass: IonRefresherElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonRefresh: 'ionRefresh',
-      onIonPull: 'ionPull',
-      onIonStart: 'ionStart',
-      onIonPullStart: 'ionPullStart',
-      onIonPullEnd: 'ionPullEnd',
+        onIonRefresh: 'ionRefresh',
+        onIonPull: 'ionPull',
+        onIonStart: 'ionStart',
+        onIonPullStart: 'ionPullStart',
+        onIonPullEnd: 'ionPullEnd'
     } as IonRefresherEvents,
-    defineCustomElement: defineIonRefresher,
-  });
+    defineCustomElement: defineIonRefresher
+});
 
 export type IonRefresherContentEvents = NonNullable<unknown>;
 
-export const IonRefresherContent: StencilReactComponent<
-  IonRefresherContentElement,
-  IonRefresherContentEvents,
-  Components.IonRefresherContent
-> = /*@__PURE__*/ createComponent<
-  IonRefresherContentElement,
-  IonRefresherContentEvents,
-  Components.IonRefresherContent
->({
-  tagName: 'ion-refresher-content',
-  elementClass: IonRefresherContentElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonRefresherContentEvents,
-  defineCustomElement: defineIonRefresherContent,
+export const IonRefresherContent: StencilReactComponent<IonRefresherContentElement, IonRefresherContentEvents, Components.IonRefresherContent> = /*@__PURE__*/ createComponent<IonRefresherContentElement, IonRefresherContentEvents, Components.IonRefresherContent>({
+    tagName: 'ion-refresher-content',
+    elementClass: IonRefresherContentElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonRefresherContentEvents,
+    defineCustomElement: defineIonRefresherContent
 });
 
 export type IonReorderEvents = NonNullable<unknown>;
 
-export const IonReorder: StencilReactComponent<IonReorderElement, IonReorderEvents, Components.IonReorder> =
-  /*@__PURE__*/ createComponent<IonReorderElement, IonReorderEvents, Components.IonReorder>({
+export const IonReorder: StencilReactComponent<IonReorderElement, IonReorderEvents, Components.IonReorder> = /*@__PURE__*/ createComponent<IonReorderElement, IonReorderEvents, Components.IonReorder>({
     tagName: 'ion-reorder',
     elementClass: IonReorderElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonReorderEvents,
-    defineCustomElement: defineIonReorder,
-  });
+    defineCustomElement: defineIonReorder
+});
 
 export type IonReorderGroupEvents = {
-  onIonItemReorder: EventName<IonReorderGroupCustomEvent<ItemReorderEventDetail>>;
-  onIonReorderStart: EventName<IonReorderGroupCustomEvent<void>>;
-  onIonReorderMove: EventName<IonReorderGroupCustomEvent<ReorderMoveEventDetail>>;
-  onIonReorderEnd: EventName<IonReorderGroupCustomEvent<ReorderEndEventDetail>>;
+    onIonItemReorder: EventName<IonReorderGroupCustomEvent<ItemReorderEventDetail>>,
+    onIonReorderStart: EventName<IonReorderGroupCustomEvent<void>>,
+    onIonReorderMove: EventName<IonReorderGroupCustomEvent<ReorderMoveEventDetail>>,
+    onIonReorderEnd: EventName<IonReorderGroupCustomEvent<ReorderEndEventDetail>>
 };
 
-export const IonReorderGroup: StencilReactComponent<
-  IonReorderGroupElement,
-  IonReorderGroupEvents,
-  Components.IonReorderGroup
-> = /*@__PURE__*/ createComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup>({
-  tagName: 'ion-reorder-group',
-  elementClass: IonReorderGroupElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {
-    onIonItemReorder: 'ionItemReorder',
-    onIonReorderStart: 'ionReorderStart',
-    onIonReorderMove: 'ionReorderMove',
-    onIonReorderEnd: 'ionReorderEnd',
-  } as IonReorderGroupEvents,
-  defineCustomElement: defineIonReorderGroup,
+export const IonReorderGroup: StencilReactComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup> = /*@__PURE__*/ createComponent<IonReorderGroupElement, IonReorderGroupEvents, Components.IonReorderGroup>({
+    tagName: 'ion-reorder-group',
+    elementClass: IonReorderGroupElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {
+        onIonItemReorder: 'ionItemReorder',
+        onIonReorderStart: 'ionReorderStart',
+        onIonReorderMove: 'ionReorderMove',
+        onIonReorderEnd: 'ionReorderEnd'
+    } as IonReorderGroupEvents,
+    defineCustomElement: defineIonReorderGroup
 });
 
 export type IonRippleEffectEvents = NonNullable<unknown>;
 
-export const IonRippleEffect: StencilReactComponent<
-  IonRippleEffectElement,
-  IonRippleEffectEvents,
-  Components.IonRippleEffect
-> = /*@__PURE__*/ createComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect>({
-  tagName: 'ion-ripple-effect',
-  elementClass: IonRippleEffectElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonRippleEffectEvents,
-  defineCustomElement: defineIonRippleEffect,
+export const IonRippleEffect: StencilReactComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect> = /*@__PURE__*/ createComponent<IonRippleEffectElement, IonRippleEffectEvents, Components.IonRippleEffect>({
+    tagName: 'ion-ripple-effect',
+    elementClass: IonRippleEffectElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonRippleEffectEvents,
+    defineCustomElement: defineIonRippleEffect
 });
 
 export type IonRowEvents = NonNullable<unknown>;
 
-export const IonRow: StencilReactComponent<IonRowElement, IonRowEvents, Components.IonRow> =
-  /*@__PURE__*/ createComponent<IonRowElement, IonRowEvents, Components.IonRow>({
+export const IonRow: StencilReactComponent<IonRowElement, IonRowEvents, Components.IonRow> = /*@__PURE__*/ createComponent<IonRowElement, IonRowEvents, Components.IonRow>({
     tagName: 'ion-row',
     elementClass: IonRowElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonRowEvents,
-    defineCustomElement: defineIonRow,
-  });
+    defineCustomElement: defineIonRow
+});
 
 export type IonSearchbarEvents = {
-  onIonInput: EventName<IonSearchbarCustomEvent<SearchbarInputEventDetail>>;
-  onIonChange: EventName<IonSearchbarCustomEvent<SearchbarChangeEventDetail>>;
-  onIonCancel: EventName<IonSearchbarCustomEvent<void>>;
-  onIonClear: EventName<IonSearchbarCustomEvent<void>>;
-  onIonBlur: EventName<IonSearchbarCustomEvent<void>>;
-  onIonFocus: EventName<IonSearchbarCustomEvent<void>>;
+    onIonInput: EventName<IonSearchbarCustomEvent<SearchbarInputEventDetail>>,
+    onIonChange: EventName<IonSearchbarCustomEvent<SearchbarChangeEventDetail>>,
+    onIonCancel: EventName<IonSearchbarCustomEvent<void>>,
+    onIonClear: EventName<IonSearchbarCustomEvent<void>>,
+    onIonBlur: EventName<IonSearchbarCustomEvent<void>>,
+    onIonFocus: EventName<IonSearchbarCustomEvent<void>>
 };
 
-export const IonSearchbar: StencilReactComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar> =
-  /*@__PURE__*/ createComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar>({
+export const IonSearchbar: StencilReactComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar> = /*@__PURE__*/ createComponent<IonSearchbarElement, IonSearchbarEvents, Components.IonSearchbar>({
     tagName: 'ion-searchbar',
     elementClass: IonSearchbarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonInput: 'ionInput',
-      onIonChange: 'ionChange',
-      onIonCancel: 'ionCancel',
-      onIonClear: 'ionClear',
-      onIonBlur: 'ionBlur',
-      onIonFocus: 'ionFocus',
+        onIonInput: 'ionInput',
+        onIonChange: 'ionChange',
+        onIonCancel: 'ionCancel',
+        onIonClear: 'ionClear',
+        onIonBlur: 'ionBlur',
+        onIonFocus: 'ionFocus'
     } as IonSearchbarEvents,
-    defineCustomElement: defineIonSearchbar,
-  });
+    defineCustomElement: defineIonSearchbar
+});
 
 export type IonSegmentEvents = { onIonChange: EventName<IonSegmentCustomEvent<SegmentChangeEventDetail>> };
 
-export const IonSegment: StencilReactComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment> =
-  /*@__PURE__*/ createComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment>({
+export const IonSegment: StencilReactComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment> = /*@__PURE__*/ createComponent<IonSegmentElement, IonSegmentEvents, Components.IonSegment>({
     tagName: 'ion-segment',
     elementClass: IonSegmentElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonChange: 'ionChange' } as IonSegmentEvents,
-    defineCustomElement: defineIonSegment,
-  });
+    defineCustomElement: defineIonSegment
+});
 
 export type IonSegmentButtonEvents = NonNullable<unknown>;
 
-export const IonSegmentButton: StencilReactComponent<
-  IonSegmentButtonElement,
-  IonSegmentButtonEvents,
-  Components.IonSegmentButton
-> = /*@__PURE__*/ createComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton>({
-  tagName: 'ion-segment-button',
-  elementClass: IonSegmentButtonElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonSegmentButtonEvents,
-  defineCustomElement: defineIonSegmentButton,
+export const IonSegmentButton: StencilReactComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton> = /*@__PURE__*/ createComponent<IonSegmentButtonElement, IonSegmentButtonEvents, Components.IonSegmentButton>({
+    tagName: 'ion-segment-button',
+    elementClass: IonSegmentButtonElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonSegmentButtonEvents,
+    defineCustomElement: defineIonSegmentButton
 });
 
 export type IonSegmentContentEvents = NonNullable<unknown>;
 
-export const IonSegmentContent: StencilReactComponent<
-  IonSegmentContentElement,
-  IonSegmentContentEvents,
-  Components.IonSegmentContent
-> = /*@__PURE__*/ createComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent>({
-  tagName: 'ion-segment-content',
-  elementClass: IonSegmentContentElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonSegmentContentEvents,
-  defineCustomElement: defineIonSegmentContent,
+export const IonSegmentContent: StencilReactComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent> = /*@__PURE__*/ createComponent<IonSegmentContentElement, IonSegmentContentEvents, Components.IonSegmentContent>({
+    tagName: 'ion-segment-content',
+    elementClass: IonSegmentContentElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonSegmentContentEvents,
+    defineCustomElement: defineIonSegmentContent
 });
 
-export type IonSegmentViewEvents = {
-  onIonSegmentViewScroll: EventName<IonSegmentViewCustomEvent<SegmentViewScrollEvent>>;
-};
+export type IonSegmentViewEvents = { onIonSegmentViewScroll: EventName<IonSegmentViewCustomEvent<SegmentViewScrollEvent>> };
 
-export const IonSegmentView: StencilReactComponent<
-  IonSegmentViewElement,
-  IonSegmentViewEvents,
-  Components.IonSegmentView
-> = /*@__PURE__*/ createComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView>({
-  tagName: 'ion-segment-view',
-  elementClass: IonSegmentViewElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: { onIonSegmentViewScroll: 'ionSegmentViewScroll' } as IonSegmentViewEvents,
-  defineCustomElement: defineIonSegmentView,
+export const IonSegmentView: StencilReactComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView> = /*@__PURE__*/ createComponent<IonSegmentViewElement, IonSegmentViewEvents, Components.IonSegmentView>({
+    tagName: 'ion-segment-view',
+    elementClass: IonSegmentViewElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: { onIonSegmentViewScroll: 'ionSegmentViewScroll' } as IonSegmentViewEvents,
+    defineCustomElement: defineIonSegmentView
 });
 
 export type IonSelectEvents = {
-  onIonChange: EventName<IonSelectCustomEvent<SelectChangeEventDetail>>;
-  onIonCancel: EventName<IonSelectCustomEvent<void>>;
-  onIonDismiss: EventName<IonSelectCustomEvent<void>>;
-  onIonFocus: EventName<IonSelectCustomEvent<void>>;
-  onIonBlur: EventName<IonSelectCustomEvent<void>>;
+    onIonChange: EventName<IonSelectCustomEvent<SelectChangeEventDetail>>,
+    onIonCancel: EventName<IonSelectCustomEvent<void>>,
+    onIonDismiss: EventName<IonSelectCustomEvent<void>>,
+    onIonFocus: EventName<IonSelectCustomEvent<void>>,
+    onIonBlur: EventName<IonSelectCustomEvent<void>>
 };
 
-export const IonSelect: StencilReactComponent<IonSelectElement, IonSelectEvents, Components.IonSelect> =
-  /*@__PURE__*/ createComponent<IonSelectElement, IonSelectEvents, Components.IonSelect>({
+export const IonSelect: StencilReactComponent<IonSelectElement, IonSelectEvents, Components.IonSelect> = /*@__PURE__*/ createComponent<IonSelectElement, IonSelectEvents, Components.IonSelect>({
     tagName: 'ion-select',
     elementClass: IonSelectElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonChange: 'ionChange',
-      onIonCancel: 'ionCancel',
-      onIonDismiss: 'ionDismiss',
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
+        onIonChange: 'ionChange',
+        onIonCancel: 'ionCancel',
+        onIonDismiss: 'ionDismiss',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur'
     } as IonSelectEvents,
-    defineCustomElement: defineIonSelect,
-  });
+    defineCustomElement: defineIonSelect
+});
 
 export type IonSelectModalEvents = NonNullable<unknown>;
 
-export const IonSelectModal: StencilReactComponent<
-  IonSelectModalElement,
-  IonSelectModalEvents,
-  Components.IonSelectModal
-> = /*@__PURE__*/ createComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal>({
-  tagName: 'ion-select-modal',
-  elementClass: IonSelectModalElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonSelectModalEvents,
-  defineCustomElement: defineIonSelectModal,
+export const IonSelectModal: StencilReactComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal> = /*@__PURE__*/ createComponent<IonSelectModalElement, IonSelectModalEvents, Components.IonSelectModal>({
+    tagName: 'ion-select-modal',
+    elementClass: IonSelectModalElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonSelectModalEvents,
+    defineCustomElement: defineIonSelectModal
 });
 
 export type IonSelectOptionEvents = NonNullable<unknown>;
 
-export const IonSelectOption: StencilReactComponent<
-  IonSelectOptionElement,
-  IonSelectOptionEvents,
-  Components.IonSelectOption
-> = /*@__PURE__*/ createComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption>({
-  tagName: 'ion-select-option',
-  elementClass: IonSelectOptionElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonSelectOptionEvents,
-  defineCustomElement: defineIonSelectOption,
+export const IonSelectOption: StencilReactComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption> = /*@__PURE__*/ createComponent<IonSelectOptionElement, IonSelectOptionEvents, Components.IonSelectOption>({
+    tagName: 'ion-select-option',
+    elementClass: IonSelectOptionElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonSelectOptionEvents,
+    defineCustomElement: defineIonSelectOption
 });
 
 export type IonSkeletonTextEvents = NonNullable<unknown>;
 
-export const IonSkeletonText: StencilReactComponent<
-  IonSkeletonTextElement,
-  IonSkeletonTextEvents,
-  Components.IonSkeletonText
-> = /*@__PURE__*/ createComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText>({
-  tagName: 'ion-skeleton-text',
-  elementClass: IonSkeletonTextElement,
-  // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
-  react: React,
-  events: {} as IonSkeletonTextEvents,
-  defineCustomElement: defineIonSkeletonText,
+export const IonSkeletonText: StencilReactComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText> = /*@__PURE__*/ createComponent<IonSkeletonTextElement, IonSkeletonTextEvents, Components.IonSkeletonText>({
+    tagName: 'ion-skeleton-text',
+    elementClass: IonSkeletonTextElement,
+    // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
+    react: React,
+    events: {} as IonSkeletonTextEvents,
+    defineCustomElement: defineIonSkeletonText
 });
 
 export type IonSpinnerEvents = NonNullable<unknown>;
 
-export const IonSpinner: StencilReactComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner> =
-  /*@__PURE__*/ createComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner>({
+export const IonSpinner: StencilReactComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner> = /*@__PURE__*/ createComponent<IonSpinnerElement, IonSpinnerEvents, Components.IonSpinner>({
     tagName: 'ion-spinner',
     elementClass: IonSpinnerElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonSpinnerEvents,
-    defineCustomElement: defineIonSpinner,
-  });
+    defineCustomElement: defineIonSpinner
+});
 
 export type IonSplitPaneEvents = { onIonSplitPaneVisible: EventName<IonSplitPaneCustomEvent<{ visible: boolean }>> };
 
-export const IonSplitPane: StencilReactComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane> =
-  /*@__PURE__*/ createComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane>({
+export const IonSplitPane: StencilReactComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane> = /*@__PURE__*/ createComponent<IonSplitPaneElement, IonSplitPaneEvents, Components.IonSplitPane>({
     tagName: 'ion-split-pane',
     elementClass: IonSplitPaneElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: { onIonSplitPaneVisible: 'ionSplitPaneVisible' } as IonSplitPaneEvents,
-    defineCustomElement: defineIonSplitPane,
-  });
+    defineCustomElement: defineIonSplitPane
+});
 
 export type IonTabEvents = NonNullable<unknown>;
 
-export const IonTab: StencilReactComponent<IonTabElement, IonTabEvents, Components.IonTab> =
-  /*@__PURE__*/ createComponent<IonTabElement, IonTabEvents, Components.IonTab>({
+export const IonTab: StencilReactComponent<IonTabElement, IonTabEvents, Components.IonTab> = /*@__PURE__*/ createComponent<IonTabElement, IonTabEvents, Components.IonTab>({
     tagName: 'ion-tab',
     elementClass: IonTabElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTabEvents,
-    defineCustomElement: defineIonTab,
-  });
+    defineCustomElement: defineIonTab
+});
 
 export type IonTextEvents = NonNullable<unknown>;
 
-export const IonText: StencilReactComponent<IonTextElement, IonTextEvents, Components.IonText> =
-  /*@__PURE__*/ createComponent<IonTextElement, IonTextEvents, Components.IonText>({
+export const IonText: StencilReactComponent<IonTextElement, IonTextEvents, Components.IonText> = /*@__PURE__*/ createComponent<IonTextElement, IonTextEvents, Components.IonText>({
     tagName: 'ion-text',
     elementClass: IonTextElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTextEvents,
-    defineCustomElement: defineIonText,
-  });
+    defineCustomElement: defineIonText
+});
 
 export type IonTextareaEvents = {
-  onIonChange: EventName<IonTextareaCustomEvent<TextareaChangeEventDetail>>;
-  onIonInput: EventName<IonTextareaCustomEvent<TextareaInputEventDetail>>;
-  onIonBlur: EventName<IonTextareaCustomEvent<FocusEvent>>;
-  onIonFocus: EventName<IonTextareaCustomEvent<FocusEvent>>;
+    onIonChange: EventName<IonTextareaCustomEvent<TextareaChangeEventDetail>>,
+    onIonInput: EventName<IonTextareaCustomEvent<TextareaInputEventDetail>>,
+    onIonBlur: EventName<IonTextareaCustomEvent<FocusEvent>>,
+    onIonFocus: EventName<IonTextareaCustomEvent<FocusEvent>>
 };
 
-export const IonTextarea: StencilReactComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea> =
-  /*@__PURE__*/ createComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea>({
+export const IonTextarea: StencilReactComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea> = /*@__PURE__*/ createComponent<IonTextareaElement, IonTextareaEvents, Components.IonTextarea>({
     tagName: 'ion-textarea',
     elementClass: IonTextareaElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonChange: 'ionChange',
-      onIonInput: 'ionInput',
-      onIonBlur: 'ionBlur',
-      onIonFocus: 'ionFocus',
+        onIonChange: 'ionChange',
+        onIonInput: 'ionInput',
+        onIonBlur: 'ionBlur',
+        onIonFocus: 'ionFocus'
     } as IonTextareaEvents,
-    defineCustomElement: defineIonTextarea,
-  });
+    defineCustomElement: defineIonTextarea
+});
 
 export type IonThumbnailEvents = NonNullable<unknown>;
 
-export const IonThumbnail: StencilReactComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail> =
-  /*@__PURE__*/ createComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail>({
+export const IonThumbnail: StencilReactComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail> = /*@__PURE__*/ createComponent<IonThumbnailElement, IonThumbnailEvents, Components.IonThumbnail>({
     tagName: 'ion-thumbnail',
     elementClass: IonThumbnailElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonThumbnailEvents,
-    defineCustomElement: defineIonThumbnail,
-  });
+    defineCustomElement: defineIonThumbnail
+});
 
 export type IonTitleEvents = NonNullable<unknown>;
 
-export const IonTitle: StencilReactComponent<IonTitleElement, IonTitleEvents, Components.IonTitle> =
-  /*@__PURE__*/ createComponent<IonTitleElement, IonTitleEvents, Components.IonTitle>({
+export const IonTitle: StencilReactComponent<IonTitleElement, IonTitleEvents, Components.IonTitle> = /*@__PURE__*/ createComponent<IonTitleElement, IonTitleEvents, Components.IonTitle>({
     tagName: 'ion-title',
     elementClass: IonTitleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonTitleEvents,
-    defineCustomElement: defineIonTitle,
-  });
+    defineCustomElement: defineIonTitle
+});
 
 export type IonToggleEvents = {
-  onIonChange: EventName<IonToggleCustomEvent<ToggleChangeEventDetail>>;
-  onIonFocus: EventName<IonToggleCustomEvent<void>>;
-  onIonBlur: EventName<IonToggleCustomEvent<void>>;
+    onIonChange: EventName<IonToggleCustomEvent<ToggleChangeEventDetail>>,
+    onIonFocus: EventName<IonToggleCustomEvent<void>>,
+    onIonBlur: EventName<IonToggleCustomEvent<void>>
 };
 
-export const IonToggle: StencilReactComponent<IonToggleElement, IonToggleEvents, Components.IonToggle> =
-  /*@__PURE__*/ createComponent<IonToggleElement, IonToggleEvents, Components.IonToggle>({
+export const IonToggle: StencilReactComponent<IonToggleElement, IonToggleEvents, Components.IonToggle> = /*@__PURE__*/ createComponent<IonToggleElement, IonToggleEvents, Components.IonToggle>({
     tagName: 'ion-toggle',
     elementClass: IonToggleElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {
-      onIonChange: 'ionChange',
-      onIonFocus: 'ionFocus',
-      onIonBlur: 'ionBlur',
+        onIonChange: 'ionChange',
+        onIonFocus: 'ionFocus',
+        onIonBlur: 'ionBlur'
     } as IonToggleEvents,
-    defineCustomElement: defineIonToggle,
-  });
+    defineCustomElement: defineIonToggle
+});
 
 export type IonToolbarEvents = NonNullable<unknown>;
 
-export const IonToolbar: StencilReactComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar> =
-  /*@__PURE__*/ createComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar>({
+export const IonToolbar: StencilReactComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar> = /*@__PURE__*/ createComponent<IonToolbarElement, IonToolbarEvents, Components.IonToolbar>({
     tagName: 'ion-toolbar',
     elementClass: IonToolbarElement,
     // @ts-ignore - ignore potential React type mismatches between the Stencil Output Target and your project.
     react: React,
     events: {} as IonToolbarEvents,
-    defineCustomElement: defineIonToolbar,
-  });
+    defineCustomElement: defineIonToolbar
+});


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
`ion-nav` doubles as an `ion-router` outlet. On load, `nav.tsx` checks `document.querySelector('ion-router')` to set a `useRouter` flag, and `ion-nav` is listed in the router's `OUTLET_SELECTOR`. When the router drives it, `ion-nav` exposes internal `setRouteId()`/`getRouteId()` methods, runs `router.canTransition()` guards inside `queueTrns`, and calls `router.navChanged()` on a successful transition so that `push`/`pop`, `ion-nav-link`, and swipe-to-go-back all update the URL. This couples an imperative stack component to URL-based routing

## What is the new behavior?
`ion-nav` is now a standalone imperative stack-navigation component with no `ion-router` integration. It implements `ComponentInterface` instead of `NavOutlet` and drops `useRouter`, the `setRouteId()`/`getRouteId()` methods, the `canTransition()` guard check, the `navChanged()` URL update, the root-attribute-with-router warning, and the `updateURL` nav option. The router no longer lists `ion-nav` in `OUTLET_SELECTOR`, so an `ion-nav` placed inside an `ion-router` is no longer discovered or driven as a routed outlet

Dropping `ion-nav` from `OUTLET_SELECTOR` exposed a hang: a page with an `ion-router` but no `ion-router-outlet` or `ion-tabs` (the #24641 pattern) left `waitUntilNavNode()` waiting forever, so the router's `componentWillLoad` never settled and the app never signalled that it finished loading. `waitUntilNavNode()` now resolves on `ionNavWillLoad` or a 500ms timeout, and warns in dev when no outlet is found

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Apps that relied on `ion-nav` to update the URL (pushing components and expecting the browser URL to change, or having router guards run on nav transitions) should use `ion-router-outlet` for URL-based routing. An `ion-nav` can still be used inside a routed page for local, URL-less stack navigation. See the Nav section in `BREAKING.md` for the migration path.

## Other information

`BREAKING.md` is updated with a new Nav section and `route.tsx` doc now lists `ion-router-outlet` instead of `ion-nav` as the navigation outlet

Preview (nav routing test page):
- https://ionic-framework-git-fw-6976-ionic1.vercel.app/src/components/nav/test/routing