### PR TITLE
feat(platform): remove capacitor v2 isNative fallback from native detection

### DIFF
--- a/BREAKING.md
+++ b/BREAKING.md
@@ -54,6 +54,13 @@ This section details the desktop browser, JavaScript framework, and mobile platf
 | iOS      | 16+                    |
 | Android  | 5.1+ with Chromium 89+ |
 
+**Minimum Native Runtime Versions**
+| Native Runtime | Supported Version |
+| -------------- | ----------------- |
+| Capacitor      | 7+                |
+
+Ionic's native platform detection no longer checks the Capacitor 2 `isNative` flag. `isCapacitorNative` now relies solely on `Capacitor.isNativePlatform()`, which was added in Capacitor 3. Apps running Capacitor 2 will no longer be detected as a native/hybrid platform, so `isPlatform('capacitor')`, `isPlatform('hybrid')`, and `getPlatforms()` will report web instead of native. Upgrade to a supported Capacitor version (7 or later).
+
 <h2 id="version-9x-package-exports">Package Exports</h2>
 
 `@ionic/core`'s `package.json` now declares an `exports` field. Subpaths like `@ionic/core/components` and `@ionic/core/loader` previously failed under Node ESM (Angular 21's default Vitest builder, raw Node, etc.) with `ERR_UNSUPPORTED_DIR_IMPORT`, because the strict ESM resolver doesn't read the nested `package.json` files this package relied on. The new `exports` map declares the documented subpaths explicitly.

--- a/core/src/utils/platform.ts
+++ b/core/src/utils/platform.ts
@@ -99,8 +99,7 @@ const isCordova = (win: any): boolean => !!(win['cordova'] || win['phonegap'] ||
 
 const isCapacitorNative = (win: any): boolean => {
   const capacitor = win['Capacitor'];
-  // TODO(ROU-11693): Remove when we no longer support Capacitor 2, which does not have isNativePlatform
-  return !!(capacitor?.isNative || (capacitor?.isNativePlatform && !!capacitor.isNativePlatform()));
+  return !!capacitor?.isNativePlatform?.();
 };
 
 const isElectron = (win: Window): boolean => testUserAgent(win, /electron/i);


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
`isCapacitorNative` in `core/src/utils/platform.ts` checks both `capacitor.isNative` and `capacitor.isNativePlatform()`. The `isNative` branch only exists to support Capacitor 2, which predates `isNativePlatform()` (added in Capacitor 3).

## What is the new behavior?
`isCapacitorNative` now relies solely on `capacitor.isNativePlatform()`. Since v9 supports Capacitor 7+, the Capacitor 2 fallback is no longer needed. This feeds our native/hybrid checks throughout the framework.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Apps running Capacitor 2 will no longer be detected as a native/hybrid platform, so `isPlatform('capacitor')`, `isPlatform('hybrid')`, and `getPlatforms()` will report web instead of native. Capacitor 2 has been out of support for a while, so migration is to upgrade to a supported Capacitor version (7 or later), which exposes `isNativePlatform()`.

## Other information

This resolves FW-6255. The existing `Capacitor` platform test config already uses `isNativePlatform`, so the platform spec suite covers the remaining path unchanged. No component test pages are affected since this only touches the platform detection utility.

Docs PR: https://github.com/ionic-team/ionic-docs/pull/4592