### PR TITLE
fix(modal): keep focus on dialog for cycle sheet modals

### DIFF
--- a/core/src/components/modal/modal.tsx
+++ b/core/src/components/modal/modal.tsx
@@ -1175,8 +1175,13 @@ export class Modal implements ComponentInterface, OverlayInterface {
    */
   private onModalFocus = (ev: FocusEvent) => {
     const { dragHandleEl, el } = this;
-    // Only handle focus if the modal itself was focused (not a child element)
-    if (ev.target === el && dragHandleEl && dragHandleEl.tabIndex !== -1) {
+    /**
+     * Shadow DOM focus is retargeted to the host, so `ev.target === el` is also
+     * true when a shadow child (the dialog wrapper present() focuses) is focused.
+     * shadowRoot's activeElement is null only when the host was focused directly,
+     * so redirect to the handle only then and leave present()'s wrapper focus intact.
+     */
+    if (ev.target === el && el.shadowRoot?.activeElement == null && dragHandleEl && dragHandleEl.tabIndex !== -1) {
       dragHandleEl.focus();
     }
   };

--- a/core/src/utils/test/overlays/overlays.e2e.ts
+++ b/core/src/utils/test/overlays/overlays.e2e.ts
@@ -473,6 +473,32 @@ configs({ modes: ['ios'], directions: ['ltr'] }).forEach(({ title, config }) => 
       await expect(wrapper).toBeFocused();
     });
 
+    test('should focus the sheet modal wrapper on present when handleBehavior is cycle', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'FW-7611',
+      });
+      // present()'s wrapper focus must survive the cycle-handle focus redirect.
+      await page.setContent(
+        `
+        <ion-modal initial-breakpoint="0.5" breakpoints="[0, 0.5, 1]" handle-behavior="cycle">
+          <ion-content>Sheet Modal Content</ion-content>
+        </ion-modal>
+      `,
+        config
+      );
+
+      const ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      const modal = page.locator('ion-modal');
+      const wrapper = page.locator('ion-modal .modal-wrapper');
+
+      await modal.evaluate((el: HTMLIonModalElement) => el.present());
+      await ionModalDidPresent.next();
+
+      await expect(wrapper).toHaveAttribute('role', 'dialog');
+      await expect(wrapper).toBeFocused();
+    });
+
     test('should focus the card modal wrapper on present', async ({ page }, testInfo) => {
       testInfo.annotations.push({
         type: 'issue',


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?
When a sheet modal uses `handleBehavior="cycle"`, the host element is focusable (`tabIndex=0`) and `onModalFocus` redirects focus to the drag handle whenever the host is focused. `present()` moves focus to the `.modal-wrapper` (the `role="dialog"` element) inside the shadow DOM, but that focus event is retargeted to the host, so `onModalFocus` sees `ev.target === el` and treats it as a direct host focus. It then bounces focus onto the handle.

This is latent on the default `handleBehavior="none"` (the host isn't focusable, so the redirect never runs), but reproduces on any sheet modal that opts into `cycle`.

## What is the new behavior?
`onModalFocus` now redirects to the handle only when the host itself was focused directly, detected by `el.shadowRoot?.activeElement` being `null`. When `present()` focuses the dialog wrapper, `activeElement` is the wrapper (not null), so the redirect is skipped and the dialog keeps focus. Tabbing into the modal from outside still lands on the handle, since the host is the focused element in that case.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
Related to the dialog focus work in #31260 . That change is correct under the default `handleBehavior`, but the `cycle` path was not covered until now. Adds an e2e test to `utils/test/overlays/overlays.e2e.ts` that presents a sheet modal with `handle-behavior="cycle"` and asserts focus stays on the wrapper.

The same fix ships on the major-9.0 sync (#31290), where `cycle` is the default and this bug is hit on every sheet modal.

Preview (sheet modal test page):
- iOS: https://ionic-framework-git-fix-modal-focus-cycle-ionic1.vercel.app/src/components/modal/test/sheet?ionic:mode=ios
- MD: https://ionic-framework-git-fix-modal-focus-cycle-ionic1.vercel.app/src/components/modal/test/sheet?ionic:mode=md