### PR TITLE
fix(datetime): tear down ready state when an overlay dismisses

### DIFF
--- a/core/src/components.d.ts
+++ b/core/src/components.d.ts
@@ -929,7 +929,7 @@ export namespace Components {
          */
         "clearText": string;
         /**
-          * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
+          * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, refer to [theming](/docs/theming/basics).
           * @default 'primary'
          */
         "color"?: Color;
@@ -6198,7 +6198,7 @@ declare namespace LocalJSX {
          */
         "clearText"?: string;
         /**
-          * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, see [theming](/docs/theming/basics).
+          * The color to use from your application's color palette. Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`. For more information on colors, refer to [theming](/docs/theming/basics).
           * @default 'primary'
          */
         "color"?: Color;

--- a/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
+++ b/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
@@ -209,8 +209,7 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
 });
 
 /**
- * The tested behavior does not
- * vary across modes/directions
+ * This behavior does not vary across modes/directions
  */
 configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
   test.describe(title('datetime-button: reopening modal'), () => {

--- a/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
+++ b/core/src/components/datetime-button/test/overlays/datetime-button.e2e.ts
@@ -1,6 +1,6 @@
 import type { Locator } from '@playwright/test';
 import { expect } from '@playwright/test';
-import type { EventSpy } from '@utils/test/playwright';
+import type { E2EPage, EventSpy } from '@utils/test/playwright';
 import { configs, test } from '@utils/test/playwright';
 
 /**
@@ -204,6 +204,112 @@ configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
       await ionModalDidDismiss.next();
 
       await openAndInteract();
+    });
+  });
+});
+
+/**
+ * The tested behavior does not
+ * vary across modes/directions
+ */
+configs({ modes: ['md'], directions: ['ltr'] }).forEach(({ title, config }) => {
+  test.describe(title('datetime-button: reopening modal'), () => {
+    let datetime: Locator;
+    let modal: Locator;
+    let monthYear: Locator;
+    let ionModalDidPresent: EventSpy;
+    let ionModalDidDismiss: EventSpy;
+
+    test.beforeEach(async ({ page }) => {
+      await page.setContent(
+        `
+        <ion-datetime-button datetime="datetime"></ion-datetime-button>
+
+        <ion-modal>
+          <ion-datetime id="datetime" locale="en-US" value="2022-03-15T16:30:00"></ion-datetime>
+        </ion-modal>
+      `,
+        config
+      );
+
+      datetime = page.locator('ion-datetime');
+      modal = page.locator('ion-modal');
+      monthYear = datetime.locator('.calendar-month-year');
+      ionModalDidPresent = await page.spyOnEvent('ionModalDidPresent');
+      ionModalDidDismiss = await page.spyOnEvent('ionModalDidDismiss');
+    });
+
+    const openModal = async (page: E2EPage) => {
+      await page.click('#date-button');
+      await ionModalDidPresent.next();
+      await page.locator('ion-datetime.datetime-ready').waitFor();
+      await page.waitForChanges();
+    };
+
+    const dismissModal = async () => {
+      await modal.evaluate((el: HTMLIonModalElement) => el.dismiss());
+      await ionModalDidDismiss.next();
+    };
+
+    test('should keep the selected day in view when reopened', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31155',
+      });
+
+      const selectedDay = datetime.locator('.calendar-day-active');
+
+      await openModal(page);
+      await expect(selectedDay).toBeInViewport();
+
+      await dismissModal();
+      await openModal(page);
+
+      await expect(selectedDay).toBeInViewport();
+    });
+
+    test('should navigate to the previous month when reopened', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31155',
+      });
+
+      await openModal(page);
+      await dismissModal();
+      await openModal(page);
+
+      await expect(monthYear).toHaveText('March 2022');
+
+      await datetime.locator('.calendar-next-prev ion-button').first().click();
+
+      await expect(monthYear).toHaveText('February 2022');
+    });
+
+    test('should select a day from the month shown in the header when reopened', async ({ page }, testInfo) => {
+      testInfo.annotations.push({
+        type: 'issue',
+        description: 'https://github.com/ionic-team/ionic-framework/issues/31155',
+      });
+
+      await openModal(page);
+      await dismissModal();
+      await openModal(page);
+
+      await expect(monthYear).toHaveText('March 2022');
+
+      const ionChange = await page.spyOnEvent('ionChange');
+
+      /**
+       * Click the middle of the calendar instead of a day by name so Playwright
+       * doesn't scroll the target into view and hide a wrong scroll position.
+       */
+      const calendarBody = (await datetime.locator('.calendar-body').boundingBox())!;
+      await page.mouse.click(calendarBody.x + calendarBody.width / 2, calendarBody.y + calendarBody.height / 2);
+      await ionChange.next();
+
+      const value = await datetime.evaluate((el: HTMLIonDatetimeElement) => el.value as string);
+      expect(value).toMatch(/^2022-03-/);
+      await expect(monthYear).toHaveText('March 2022');
     });
   });
 });

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -140,6 +140,10 @@ export class Datetime implements ComponentInterface {
    * Set true only by `visibleCallback`. Lets `hiddenCallback` ignore the
    * synthetic "not intersecting" entry IntersectionObserver fires on
    * `observe()` when the host mounts offscreen.
+   *
+   * Don't reset this in `disconnectedCallback`. Overlays disconnect and
+   * reconnect the host without re-creating the observers, so a reset there
+   * makes `hiddenCallback` miss the dismissal.
    */
   private hasBeenIntersecting = false;
 
@@ -1116,7 +1120,6 @@ export class Datetime implements ComponentInterface {
       this.clearFocusVisible = undefined;
     }
     this.loadTimeoutCleanup();
-    this.hasBeenIntersecting = false;
   }
 
   /**

--- a/core/src/components/datetime/datetime.tsx
+++ b/core/src/components/datetime/datetime.tsx
@@ -183,7 +183,7 @@ export class Datetime implements ComponentInterface {
   /**
    * The color to use from your application's color palette.
    * Default options are: `"primary"`, `"secondary"`, `"tertiary"`, `"success"`, `"warning"`, `"danger"`, `"light"`, `"medium"`, and `"dark"`.
-   * For more information on colors, see [theming](/docs/theming/basics).
+   * For more information on colors, refer to [theming](/docs/theming/basics).
    */
   @Prop() color?: Color = 'primary';
 


