### PR TITLE
ci(github): pin third-party actions to commit SHAs

### DIFF
--- a/.github/workflows/actions/build-angular/action.yml
+++ b/.github/workflows/actions/build-angular/action.yml
@@ -3,7 +3,7 @@ description: 'Build Ionic Angular'
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-node@v7
+    - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24.x
     - uses: ./.github/workflows/actions/download-archive

--- a/.github/workflows/actions/download-archive/action.yml
+++ b/.github/workflows/actions/download-archive/action.yml
@@ -10,7 +10,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.path }}

--- a/.github/workflows/actions/test-core-screenshot/action.yml
+++ b/.github/workflows/actions/test-core-screenshot/action.yml
@@ -66,7 +66,7 @@ runs:
       working-directory: ./core
     - name: 📦 Archive Updated Screenshots
       if: inputs.update == 'true' && steps.test-and-update.outputs.hasUpdatedScreenshots == 'true'
-      uses: actions/upload-artifact@v7
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: updated-screenshots-${{ inputs.shard }}-${{ inputs.totalShards }}
         path: UpdatedScreenshots-${{ inputs.shard }}-${{ inputs.totalShards }}.zip

--- a/.github/workflows/actions/update-reference-screenshots/action.yml
+++ b/.github/workflows/actions/update-reference-screenshots/action.yml
@@ -10,7 +10,7 @@ runs:
     - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
       with:
         node-version: 24.x
-    - uses: actions/download-artifact@v8
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         path: ./artifacts
     - name: 🔎 Extract Archives

--- a/.github/workflows/actions/upload-archive/action.yml
+++ b/.github/workflows/actions/upload-archive/action.yml
@@ -13,7 +13,7 @@ runs:
     - name: 🗄️ Create Archive
       run: zip -q -r ${{ inputs.output }} ${{ inputs.paths }}
       shell: bash
-    - uses: actions/upload-artifact@v7
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: ${{ inputs.name }}
         path: ${{ inputs.output }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -15,7 +15,7 @@ jobs:
       security-events: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: github/codeql-action/init@v4
+      - uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           languages: javascript
-      - uses: github/codeql-action/analyze@v4
+      - uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1

--- a/.github/workflows/conventional-commit.yml
+++ b/.github/workflows/conventional-commit.yml
@@ -12,7 +12,7 @@ jobs:
         if: |
           !contains(github.event.pull_request.title, 'release') &&
           !contains(github.event.pull_request.title, 'chore')
-        uses: amannn/action-semantic-pull-request@v6
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -13,7 +13,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/labeler@v6
+    - uses: actions/labeler@b8dd2d9be0f68b860e7dae5dae7d772984eacd6d # v6.2.0
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         sync-labels: true


### PR DESCRIPTION
Issue number: FW-6928

---------

<!-- Following up FW-6926: review reusable actions and pin them to commit SHAs for supply-chain security. -->

## What is the current behavior?

Several third-party GitHub Actions in our workflows and composite actions
were still referenced by mutable tags (`@v6`/`@v7`/`@v8`/`@v4`). A mutable
tag can be repointed by the action author — or an attacker who gains write
access to the action repo — to arbitrary code, which then runs with the
workflow's permissions and secrets (notably in the release pipeline).

## What is the new behavior?

All remaining unpinned third-party actions are now pinned to a full-length
commit SHA with a `# vX.Y.Z` comment, matching the convention already used
across the repo (e.g. `actions/checkout@9c091bb… # v7.0.0`). Each action
keeps its current major, pinned to the latest patch of that major. Every
SHA was independently verified against its upstream tag.

File | Action | Pinned to
-- | -- | --
actions/build-angular/action.yml | actions/setup-node | 820762786… # v7.0.0
actions/upload-archive/action.yml | actions/upload-artifact | 043fb46d1… # v7.0.1
actions/test-core-screenshot/action.yml | actions/upload-artifact | 043fb46d1… # v7.0.1
actions/download-archive/action.yml | actions/download-artifact | 3e5f45b2c… # v8.0.1
actions/update-reference-screenshots/action.yml | actions/download-artifact | 3e5f45b2c… # v8.0.1
codeql-analysis.yml (init + analyze) | github/codeql-action | 7188fc363… # v4.37.1
conventional-commit.yml | amannn/action-semantic-pull-request | 48f256284… # v6.1.1
label.yml | actions/labeler | b8dd2d9be… # v6.2.0


Local `uses: ./…` composite/reusable refs are intentionally left unchanged
(same-repo, no external supply-chain risk).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

No behavioural change — this only pins which upstream commit CI executes.

## Other information

- No major-version upgrades; that's deferred as a separate maintenance concern.
- Follow-ups considered but out of scope: a CI guard to block reintroducing
  unpinned actions, and a `github-actions` Dependabot entry to keep the pins
  bumped.
