### PR TITLE
test(playwright): scope drag selection clear to firefox

### DIFF
--- a/core/src/utils/test/playwright/drag-element.ts
+++ b/core/src/utils/test/playwright/drag-element.ts
@@ -39,7 +39,16 @@ export const dragElementBy = async (
   // initiates text selection on mouse.down(). In Playwright, this selection
   // locks in before the gesture detector fires, blocking pointer events.
   // Clearing it here allows the drag gesture to proceed normally.
-  await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  //
+  // This is scoped to Firefox because the extra page.evaluate() is an awaited
+  // round-trip that adds variable latency between mouse.down() and the first
+  // mouse.move(). Chromium and WebKit don't need the selection clear, and on
+  // WebKit that latency perturbs the timing-derived gesture velocity, causing
+  // the item to settle a few pixels off and flaking screenshot comparisons
+  // (e.g. item-sliding safe-area tests).
+  if (page.context().browser()?.browserType().name() === 'firefox') {
+    await page.evaluate(() => window.getSelection()?.removeAllRanges());
+  }
 
   // Drag the element.
   await moveElement(page, startX, startY, dragByX, dragByY);


### PR DESCRIPTION
Issue number: internal

---------

## What is the current behavior?

The shared `dragElementBy` Playwright helper (`core/src/utils/test/playwright/drag-element.ts`, used by every gesture e2e test) unconditionally runs `await page.evaluate(() => window.getSelection()?.removeAllRanges())` between `mouse.down()` and the drag movement. That line was added in #31260 to clear a Firefox-only text selection, but the extra `page.evaluate()` is an awaited round-trip that injects variable latency into the gesture path for all browsers. On WebKit that latency messes up the gesture's timing-derived `velocityX`, so the `item-sliding` safe-area screenshot tests in md mode settle a few pixels off and flake randomly. Since it lives on main, the flake has propagated to every other branch (next and major-9.0) and causes random test failures in PRs and nightlies.

## What is the new behavior?

The selection clear now only runs on Firefox, which is the only engine that needs it (the existing comment already scoped the problem to Firefox). Chromium and WebKit skip the extra round-trip and get the same drag timing they had before #31260, so the item settles deterministically and the flake goes away. This matches the `browserType().name() === 'webkit'` gate already used elsewhere in the same file.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

Regression was introduced by #31260 (the `removeAllRanges` line, not the modal a11y change itself). Verified by running in docker locally several times.