### PR DESCRIPTION
Issue number: resolves #31155, resolves #31143

---------

## What is the current behavior?

Currently, an `ion-datetime` inside a modal or popover shows the wrong month once the overlay is reopened. The selected day isn't visible, the previous month button does nothing, and picking a day from the grid lands on an unrelated date.

Overlays move their host element into `ion-app` when presenting and back to its original position when dismissing, which disconnects and reconnects the datetime. `disconnectedCallback` reset `hasBeenIntersecting` during that move, so by the time the hidden-state `IntersectionObserver` entry arrived, `hiddenCallback` mistook the dismissal for the synthetic initial entry and returned early. That left `datetime-ready` on the host, so on the next present `markReady` saw the class and returned without re-centering the calendar on the working month, and the browser had already reset `scrollLeft` to 0 while the overlay was hidden. `scrollLeft: 0` renders the previous month's grid while the header still names the working month, which is what produces all three symptoms.

## What is the new behavior?

With this change, `disconnectedCallback` no longer resets `hasBeenIntersecting`. That flag tracks the observers, and the observers are only created in `componentDidLoad` and never re-created on reconnect, so a DOM move has no business clearing it. `hiddenCallback` now sees the real hidden transition on dismiss and tears down as it did before #31108, which lets `markReady` run again on the next present and re-center the calendar.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->

This regression was introduced in #31108. That PR needed the flag to make `hiddenCallback` ignore the synthetic initial entry, but the `disconnectedCallback` reset it also added had no job and broke the overlay case. Before #31108, `hiddenCallback` had no guard at all and always removed `datetime-ready` on dismiss, so this restores the behavior that shipped for all of v8..

- [Relevant test screen - iOS](https://ionic-framework-git-fix-31155-ionic1.vercel.app/src/components/datetime-button/test/overlays?ionic:mode=ios)
- [Relevant test screen - MD](https://ionic-framework-git-fix-31155-ionic1.vercel.app/src/components/datetime-button/test/overlays?ionic:mode=md)

To reproduce: open the "Modal - Default" picker, dismiss it, then open it again. On `main` the grid shows February while the header reads March 2022.