### PR TITLE
fix(refresher): avoid gesture setup after disconnect

### DIFF
--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -299,8 +299,18 @@ export class Refresher implements ComponentInterface {
 
     this.scrollEl!.addEventListener('scroll', this.scrollListenerCallback);
 
-    this.gesture = (await import('../../utils/gesture')).createGesture({
-      el: this.scrollEl!,
+    const { createGesture } = await import('../../utils/gesture');
+
+    /**
+     * The dynamic import createGesture yields to the event loop, so the refresher may
+     * be disconnected if the component unmounts while it resolves.
+     */
+    if (!this.scrollEl) {
+      return;
+    }
+
+    this.gesture = createGesture({
+      el: this.scrollEl,
       gestureName: 'refresher',
       gesturePriority: 31,
       direction: 'y',
@@ -369,8 +379,18 @@ export class Refresher implements ComponentInterface {
       });
     }
 
-    this.gesture = (await import('../../utils/gesture')).createGesture({
-      el: this.scrollEl!,
+    const { createGesture } = await import('../../utils/gesture');
+
+    /**
+     * The dynamic import createGesture yields to the event loop, so the refresher may
+     * be disconnected if the component unmounts while it resolves.
+     */
+    if (!this.scrollEl) {
+      return;
+    }
+
+    this.gesture = createGesture({
+      el: this.scrollEl,
       gestureName: 'refresher',
       gesturePriority: 31,
       direction: 'y',

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -302,8 +302,9 @@ export class Refresher implements ComponentInterface {
     const { createGesture } = await import('../../utils/gesture');
 
     /**
-     * The dynamic import createGesture yields to the event loop, so the refresher may
-     * be disconnected if the component unmounts while it resolves.
+     * Awaiting the dynamic import yields to the event loop, so the component can
+     * disconnect before it resolves. disconnectedCallback clears scrollEl, so a
+     * missing scrollEl here means there is nothing left to attach a gesture to.
      */
     if (!this.scrollEl) {
       return;

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -382,8 +382,9 @@ export class Refresher implements ComponentInterface {
     const { createGesture } = await import('../../utils/gesture');
 
     /**
-     * The dynamic import createGesture yields to the event loop, so the refresher may
-     * be disconnected if the component unmounts while it resolves.
+     * Awaiting the dynamic import yields to the event loop, so the component can
+     * disconnect before it resolves. disconnectedCallback clears scrollEl, so a
+     * missing scrollEl here means there is nothing left to attach a gesture to.
      */
     if (!this.scrollEl) {
       return;

--- a/core/src/components/refresher/refresher.tsx
+++ b/core/src/components/refresher/refresher.tsx
@@ -548,7 +548,18 @@ export class Refresher implements ComponentInterface {
       if (await shouldUseNativeRefresher(this.el, getIonMode(this))) {
         this.setupNativeRefresher(contentEl);
       } else {
-        this.gesture = (await import('../../utils/gesture')).createGesture({
+        const { createGesture } = await import('../../utils/gesture');
+
+        /**
+         * Awaiting the dynamic import yields to the event loop, so the component can
+         * disconnect before it resolves. A disconnected contentEl means there is
+         * nothing left to attach a gesture to.
+         */
+        if (!contentEl.isConnected) {
+          return;
+        }
+
+        this.gesture = createGesture({
           el: contentEl,
           gestureName: 'refresher',
           gesturePriority: 31,


### PR DESCRIPTION
Issue number: resolves #31315 
---------

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->

<!-- Please try to limit your pull request to one type (bugfix, feature, etc). Submit multiple pull requests if needed. -->

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying. -->

When an `ion-refresher`'s host page is unmounted while the native refresher is still being set up, Ionic throws an uncaught `TypeError` from the gesture utility:

```
TypeError: Cannot read properties of undefined (reading '__zone_symbol__addEventListener')
    at addEventListener (core/src/utils/gesture/listener.ts:21)
    at Object.enable (core/src/utils/gesture/index.ts)
    at Refresher.disabledChanged (core/src/components/refresher/refresher.tsx:125)
    at Refresher.setupMDNativeRefresher (core/src/components/refresher/refresher.tsx:372)
```

`setupMDNativeRefresher()` and `setupiOSNativeRefresher()` both do:

```ts
this.gesture = (await import('../../utils/gesture')).createGesture({
  el: this.scrollEl!,
  ...
});
```

The dynamic import yields to the event loop. If the refresher is disconnected while it resolves, `disconnectedCallback()` (line 547-549) has already run `this.scrollEl = undefined`, so `createGesture` receives `el: undefined`, and the subsequent `disabledChanged()` → `gesture.enable(true)` calls `addEventListener(undefined, ...)`, which throws.

Because this happens inside an async method that nothing awaits, it surfaces as an **unhandled promise rejection** — it cannot be caught by a framework error boundary; this crashes my app in playwright sometimes when components are mounted very quickly.

The `!` non-null assertions on `this.scrollEl` are what hide this from TypeScript.

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

If the refresher is disconnected while the gesture module is being imported, setup aborts quietly. No gesture is created, and no error is thrown.

## Does this introduce a breaking change?

- [ ] Yes
- [ X] No

<!--
  If this introduces a breaking change:
  1. Describe the impact and migration path for existing applications below.
  2. Update the BREAKING.md file with the breaking change.
  3. Add "BREAKING CHANGE: [...]" to the commit description when merging. See https://github.com/ionic-team/ionic-framework/blob/main/docs/CONTRIBUTING.md#footer for more information.
-->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
