### PR TITLE
fix(angular): guard transition against destroyed router outlet

### DIFF
--- a/packages/angular/common/src/directives/navigation/stack-controller.ts
+++ b/packages/angular/common/src/directives/navigation/stack-controller.ts
@@ -275,7 +275,10 @@ export class StackController {
       enteringEl.classList.add('ion-page');
       enteringEl.classList.add('ion-page-invisible');
 
-      if ((containerEl as any).commit) {
+      // containerEl is set to undefined when the stack controller is destroyed,
+      // so a transition that resolves after its outlet was destroyed must not
+      // dereference it (see destroy()).
+      if ((containerEl as any)?.commit) {
         return containerEl.commit(enteringEl, leavingEl, {
           duration: direction === undefined ? 0 : undefined,
           direction,


### PR DESCRIPTION
Issue number: resolves #31296

---------

## What is the current behavior?

`StackController.destroy()` sets `this.containerEl = undefined!`, but a transition that is still queued behind `wait()` can resolve after the `ion-router-outlet` was destroyed (interrupted / re-entrant / cancelled navigation during fast back-navigation). `transition()` then dereferences the `undefined` element at `if ((containerEl as any).commit)` and throws:

```
TypeError: undefined is not an object (evaluating 'containerEl.commit')
    at transition
```

Observed at production scale in an Ionic Angular + Capacitor app (several hundred RUM crash events per week from a single build, concentrated on rapid back-navigation between nested outlets).

## What is the new behavior?

- `transition()` null-checks `containerEl` (optional chaining) before probing for `commit`.
- A transition resolving after its outlet was destroyed now takes the method's existing fallback path and resolves `false`, instead of throwing an unhandled `TypeError`.
- No behavior change for live outlets.

Regarding tests: there is no existing unit harness for `StackController` (only the e2e test apps), and the defect is a timing race between a queued transition and outlet destruction, which is impractical to reproduce deterministically in e2e. The change is a defensive null-check on a field that `destroy()` explicitly sets to `undefined` (with a lint-suppressed non-null assertion). We have run this exact guard in production via patch-package: the crash class disappears with no observed regressions.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

The unguarded dereference is present in v8.8.13 through latest stable 8.8.15 and `8.8.16-nightly.20260724`.
